### PR TITLE
Add polls feature

### DIFF
--- a/openspec/changes/archive/2026-04-02-add-polls/design.md
+++ b/openspec/changes/archive/2026-04-02-add-polls/design.md
@@ -1,0 +1,169 @@
+## Context
+
+Wild Lychee is a config-driven community portal on Run402 (static Astro SSG + PostgREST + edge functions). Content types (announcements, events, forum topics) are database rows rendered by Astro pages with client-side JS. The codebase uses a polymorphic pattern for cross-cutting features (e.g., `reactions` table with `content_type` + `content_id`). All features are toggled via `site_config` feature flags.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Polls as standalone entities attachable to announcements, forum topics, homepage sections, or standalone at `/polls`
+- One shared `renderPoll()` function reused across all surfaces
+- Inline poll creation form embeddable in announcement/forum editors and on `/polls`
+- Configurable results visibility: always, after vote, after close
+- Anonymous voting option (voter identity stored for dedup, hidden from display)
+- Admins always create polls; members optionally via `polls_member_create` config
+- Auto-close polls on page load when `closes_at` has passed
+- Activity logging for poll creation and voting
+
+**Non-Goals:**
+
+- Scheduled auto-close via cron (deferred — check on page load for now)
+- Rating scale or free-text poll types (start with single-choice and multiple-choice only)
+- Real-time vote updates / WebSocket push
+- Full survey builder (multi-page, conditional logic, text responses)
+- Poll analytics dashboard (admin sees results inline, no separate analytics page)
+
+## Decisions
+
+### 1. Polls are standalone entities with polymorphic attachment
+
+A poll is a first-class row in `polls` with optional `attached_to` (content type string) and `attached_id` (integer) fields. This mirrors the `reactions` table pattern. When `attached_to` is NULL, the poll is standalone and appears on `/polls`.
+
+**Why not embed poll data as JSONB inside announcements/topics?** Standalone polls would require a separate table anyway, so two storage models means two code paths. One table with an optional attachment reference is simpler.
+
+**Why not foreign keys for attachment?** The polymorphic `content_type` + `content_id` pattern is already established by `reactions`. Adding FK constraints would require separate nullable columns per content type, which scales poorly as more attachable surfaces are added.
+
+### 2. Vote enforcement: application-level for single-choice, constraint for safety
+
+For single-choice polls, the app deletes existing votes for that member+poll before inserting the new one. This gives "change your vote" for free. The `UNIQUE(poll_id, member_id, option_id)` constraint remains as a safety net for both poll types.
+
+For multiple-choice polls, each selected option is a separate row. The unique constraint prevents duplicate option selections.
+
+**Why not a stricter `UNIQUE(poll_id, member_id)` for single-choice?** It would prevent the multi-choice pattern from working with the same table. Application-level enforcement is simple (one DELETE + one INSERT) and the constraint catches bugs.
+
+### 3. Anonymous polls store member_id but never expose it
+
+When `is_anonymous = true`, `poll_votes.member_id` is still stored to enforce one-vote-per-member. The API layer and UI never return or display voter identity for anonymous polls. Admin dashboard shows aggregate counts only.
+
+**Why not truly anonymous (no member_id)?** Without member_id, there's no way to prevent duplicate votes or support "change your vote." The trust contract is clear: identity is stored for integrity, hidden for privacy.
+
+### 4. Results visibility is a per-poll enum
+
+Three modes: `always` (results visible before voting), `after_vote` (results shown only after the member votes), `after_close` (results hidden until poll closes). Default is `after_vote` to maximize participation by preventing bandwagon bias.
+
+### 5. Inline creation form as a shared JS function
+
+`createPollForm(container, attachConfig?)` renders the poll creation form. Called with no `attachConfig` on `/polls` (standalone), or with `{ type: 'announcement', id: null }` inside the announcement editor. The parent's save handler creates the parent first, gets the ID, then creates the poll with `attached_to` and `attached_id`.
+
+**Why not a separate Astro component?** Poll creation is a client-side interaction (dynamic form with add/remove options). It needs to be a JS function, not a server-rendered component. The function lives in a shared module importable by any page.
+
+### 6. Page-load close check instead of cron
+
+When any page renders a poll, if `closes_at` is non-null and in the past, the UI treats it as closed (no vote buttons, full results shown). A PATCH to set `is_open = false` fires on first view after expiry.
+
+**Why not a cron job?** Avoids a new scheduled function for MVP. The only downside is that a poll might accept a vote between `closes_at` and the first page load that triggers the close. This is acceptable for community polls — they're not elections.
+
+**TODO:** Add scheduled function later for accurate auto-close.
+
+### 7. Orphan cleanup in delete handlers
+
+When an announcement or forum topic is deleted, its attached poll is also deleted (`DELETE FROM polls WHERE attached_to = X AND attached_id = Y`). This is handled in the existing delete logic for each content type, not via foreign keys or a separate cleanup job.
+
+## Schema
+
+### New tables
+
+```
+polls
+─────────────────────────────────────
+id              SERIAL PRIMARY KEY
+question        TEXT NOT NULL
+description     TEXT
+poll_type       TEXT NOT NULL DEFAULT 'single'    -- 'single' | 'multiple'
+is_anonymous    BOOLEAN DEFAULT false
+results_visible TEXT NOT NULL DEFAULT 'after_vote' -- 'always' | 'after_vote' | 'after_close'
+is_open         BOOLEAN DEFAULT true
+closes_at       TIMESTAMPTZ                       -- NULL = no expiry
+attached_to     TEXT                              -- 'announcement' | 'forum_topic' | 'section' | NULL
+attached_id     INT                               -- ID of parent, or NULL
+created_by      INT REFERENCES members(id)
+created_at      TIMESTAMPTZ DEFAULT now()
+
+poll_options
+─────────────────────────────────────
+id              SERIAL PRIMARY KEY
+poll_id         INT REFERENCES polls(id) ON DELETE CASCADE
+label           TEXT NOT NULL
+position        INT NOT NULL
+
+poll_votes
+─────────────────────────────────────
+id              SERIAL PRIMARY KEY
+poll_id         INT REFERENCES polls(id) ON DELETE CASCADE
+option_id       INT REFERENCES poll_options(id) ON DELETE CASCADE
+member_id       INT REFERENCES members(id)
+created_at      TIMESTAMPTZ DEFAULT now()
+UNIQUE(poll_id, member_id, option_id)
+```
+
+### Modified tables
+
+- `site_config`: Add rows for `feature_polls` (default true) and `polls_member_create` (default false)
+
+### New Zod schemas (src/schemas/poll.ts)
+
+- `PollSchema`, `PollOptionSchema`, `PollVoteSchema` with inferred types
+- Typed wrappers in `src/lib/api.ts`: `getPolls()`, `getPollOptions()`, `getPollVotes()`
+
+## Key Flows
+
+### Vote flow (single-choice)
+
+1. Member clicks option
+2. Client sends `DELETE FROM poll_votes WHERE poll_id = X AND member_id = Y`
+3. Client sends `INSERT INTO poll_votes (poll_id, option_id, member_id)`
+4. Client sends `POST activity_log` with action `poll_vote`
+5. Re-render poll widget with updated counts
+
+### Vote flow (multiple-choice)
+
+1. Member toggles option on: `INSERT INTO poll_votes (poll_id, option_id, member_id)`
+2. Member toggles option off: `DELETE FROM poll_votes WHERE poll_id = X AND option_id = Z AND member_id = Y`
+3. Activity log on each change
+4. Re-render poll widget
+
+### Embedded poll fetch (announcement detail)
+
+1. Fetch announcement by ID
+2. Fetch `polls?attached_to=eq.announcement&attached_id=eq.{id}`
+3. If poll found, fetch `poll_options?poll_id=eq.{poll_id}&order=position.asc`
+4. Fetch `poll_votes?poll_id=eq.{poll_id}` (for anonymous polls, strip member_id client-side or use a select param)
+5. Call `renderPoll(poll, options, votes, session)` and insert below announcement body
+
+### Results visibility logic
+
+| `results_visible` | Member hasn't voted | Member has voted | Poll closed |
+|---|---|---|---|
+| `always` | Show bars + counts | Show bars + counts + highlight vote | Show bars + counts |
+| `after_vote` | Show options only + total votes | Show bars + counts + highlight vote | Show bars + counts |
+| `after_close` | Show options only + "results after close" | Show "your vote" indicator only | Show bars + counts |
+
+## File Changes
+
+### New files
+
+- `src/schemas/poll.ts` — Zod schemas and types
+- `src/pages/polls.astro` — Standalone polls page (list + create + vote)
+- `src/lib/poll-ui.ts` — Shared `renderPoll()` and `createPollForm()` functions
+
+### Modified files
+
+- `schema.sql` — Add polls, poll_options, poll_votes tables
+- `seed.sql` — Add `feature_polls` and `polls_member_create` to site_config
+- `src/lib/api.ts` — Add typed poll wrappers
+- `src/pages/index.astro` — Add `polls` case to section renderer
+- `src/pages/forum.astro` — Add poll attachment to topic creation, render attached polls in topic detail
+- `src/pages/event.astro` — (Announcements are rendered here or inline) Add poll widget rendering for attached polls
+- `src/components/Nav.astro` or nav config — Add polls nav item (conditional on feature flag)
+- `src/pages/admin-settings.astro` — Add polls toggle to feature flags section
+- `public/css/styles.css` — Add poll widget styles (progress bars, vote buttons, results display)

--- a/openspec/changes/archive/2026-04-02-add-polls/proposal.md
+++ b/openspec/changes/archive/2026-04-02-add-polls/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Communities need lightweight decision-making tools built into their portal. Currently, admins who want member input resort to external tools (Google Forms, Strawpoll) that fragment the experience and lose context. Polls embedded directly in announcements, forum topics, and the homepage keep members engaged within the portal and give admins actionable signal without leaving the platform.
+
+Polls are also one of the highest-engagement features across community platforms — they require minimal effort from members (one click) and create visible social proof that draws more participation.
+
+## What Changes
+
+- **Add polls as standalone entities that can be embedded anywhere** — a poll is a first-class object with its own table, attachable to announcements, forum topics, homepage sections, or standing alone at `/polls`
+- **Poll creation inline** — admins (and optionally members) create polls via an inline form that appears inside announcement/forum editors or on the standalone `/polls` page
+- **Voting with configurable visibility** — members vote with one click; results display based on per-poll policy: always visible, after voting, or after poll closes
+- **Anonymous voting option** — per-poll boolean controls whether voter identity is exposed in results
+- **Poll auto-close on page load** — polls with a `closes_at` timestamp are marked closed when viewed after expiry (scheduled auto-close deferred to later)
+- **Feature-flagged** — `feature_polls` toggle; `polls_member_create` controls whether non-admin members can create polls
+
+## Capabilities
+
+### New Capabilities
+
+- `polls`: Poll CRUD, voting, results display, embedding in other content types, feature flags, and the standalone `/polls` page
+
+### Modified Capabilities
+
+- `announcements`: Announcements can have an attached poll; poll form appears in announcement editor for admins; poll widget renders below announcement body
+- `forum`: Forum topics can have an attached poll; poll form appears in topic creation; poll widget renders in topic detail view
+- `config-driven-ui`: New homepage section type `polls` renders featured polls; new feature flags `feature_polls` and `polls_member_create` added to site_config

--- a/openspec/changes/archive/2026-04-02-add-polls/specs/polls/spec.md
+++ b/openspec/changes/archive/2026-04-02-add-polls/specs/polls/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Poll CRUD
+
+The system SHALL support creating, reading, and deleting polls. Each poll MUST have: question (TEXT), poll_type ('single' or 'multiple'), is_anonymous (BOOLEAN), results_visible ('always', 'after_vote', or 'after_close'), is_open (BOOLEAN), and optional description, closes_at, attached_to, and attached_id fields. Only admin users SHALL be able to create polls by default. Members MAY create polls when `polls_member_create` is `true` in site_config.
+
+#### Scenario: Admin creates a standalone poll
+- **WHEN** an admin submits the poll creation form on `/polls` with question, options (minimum 2), and settings
+- **THEN** a poll row is inserted with `attached_to = NULL`
+- **THEN** poll_options rows are inserted for each option with sequential position values
+- **THEN** an activity_log entry is created with action `poll_create`
+- **THEN** the poll appears on the `/polls` page
+
+#### Scenario: Admin creates a poll attached to an announcement
+- **WHEN** an admin clicks "Add Poll" in the announcement editor and fills in the poll form
+- **THEN** the announcement is saved first, returning its ID
+- **THEN** the poll is created with `attached_to = 'announcement'` and `attached_id` = the announcement ID
+- **THEN** the poll widget renders below the announcement body
+
+#### Scenario: Admin creates a poll attached to a forum topic
+- **WHEN** an admin clicks "Add Poll" in the forum topic creation form and fills in the poll form
+- **THEN** the topic is saved first, returning its ID
+- **THEN** the poll is created with `attached_to = 'forum_topic'` and `attached_id` = the topic ID
+- **THEN** the poll widget renders in the topic detail view
+
+#### Scenario: Member creates a poll (when allowed)
+- **WHEN** `polls_member_create` is `true` and an authenticated member submits the poll creation form
+- **THEN** the poll is created with `created_by` = the member's ID
+
+#### Scenario: Member cannot create polls when disabled
+- **WHEN** `polls_member_create` is `false` and a non-admin member views `/polls`
+- **THEN** the "Create Poll" button is not shown
+
+#### Scenario: Admin deletes a poll
+- **WHEN** an admin deletes a poll
+- **THEN** the poll, its options, and all votes are deleted (CASCADE)
+
+#### Scenario: Minimum two options required
+- **WHEN** a user attempts to create a poll with fewer than 2 options
+- **THEN** the form prevents submission and shows a validation message
+
+### Requirement: Voting
+
+Members SHALL be able to vote on open polls. Single-choice polls allow one selection; multiple-choice polls allow multiple selections. Members MAY change their vote on open polls.
+
+#### Scenario: Member votes on a single-choice poll
+- **WHEN** an authenticated member clicks an option on a single-choice poll
+- **THEN** any existing vote by that member on that poll is deleted
+- **THEN** a new poll_votes row is inserted with the selected option
+- **THEN** an activity_log entry is created with action `poll_vote`
+- **THEN** the poll widget re-renders with updated counts
+
+#### Scenario: Member changes vote on a single-choice poll
+- **WHEN** a member clicks a different option on a single-choice poll they already voted on
+- **THEN** the previous vote is replaced with the new selection
+- **THEN** the poll widget re-renders showing the new selection
+
+#### Scenario: Member votes on a multiple-choice poll
+- **WHEN** an authenticated member clicks an option on a multiple-choice poll
+- **THEN** if the member has not voted for that option, a poll_votes row is inserted
+- **THEN** if the member has already voted for that option, the poll_votes row is deleted (toggle)
+- **THEN** the poll widget re-renders with updated counts
+
+#### Scenario: Duplicate vote prevented
+- **WHEN** a member attempts to insert a duplicate (poll_id, member_id, option_id) row
+- **THEN** the UNIQUE constraint prevents the duplicate
+
+#### Scenario: Voting on closed poll prevented
+- **WHEN** a member attempts to vote on a poll where `is_open = false`
+- **THEN** the vote buttons are not shown and no vote can be submitted
+
+#### Scenario: Unauthenticated users cannot vote
+- **WHEN** an unauthenticated user views a poll
+- **THEN** the poll results are displayed (per results_visible policy) but no vote buttons are shown
+
+### Requirement: Results visibility
+
+Poll results SHALL be displayed according to the poll's `results_visible` setting.
+
+#### Scenario: results_visible = 'always'
+- **WHEN** any user (authenticated or not) views the poll
+- **THEN** option labels, vote counts, and percentage bars are shown
+- **THEN** if the user has voted, their selection is highlighted
+
+#### Scenario: results_visible = 'after_vote' (before voting)
+- **WHEN** an authenticated member who has not voted views the poll
+- **THEN** option labels are shown as selectable buttons without counts or bars
+- **THEN** the total vote count is shown (e.g., "72 votes")
+
+#### Scenario: results_visible = 'after_vote' (after voting)
+- **WHEN** an authenticated member who has voted views the poll
+- **THEN** option labels, vote counts, and percentage bars are shown
+- **THEN** the member's selection is highlighted with a checkmark
+
+#### Scenario: results_visible = 'after_close' (while open)
+- **WHEN** a member views an open poll with `results_visible = 'after_close'`
+- **THEN** option labels are shown; if the member voted, their selection is indicated
+- **THEN** no counts or percentage bars are shown
+- **THEN** a message reads "Results shown after poll closes"
+
+#### Scenario: results_visible = 'after_close' (after close)
+- **WHEN** any user views a closed poll with `results_visible = 'after_close'`
+- **THEN** full results with counts and bars are shown
+
+### Requirement: Anonymous polls
+
+When `is_anonymous = true`, voter identity SHALL NOT be exposed in the UI or API responses. The system SHALL still store `member_id` internally to enforce vote uniqueness.
+
+#### Scenario: Anonymous poll hides voter identity
+- **WHEN** a user views results of an anonymous poll
+- **THEN** no voter names or member IDs are displayed
+- **THEN** only aggregate counts and percentages are shown
+
+#### Scenario: Non-anonymous poll shows voters (optional)
+- **WHEN** a user views results of a non-anonymous poll
+- **THEN** voter names MAY be shown (e.g., on hover or in a details panel)
+
+### Requirement: Poll auto-close on page load
+
+Polls with a `closes_at` timestamp in the past SHALL be treated as closed when rendered.
+
+#### Scenario: Expired poll auto-closes
+- **WHEN** a poll with `closes_at` in the past is rendered and `is_open` is still `true`
+- **THEN** the UI treats the poll as closed (no vote buttons, full results per visibility policy)
+- **THEN** a PATCH request sets `is_open = false` on the poll
+
+#### Scenario: Poll with no expiry stays open
+- **WHEN** a poll has `closes_at = NULL`
+- **THEN** the poll remains open until manually closed by an admin
+
+### Requirement: Poll deletion cascades with parent content
+
+When a content item with an attached poll is deleted, the attached poll SHALL also be deleted.
+
+#### Scenario: Deleting announcement deletes attached poll
+- **WHEN** an admin deletes an announcement that has an attached poll
+- **THEN** the poll with `attached_to = 'announcement'` and `attached_id` = the announcement ID is also deleted
+
+#### Scenario: Deleting forum topic deletes attached poll
+- **WHEN** an admin deletes a forum topic that has an attached poll
+- **THEN** the poll with `attached_to = 'forum_topic'` and `attached_id` = the topic ID is also deleted
+
+### Requirement: Polls are feature-flagged
+
+The polls UI SHALL only render when `feature_polls` is `true` in `site_config`. The `/polls` nav item SHALL only appear when the flag is enabled.
+
+#### Scenario: Feature flag enabled
+- **WHEN** `feature_polls` is `true`
+- **THEN** the `/polls` page is accessible, polls render in announcements/forum/homepage, and the nav item is shown
+
+#### Scenario: Feature flag disabled
+- **WHEN** `feature_polls` is `false`
+- **THEN** no poll UI renders anywhere, the nav item is hidden, and existing poll data is preserved
+
+### Requirement: Polls homepage section
+
+A new section type `polls` SHALL be supported on the homepage. The section config specifies which polls to feature.
+
+#### Scenario: Homepage polls section renders featured polls
+- **WHEN** a section with `section_type = 'polls'` exists and is visible
+- **THEN** the polls specified in `config.poll_ids` are rendered as interactive poll widgets
+- **THEN** members can vote directly from the homepage
+
+### Requirement: Standalone polls page
+
+The `/polls` page SHALL list all standalone polls (where `attached_to IS NULL`) and provide a creation form for authorized users.
+
+#### Scenario: Viewing the polls page
+- **WHEN** a user visits `/polls`
+- **THEN** open polls are listed first, followed by closed polls
+- **THEN** each poll shows the question, option count, total votes, and status (open/closed)
+
+#### Scenario: Viewing poll detail on the polls page
+- **WHEN** a user clicks on a poll in the list
+- **THEN** the full poll widget expands or navigates to show all options and results per visibility policy

--- a/openspec/changes/archive/2026-04-02-add-polls/tasks.md
+++ b/openspec/changes/archive/2026-04-02-add-polls/tasks.md
@@ -1,0 +1,56 @@
+## 1. Database Schema & Seed Data
+
+- [x] 1.1 Add `polls` table to `schema.sql` with columns: id, question, description, poll_type, is_anonymous, results_visible, is_open, closes_at, attached_to, attached_id, created_by, created_at
+- [x] 1.2 Add `poll_options` table to `schema.sql` with columns: id, poll_id (FK CASCADE), label, position
+- [x] 1.3 Add `poll_votes` table to `schema.sql` with columns: id, poll_id (FK CASCADE), option_id (FK CASCADE), member_id (FK), created_at, UNIQUE(poll_id, member_id, option_id)
+- [x] 1.4 Add `feature_polls` (default true) and `polls_member_create` (default false) to `seed.sql` site_config
+
+## 2. Zod Schemas & API Wrappers
+
+- [x] 2.1 Create `src/schemas/poll.ts` with PollSchema, PollOptionSchema, PollVoteSchema and exported types
+- [x] 2.2 Add typed wrappers to `src/lib/api.ts`: `getPolls()`, `getPollOptions()`, `getPollVotes()`
+
+## 3. Shared Poll UI Module
+
+- [x] 3.1 Create `src/lib/poll-ui.ts` with `renderPoll(poll, options, votes, session)` function — renders the poll widget HTML with vote bars, buttons, results visibility logic, and anonymous mode handling
+- [x] 3.2 Add `createPollForm(container, attachConfig?)` function to `src/lib/poll-ui.ts` — renders the poll creation form with question, dynamic option list (add/remove), poll_type toggle, is_anonymous checkbox, results_visible select, closes_at date picker
+- [x] 3.3 Add vote handler functions to `src/lib/poll-ui.ts`: `handleSingleVote(pollId, optionId, memberId)` (delete + insert), `handleMultiVote(pollId, optionId, memberId)` (toggle insert/delete), `checkAutoClose(poll)` (PATCH is_open if expired)
+
+## 4. Poll Styles
+
+- [x] 4.1 Add poll widget styles to `public/css/styles.css`: `.poll-widget`, `.poll-question`, `.poll-option`, `.poll-bar`, `.poll-bar-fill`, `.poll-vote-btn`, `.poll-results`, `.poll-meta`, `.poll-form`, `.poll-closed`
+
+## 5. Standalone Polls Page
+
+- [x] 5.1 Create `src/pages/polls.astro` with Portal layout — list open polls first then closed polls, each rendered with `renderPoll()`
+- [x] 5.2 Add poll creation form to `/polls` page — shown for admins always, members when `polls_member_create` is true; uses `createPollForm()` with no attachConfig
+- [x] 5.3 Wire up poll creation submit: POST to `polls`, then POST each option to `poll_options`, then POST to `activity_log`
+
+## 6. Embed Polls in Announcements
+
+- [x] 6.1 Modify announcement detail rendering (in the page that shows individual announcements) to fetch attached poll via `polls?attached_to=eq.announcement&attached_id=eq.{id}` and render with `renderPoll()` below the announcement body
+- [x] 6.2 Add "Add Poll" button to announcement creation/editing (admin only) that inserts `createPollForm(container, { type: 'announcement', id: null })` inline
+- [x] 6.3 Update announcement save handler to create the poll after the announcement is saved, linking via attached_to/attached_id
+- [x] 6.4 Update announcement delete handler to also delete attached poll: `del('polls?attached_to=eq.announcement&attached_id=eq.{id}')`
+
+## 7. Embed Polls in Forum Topics
+
+- [x] 7.1 Modify forum topic detail rendering to fetch attached poll via `polls?attached_to=eq.forum_topic&attached_id=eq.{id}` and render with `renderPoll()`
+- [x] 7.2 Add "Add Poll" button to forum topic creation form (admin only, or members if `polls_member_create`) that inserts `createPollForm()` inline
+- [x] 7.3 Update topic save handler to create the poll after the topic is saved, linking via attached_to/attached_id
+- [x] 7.4 Update topic delete handler to also delete attached poll
+
+## 8. Homepage Section
+
+- [x] 8.1 Add `polls` case to `renderSection()` in `src/pages/index.astro` — reads `config.poll_ids`, fetches each poll with options and votes, renders with `renderPoll()`
+
+## 9. Feature Flags & Navigation
+
+- [x] 9.1 Add polls nav item to nav config in `seed.sql` — conditional on `feature_polls`, positioned after existing nav items
+- [x] 9.2 Add `feature_polls` toggle to admin settings page feature flags section (auto-populated from feature_* keys)
+
+## 10. Tests
+
+- [x] 10.1 Add unit tests for `src/schemas/poll.ts` — validate schema parsing for valid and invalid poll/option/vote data
+- [x] 10.2 Add unit tests for `src/lib/poll-ui.ts` — test `renderPoll()` output for each results_visible mode, anonymous mode, closed state, voted/not-voted states
+- [x] 10.3 Add integration test for vote flow — single-choice replace, multi-choice toggle, closed poll rejection

--- a/openspec/specs/polls/spec.md
+++ b/openspec/specs/polls/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Poll CRUD
+
+The system SHALL support creating, reading, and deleting polls. Each poll MUST have: question (TEXT), poll_type ('single' or 'multiple'), is_anonymous (BOOLEAN), results_visible ('always', 'after_vote', or 'after_close'), is_open (BOOLEAN), and optional description, closes_at, attached_to, and attached_id fields. Only admin users SHALL be able to create polls by default. Members MAY create polls when `polls_member_create` is `true` in site_config.
+
+#### Scenario: Admin creates a standalone poll
+- **WHEN** an admin submits the poll creation form on `/polls` with question, options (minimum 2), and settings
+- **THEN** a poll row is inserted with `attached_to = NULL`
+- **THEN** poll_options rows are inserted for each option with sequential position values
+- **THEN** an activity_log entry is created with action `poll_create`
+- **THEN** the poll appears on the `/polls` page
+
+#### Scenario: Admin creates a poll attached to an announcement
+- **WHEN** an admin clicks "Add Poll" in the announcement editor and fills in the poll form
+- **THEN** the announcement is saved first, returning its ID
+- **THEN** the poll is created with `attached_to = 'announcement'` and `attached_id` = the announcement ID
+- **THEN** the poll widget renders below the announcement body
+
+#### Scenario: Admin creates a poll attached to a forum topic
+- **WHEN** an admin clicks "Add Poll" in the forum topic creation form and fills in the poll form
+- **THEN** the topic is saved first, returning its ID
+- **THEN** the poll is created with `attached_to = 'forum_topic'` and `attached_id` = the topic ID
+- **THEN** the poll widget renders in the topic detail view
+
+#### Scenario: Member creates a poll (when allowed)
+- **WHEN** `polls_member_create` is `true` and an authenticated member submits the poll creation form
+- **THEN** the poll is created with `created_by` = the member's ID
+
+#### Scenario: Member cannot create polls when disabled
+- **WHEN** `polls_member_create` is `false` and a non-admin member views `/polls`
+- **THEN** the "Create Poll" button is not shown
+
+#### Scenario: Admin deletes a poll
+- **WHEN** an admin deletes a poll
+- **THEN** the poll, its options, and all votes are deleted (CASCADE)
+
+#### Scenario: Minimum two options required
+- **WHEN** a user attempts to create a poll with fewer than 2 options
+- **THEN** the form prevents submission and shows a validation message
+
+### Requirement: Voting
+
+Members SHALL be able to vote on open polls. Single-choice polls allow one selection; multiple-choice polls allow multiple selections. Members MAY change their vote on open polls.
+
+#### Scenario: Member votes on a single-choice poll
+- **WHEN** an authenticated member clicks an option on a single-choice poll
+- **THEN** any existing vote by that member on that poll is deleted
+- **THEN** a new poll_votes row is inserted with the selected option
+- **THEN** an activity_log entry is created with action `poll_vote`
+- **THEN** the poll widget re-renders with updated counts
+
+#### Scenario: Member changes vote on a single-choice poll
+- **WHEN** a member clicks a different option on a single-choice poll they already voted on
+- **THEN** the previous vote is replaced with the new selection
+- **THEN** the poll widget re-renders showing the new selection
+
+#### Scenario: Member votes on a multiple-choice poll
+- **WHEN** an authenticated member clicks an option on a multiple-choice poll
+- **THEN** if the member has not voted for that option, a poll_votes row is inserted
+- **THEN** if the member has already voted for that option, the poll_votes row is deleted (toggle)
+- **THEN** the poll widget re-renders with updated counts
+
+#### Scenario: Duplicate vote prevented
+- **WHEN** a member attempts to insert a duplicate (poll_id, member_id, option_id) row
+- **THEN** the UNIQUE constraint prevents the duplicate
+
+#### Scenario: Voting on closed poll prevented
+- **WHEN** a member attempts to vote on a poll where `is_open = false`
+- **THEN** the vote buttons are not shown and no vote can be submitted
+
+#### Scenario: Unauthenticated users cannot vote
+- **WHEN** an unauthenticated user views a poll
+- **THEN** the poll results are displayed (per results_visible policy) but no vote buttons are shown
+
+### Requirement: Results visibility
+
+Poll results SHALL be displayed according to the poll's `results_visible` setting.
+
+#### Scenario: results_visible = 'always'
+- **WHEN** any user (authenticated or not) views the poll
+- **THEN** option labels, vote counts, and percentage bars are shown
+- **THEN** if the user has voted, their selection is highlighted
+
+#### Scenario: results_visible = 'after_vote' (before voting)
+- **WHEN** an authenticated member who has not voted views the poll
+- **THEN** option labels are shown as selectable buttons without counts or bars
+- **THEN** the total vote count is shown (e.g., "72 votes")
+
+#### Scenario: results_visible = 'after_vote' (after voting)
+- **WHEN** an authenticated member who has voted views the poll
+- **THEN** option labels, vote counts, and percentage bars are shown
+- **THEN** the member's selection is highlighted with a checkmark
+
+#### Scenario: results_visible = 'after_close' (while open)
+- **WHEN** a member views an open poll with `results_visible = 'after_close'`
+- **THEN** option labels are shown; if the member voted, their selection is indicated
+- **THEN** no counts or percentage bars are shown
+- **THEN** a message reads "Results shown after poll closes"
+
+#### Scenario: results_visible = 'after_close' (after close)
+- **WHEN** any user views a closed poll with `results_visible = 'after_close'`
+- **THEN** full results with counts and bars are shown
+
+### Requirement: Anonymous polls
+
+When `is_anonymous = true`, voter identity SHALL NOT be exposed in the UI or API responses. The system SHALL still store `member_id` internally to enforce vote uniqueness.
+
+#### Scenario: Anonymous poll hides voter identity
+- **WHEN** a user views results of an anonymous poll
+- **THEN** no voter names or member IDs are displayed
+- **THEN** only aggregate counts and percentages are shown
+
+#### Scenario: Non-anonymous poll shows voters (optional)
+- **WHEN** a user views results of a non-anonymous poll
+- **THEN** voter names MAY be shown (e.g., on hover or in a details panel)
+
+### Requirement: Poll auto-close on page load
+
+Polls with a `closes_at` timestamp in the past SHALL be treated as closed when rendered.
+
+#### Scenario: Expired poll auto-closes
+- **WHEN** a poll with `closes_at` in the past is rendered and `is_open` is still `true`
+- **THEN** the UI treats the poll as closed (no vote buttons, full results per visibility policy)
+- **THEN** a PATCH request sets `is_open = false` on the poll
+
+#### Scenario: Poll with no expiry stays open
+- **WHEN** a poll has `closes_at = NULL`
+- **THEN** the poll remains open until manually closed by an admin
+
+### Requirement: Poll deletion cascades with parent content
+
+When a content item with an attached poll is deleted, the attached poll SHALL also be deleted.
+
+#### Scenario: Deleting announcement deletes attached poll
+- **WHEN** an admin deletes an announcement that has an attached poll
+- **THEN** the poll with `attached_to = 'announcement'` and `attached_id` = the announcement ID is also deleted
+
+#### Scenario: Deleting forum topic deletes attached poll
+- **WHEN** an admin deletes a forum topic that has an attached poll
+- **THEN** the poll with `attached_to = 'forum_topic'` and `attached_id` = the topic ID is also deleted
+
+### Requirement: Polls are feature-flagged
+
+The polls UI SHALL only render when `feature_polls` is `true` in `site_config`. The `/polls` nav item SHALL only appear when the flag is enabled.
+
+#### Scenario: Feature flag enabled
+- **WHEN** `feature_polls` is `true`
+- **THEN** the `/polls` page is accessible, polls render in announcements/forum/homepage, and the nav item is shown
+
+#### Scenario: Feature flag disabled
+- **WHEN** `feature_polls` is `false`
+- **THEN** no poll UI renders anywhere, the nav item is hidden, and existing poll data is preserved
+
+### Requirement: Polls homepage section
+
+A new section type `polls` SHALL be supported on the homepage. The section config specifies which polls to feature.
+
+#### Scenario: Homepage polls section renders featured polls
+- **WHEN** a section with `section_type = 'polls'` exists and is visible
+- **THEN** the polls specified in `config.poll_ids` are rendered as interactive poll widgets
+- **THEN** members can vote directly from the homepage
+
+### Requirement: Standalone polls page
+
+The `/polls` page SHALL list all standalone polls (where `attached_to IS NULL`) and provide a creation form for authorized users.
+
+#### Scenario: Viewing the polls page
+- **WHEN** a user visits `/polls`
+- **THEN** open polls are listed first, followed by closed polls
+- **THEN** each poll shows the question, option count, total votes, and status (open/closed)
+
+#### Scenario: Viewing poll detail on the polls page
+- **WHEN** a user clicks on a poll in the list
+- **THEN** the full poll widget expands or navigates to show all options and results per visibility policy

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1028,3 +1028,136 @@ tr:hover td {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* Polls */
+.poll-widget {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-top: 1rem;
+  background: var(--color-surface);
+}
+.poll-widget.poll-closed {
+  opacity: 0.85;
+}
+.poll-question {
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+}
+.poll-description {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+.poll-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.poll-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  border-radius: var(--radius);
+  padding: 0.125rem 0;
+}
+.poll-option-readonly {
+  cursor: default;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+.poll-option-voted {
+  font-weight: 500;
+}
+.poll-bar {
+  flex: 1;
+  position: relative;
+  height: 2rem;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+.poll-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: var(--color-primary);
+  opacity: 0.15;
+  transition: width 0.3s ease;
+}
+.poll-option-voted .poll-bar-fill {
+  opacity: 0.25;
+}
+.poll-bar-label {
+  position: relative;
+  z-index: 1;
+  padding-left: 0.75rem;
+  line-height: 2rem;
+  font-size: 0.875rem;
+}
+.poll-bar-pct {
+  position: absolute;
+  right: 0.75rem;
+  top: 0;
+  z-index: 1;
+  line-height: 2rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+.poll-bar-count {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  min-width: 2rem;
+  text-align: right;
+}
+.poll-vote-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+}
+.poll-vote-btn:hover {
+  border-color: var(--color-primary);
+  background: rgba(99, 102, 241, 0.04);
+}
+.poll-vote-btn.poll-option-selected {
+  border-color: var(--color-primary);
+  background: rgba(99, 102, 241, 0.08);
+}
+.poll-vote-indicator {
+  font-size: 1rem;
+  line-height: 1;
+}
+.poll-meta {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+.poll-form {
+  margin-top: 1rem;
+}
+.poll-form .form-label {
+  font-size: 0.875rem;
+}
+.poll-form-option-row .poll-form-option-remove {
+  flex-shrink: 0;
+}
+.mb-half {
+  margin-bottom: 0.5rem;
+}
+.mt-half {
+  margin-top: 0.5rem;
+}

--- a/schema.sql
+++ b/schema.sql
@@ -188,6 +188,41 @@ CREATE TABLE IF NOT EXISTS announcements (
 );
 
 -- ============================================
+-- SECTION: Polls (feature: polls)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS polls (
+  id SERIAL PRIMARY KEY,
+  question TEXT NOT NULL,
+  description TEXT,
+  poll_type TEXT NOT NULL DEFAULT 'single',
+  is_anonymous BOOLEAN DEFAULT false,
+  results_visible TEXT NOT NULL DEFAULT 'after_vote',
+  is_open BOOLEAN DEFAULT true,
+  closes_at TIMESTAMPTZ,
+  attached_to TEXT,
+  attached_id INT,
+  created_by INT REFERENCES members(id),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS poll_options (
+  id SERIAL PRIMARY KEY,
+  poll_id INT REFERENCES polls(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  position INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS poll_votes (
+  id SERIAL PRIMARY KEY,
+  poll_id INT REFERENCES polls(id) ON DELETE CASCADE,
+  option_id INT REFERENCES poll_options(id) ON DELETE CASCADE,
+  member_id INT REFERENCES members(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(poll_id, member_id, option_id)
+);
+
+-- ============================================
 -- SECTION: Reactions
 -- ============================================
 

--- a/seed.sql
+++ b/seed.sql
@@ -45,7 +45,9 @@ INSERT INTO site_config (key, value, category) VALUES
   ('directory_public', 'false', 'features'),
   ('signup_mode', '"approved"', 'features'),
   ('feature_activity_feed', 'true', 'features'),
-  ('feature_reactions', 'true', 'features')
+  ('feature_reactions', 'true', 'features'),
+  ('feature_polls', 'true', 'features'),
+  ('polls_member_create', 'false', 'features')
 ON CONFLICT (key) DO NOTHING;
 
 -- Navigation
@@ -57,6 +59,7 @@ INSERT INTO site_config (key, value, category) VALUES
     {"label": "Resources", "href": "/resources.html", "icon": "book-open", "feature": "feature_resources"},
     {"label": "Forum", "href": "/forum.html", "icon": "message-circle", "feature": "feature_forum"},
     {"label": "Committees", "href": "/committees.html", "icon": "briefcase", "feature": "feature_committees"},
+    {"label": "Polls", "href": "/polls.html", "icon": "bar-chart", "feature": "feature_polls"},
     {"label": "Dashboard", "href": "/admin.html", "icon": "bar-chart-2", "admin": true},
     {"label": "Members", "href": "/admin-members.html", "icon": "users", "admin": true},
     {"label": "Settings", "href": "/admin-settings.html", "icon": "settings", "admin": true}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -119,12 +119,14 @@ import { SiteConfigRowSchema } from '../schemas/config';
 import { AnnouncementSchema, ResourceSchema, SectionSchema, PageSchema, ReactionSchema } from '../schemas/content';
 import { ForumCategorySchema, ForumTopicSchema, ForumReplySchema } from '../schemas/forum';
 import { CommitteeSchema, CommitteeMemberSchema } from '../schemas/committee';
+import { PollSchema, PollOptionSchema, PollVoteSchema } from '../schemas/poll';
 import type { Event, EventRSVP } from '../schemas/event';
 import type { Member, MemberTier } from '../schemas/member';
 import type { SiteConfigRow } from '../schemas/config';
 import type { Announcement, Resource, Section, Page, Reaction } from '../schemas/content';
 import type { ForumCategory, ForumTopic, ForumReply } from '../schemas/forum';
 import type { Committee, CommitteeMember } from '../schemas/committee';
+import type { Poll, PollOption, PollVote } from '../schemas/poll';
 
 export async function getConfig(): Promise<SiteConfigRow[]> {
   const data = await get('site_config');
@@ -200,6 +202,21 @@ export async function getCommittees(): Promise<Committee[]> {
 export async function getCommitteeMembers(committeeId: number): Promise<CommitteeMember[]> {
   const data = await get(`committee_members?committee_id=eq.${committeeId}`);
   return z.array(CommitteeMemberSchema).parse(data);
+}
+
+export async function getPolls(query = ''): Promise<Poll[]> {
+  const data = await get(`polls${query ? `?${query}` : '?order=created_at.desc'}`);
+  return z.array(PollSchema).parse(data);
+}
+
+export async function getPollOptions(pollId: number): Promise<PollOption[]> {
+  const data = await get(`poll_options?poll_id=eq.${pollId}&order=position.asc`);
+  return z.array(PollOptionSchema).parse(data);
+}
+
+export async function getPollVotes(pollId: number): Promise<PollVote[]> {
+  const data = await get(`poll_votes?poll_id=eq.${pollId}`);
+  return z.array(PollVoteSchema).parse(data);
 }
 
 export { getAPI, getAnonKey, getAuthHeaders };

--- a/src/lib/poll-ui.ts
+++ b/src/lib/poll-ui.ts
@@ -1,0 +1,379 @@
+// poll-ui.ts — Shared poll rendering and creation functions
+import { del, get, patch, post } from './api';
+
+function esc(s: string): string {
+  const d = document.createElement('div');
+  d.textContent = String(s || '');
+  return d.innerHTML;
+}
+
+interface PollData {
+  id: number;
+  question: string;
+  description: string | null;
+  poll_type: string;
+  is_anonymous: boolean;
+  results_visible: string;
+  is_open: boolean;
+  closes_at: string | null;
+  created_by: number | null;
+  created_at: string;
+}
+
+interface PollOptionData {
+  id: number;
+  poll_id: number;
+  label: string;
+  position: number;
+}
+
+interface PollVoteData {
+  id: number;
+  poll_id: number;
+  option_id: number;
+  member_id: number | null;
+}
+
+interface SessionData {
+  user?: { member?: { id: number } };
+}
+
+// --- Auto-close check ---
+export async function checkAutoClose(poll: PollData): Promise<boolean> {
+  if (!poll.is_open || !poll.closes_at) return false;
+  if (new Date(poll.closes_at) > new Date()) return false;
+  try {
+    await patch(`polls?id=eq.${poll.id}`, { is_open: false });
+  } catch {}
+  return true;
+}
+
+// --- Render poll widget ---
+export function renderPoll(
+  poll: PollData,
+  options: PollOptionData[],
+  votes: PollVoteData[],
+  session: SessionData | null,
+): string {
+  const memberId = session?.user?.member?.id ?? null;
+  const isAuthenticated = memberId !== null;
+  const expired = poll.closes_at ? new Date(poll.closes_at) <= new Date() : false;
+  const isClosed = !poll.is_open || expired;
+  const myVotes = isAuthenticated ? votes.filter((v) => v.member_id === memberId) : [];
+  const hasVoted = myVotes.length > 0;
+  const totalVotes = votes.length;
+
+  // Determine if we show results
+  const showResults =
+    poll.results_visible === 'always' ||
+    (poll.results_visible === 'after_vote' && hasVoted) ||
+    (poll.results_visible === 'after_close' && isClosed);
+
+  // Count votes per option
+  const voteCounts: Record<number, number> = {};
+  for (const opt of options) voteCounts[opt.id] = 0;
+  for (const v of votes) voteCounts[v.option_id] = (voteCounts[v.option_id] || 0) + 1;
+
+  let optionsHtml = '';
+  for (const opt of options) {
+    const count = voteCounts[opt.id] || 0;
+    const pct = totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
+    const isMyVote = myVotes.some((v) => v.option_id === opt.id);
+
+    if (showResults) {
+      // Results mode: show bars + counts
+      optionsHtml += `
+        <div class="poll-option ${isMyVote ? 'poll-option-voted' : ''}" data-poll-vote="${opt.id}" data-poll-id="${poll.id}">
+          <div class="poll-bar">
+            <div class="poll-bar-fill" style="width:${pct}%"></div>
+            <span class="poll-bar-label">${esc(opt.label)}</span>
+            <span class="poll-bar-pct">${pct}%${isMyVote ? ' \u2713' : ''}</span>
+          </div>
+          <span class="poll-bar-count">${count}</span>
+        </div>`;
+    } else if (isAuthenticated && !isClosed) {
+      // Voting mode: clickable options
+      const selectedClass = isMyVote ? ' poll-option-selected' : '';
+      const indicator = poll.poll_type === 'multiple' ? (isMyVote ? '\u2611' : '\u2610') : isMyVote ? '\u25C9' : '\u25CB';
+      optionsHtml += `
+        <button class="poll-vote-btn${selectedClass}" data-poll-vote="${opt.id}" data-poll-id="${poll.id}">
+          <span class="poll-vote-indicator">${indicator}</span>
+          <span>${esc(opt.label)}</span>
+        </button>`;
+    } else {
+      // Read-only mode (not authenticated or closed without results)
+      optionsHtml += `
+        <div class="poll-option poll-option-readonly">
+          <span>${esc(opt.label)}</span>
+        </div>`;
+    }
+  }
+
+  // Meta line
+  const metaParts: string[] = [];
+  metaParts.push(`${totalVotes} vote${totalVotes !== 1 ? 's' : ''}`);
+  if (poll.closes_at && !isClosed) {
+    const closesDate = new Date(poll.closes_at).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+    metaParts.push(`Closes ${closesDate}`);
+  }
+  if (isClosed) metaParts.push('Closed');
+  if (poll.is_anonymous) metaParts.push('Anonymous');
+  if (poll.poll_type === 'multiple') metaParts.push('Select multiple');
+  if (poll.results_visible === 'after_close' && !isClosed && !showResults) {
+    metaParts.push('Results after close');
+  }
+
+  return `
+    <div class="poll-widget${isClosed ? ' poll-closed' : ''}" data-poll-widget="${poll.id}" data-poll-type="${poll.poll_type}">
+      <div class="poll-question">${esc(poll.question)}</div>
+      ${poll.description ? `<div class="poll-description">${esc(poll.description)}</div>` : ''}
+      <div class="poll-options">${optionsHtml}</div>
+      <div class="poll-meta">${metaParts.join(' \u00B7 ')}</div>
+    </div>`;
+}
+
+// --- Vote handlers ---
+export async function handleSingleVote(
+  pollId: number,
+  optionId: number,
+  memberId: number,
+): Promise<void> {
+  // Delete any existing votes for this member on this poll
+  await del(`poll_votes?poll_id=eq.${pollId}&member_id=eq.${memberId}`);
+  // Insert new vote
+  await post('poll_votes', { poll_id: pollId, option_id: optionId, member_id: memberId });
+  await post('activity_log', {
+    member_id: memberId,
+    action: 'poll_vote',
+    metadata: { poll_id: pollId },
+  });
+}
+
+export async function handleMultiVote(
+  pollId: number,
+  optionId: number,
+  memberId: number,
+  currentVotes: PollVoteData[],
+): Promise<void> {
+  const existing = currentVotes.find(
+    (v) => v.option_id === optionId && v.member_id === memberId,
+  );
+  if (existing) {
+    await del(`poll_votes?id=eq.${existing.id}`);
+  } else {
+    await post('poll_votes', { poll_id: pollId, option_id: optionId, member_id: memberId });
+  }
+  await post('activity_log', {
+    member_id: memberId,
+    action: 'poll_vote',
+    metadata: { poll_id: pollId },
+  });
+}
+
+// --- Bind vote event listeners ---
+export function bindPollVoteListeners(
+  container: HTMLElement,
+  poll: PollData,
+  votes: PollVoteData[],
+  memberId: number | null,
+  onVote: () => void,
+): void {
+  if (!memberId || !poll.is_open) return;
+  const expired = poll.closes_at ? new Date(poll.closes_at) <= new Date() : false;
+  if (expired) return;
+
+  container.querySelectorAll('[data-poll-vote]').forEach((el) => {
+    el.addEventListener('click', async () => {
+      const optionId = parseInt((el as HTMLElement).dataset.pollVote!, 10);
+      try {
+        if (poll.poll_type === 'multiple') {
+          await handleMultiVote(poll.id, optionId, memberId, votes);
+        } else {
+          await handleSingleVote(poll.id, optionId, memberId);
+        }
+        onVote();
+      } catch (e) {
+        console.error('Vote failed:', e);
+      }
+    });
+  });
+}
+
+// --- Fetch and render a poll by ID ---
+export async function fetchAndRenderPoll(
+  pollId: number,
+  session: SessionData | null,
+): Promise<{ html: string; poll: PollData; options: PollOptionData[]; votes: PollVoteData[] }> {
+  const polls = await get(`polls?id=eq.${pollId}`);
+  const poll = polls[0];
+  if (!poll) throw new Error('Poll not found');
+  await checkAutoClose(poll);
+  const options = await get(`poll_options?poll_id=eq.${pollId}&order=position.asc`);
+  const votes = await get(`poll_votes?poll_id=eq.${pollId}`);
+  const html = renderPoll(poll, options, votes, session);
+  return { html, poll, options, votes };
+}
+
+// --- Fetch and render attached poll ---
+export async function fetchAttachedPoll(
+  attachedTo: string,
+  attachedId: number,
+  session: SessionData | null,
+): Promise<{ html: string; poll: PollData; options: PollOptionData[]; votes: PollVoteData[] } | null> {
+  const polls = await get(`polls?attached_to=eq.${attachedTo}&attached_id=eq.${attachedId}`);
+  if (!polls || polls.length === 0) return null;
+  const poll = polls[0];
+  await checkAutoClose(poll);
+  const options = await get(`poll_options?poll_id=eq.${poll.id}&order=position.asc`);
+  const votes = await get(`poll_votes?poll_id=eq.${poll.id}`);
+  const html = renderPoll(poll, options, votes, session);
+  return { html, poll, options, votes };
+}
+
+// --- Poll creation form ---
+export interface AttachConfig {
+  type: string;
+  id: number | null;
+}
+
+export function createPollForm(
+  container: HTMLElement,
+  _attachConfig?: AttachConfig | null,
+): { getPollData: () => { question: string; options: string[]; poll_type: string; is_anonymous: boolean; results_visible: string; closes_at: string | null } | null; remove: () => void } {
+  container.innerHTML = `
+    <div class="poll-form card">
+      <div class="flex justify-between items-center mb-1">
+        <h4>Add Poll</h4>
+        <button class="btn btn-sm btn-secondary poll-form-remove" type="button">\u2715 Remove</button>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Question</label>
+        <input class="form-input poll-form-question" required placeholder="What do you want to ask?">
+      </div>
+      <div class="poll-form-options">
+        <label class="form-label">Options (minimum 2)</label>
+        <div class="poll-form-option-list">
+          <div class="poll-form-option-row flex gap-1 mb-half">
+            <input class="form-input poll-form-option-input" placeholder="Option 1" required>
+            <button class="btn btn-sm btn-secondary poll-form-option-remove" type="button">\u2715</button>
+          </div>
+          <div class="poll-form-option-row flex gap-1 mb-half">
+            <input class="form-input poll-form-option-input" placeholder="Option 2" required>
+            <button class="btn btn-sm btn-secondary poll-form-option-remove" type="button">\u2715</button>
+          </div>
+        </div>
+        <button class="btn btn-sm btn-secondary mt-half poll-form-add-option" type="button">+ Add option</button>
+      </div>
+      <div class="poll-form-settings mt-1">
+        <div class="flex gap-2 flex-wrap">
+          <label class="form-label" style="display:flex;align-items:center;gap:0.5rem">
+            Type:
+            <select class="form-input poll-form-type" style="width:auto">
+              <option value="single">Single choice</option>
+              <option value="multiple">Multiple choice</option>
+            </select>
+          </label>
+          <label class="form-label" style="display:flex;align-items:center;gap:0.5rem">
+            Results:
+            <select class="form-input poll-form-visibility" style="width:auto">
+              <option value="after_vote">After voting</option>
+              <option value="always">Always visible</option>
+              <option value="after_close">After close</option>
+            </select>
+          </label>
+          <label class="form-label" style="display:flex;align-items:center;gap:0.5rem">
+            <input type="checkbox" class="poll-form-anonymous"> Anonymous
+          </label>
+        </div>
+        <div class="form-group mt-1">
+          <label class="form-label">Closes at (optional)</label>
+          <input type="datetime-local" class="form-input poll-form-closes" style="width:auto">
+        </div>
+      </div>
+    </div>`;
+
+  // Add option handler
+  const optionList = container.querySelector('.poll-form-option-list')!;
+  container.querySelector('.poll-form-add-option')!.addEventListener('click', () => {
+    const count = optionList.querySelectorAll('.poll-form-option-row').length;
+    const row = document.createElement('div');
+    row.className = 'poll-form-option-row flex gap-1 mb-half';
+    row.innerHTML = `
+      <input class="form-input poll-form-option-input" placeholder="Option ${count + 1}" required>
+      <button class="btn btn-sm btn-secondary poll-form-option-remove" type="button">\u2715</button>`;
+    optionList.appendChild(row);
+    bindOptionRemove(row);
+  });
+
+  // Remove option handler
+  function bindOptionRemove(row: Element) {
+    row.querySelector('.poll-form-option-remove')!.addEventListener('click', () => {
+      if (optionList.querySelectorAll('.poll-form-option-row').length <= 2) return;
+      row.remove();
+    });
+  }
+  container.querySelectorAll('.poll-form-option-row').forEach(bindOptionRemove);
+
+  // Remove form handler
+  const removeBtn = container.querySelector('.poll-form-remove')!;
+  const remove = () => {
+    container.innerHTML = '';
+  };
+  removeBtn.addEventListener('click', remove);
+
+  // Get data
+  function getPollData() {
+    const question = (container.querySelector('.poll-form-question') as HTMLInputElement)?.value.trim();
+    if (!question) return null;
+    const optionInputs = container.querySelectorAll('.poll-form-option-input') as NodeListOf<HTMLInputElement>;
+    const options = Array.from(optionInputs)
+      .map((i) => i.value.trim())
+      .filter(Boolean);
+    if (options.length < 2) return null;
+    const poll_type = (container.querySelector('.poll-form-type') as HTMLSelectElement).value;
+    const is_anonymous = (container.querySelector('.poll-form-anonymous') as HTMLInputElement).checked;
+    const results_visible = (container.querySelector('.poll-form-visibility') as HTMLSelectElement).value;
+    const closesInput = (container.querySelector('.poll-form-closes') as HTMLInputElement).value;
+    const closes_at = closesInput ? new Date(closesInput).toISOString() : null;
+    return { question, options, poll_type, is_anonymous, results_visible, closes_at };
+  }
+
+  return { getPollData, remove };
+}
+
+// --- Submit poll to API ---
+export async function submitPoll(
+  data: { question: string; options: string[]; poll_type: string; is_anonymous: boolean; results_visible: string; closes_at: string | null },
+  memberId: number,
+  attachConfig?: AttachConfig | null,
+): Promise<number> {
+  const pollBody: Record<string, any> = {
+    question: data.question,
+    poll_type: data.poll_type,
+    is_anonymous: data.is_anonymous,
+    results_visible: data.results_visible,
+    closes_at: data.closes_at,
+    created_by: memberId,
+  };
+  if (attachConfig?.type && attachConfig.id) {
+    pollBody.attached_to = attachConfig.type;
+    pollBody.attached_id = attachConfig.id;
+  }
+  const [created] = await post('polls', pollBody);
+  const pollId = created.id;
+
+  for (let i = 0; i < data.options.length; i++) {
+    await post('poll_options', { poll_id: pollId, label: data.options[i], position: i });
+  }
+
+  await post('activity_log', {
+    member_id: memberId,
+    action: 'poll_create',
+    metadata: { poll_id: pollId, question: data.question },
+  });
+
+  return pollId;
+}

--- a/src/pages/forum.astro
+++ b/src/pages/forum.astro
@@ -47,7 +47,8 @@ import Portal from '../layouts/Portal.astro';
 <script>
   import { del, get, patch, post } from '../lib/api';
   import { getSession, isAdmin, isAuthenticated } from '../lib/auth';
-  import { addTranslateButton, translateItems } from '../lib/config';
+  import { addTranslateButton, translateItems, isFeatureEnabled, getConfig } from '../lib/config';
+  import { renderPoll, bindPollVoteListeners, createPollForm, submitPoll, fetchAttachedPoll } from '../lib/poll-ui';
 
   function esc(s: string): string {
     const d = document.createElement('div');
@@ -204,6 +205,8 @@ import Portal from '../layouts/Portal.astro';
 
     // New topic form
     if (isAuthenticated()) {
+      const pollsEnabled = isFeatureEnabled('feature_polls');
+      const canCreatePoll = isAdmin() || getConfig('polls_member_create') === true;
       html += `
         <div class="forum-new-topic-form">
           <h3 class="mb-1">New Topic</h3>
@@ -216,12 +219,33 @@ import Portal from '../layouts/Portal.astro';
               <label class="form-label">Body</label>
               <textarea class="form-textarea" id="nt-body" required></textarea>
             </div>
+            ${pollsEnabled && canCreatePoll ? '<div id="nt-poll-form-container"></div><button class="btn btn-sm btn-secondary mb-1" id="nt-add-poll" type="button">+ Add Poll</button>' : ''}
             <button type="submit" class="btn btn-primary">Create Topic</button>
           </form>
         </div>`;
     }
 
     root.innerHTML = html;
+
+    // Bind poll form on new topic
+    let topicPollFormRef: ReturnType<typeof createPollForm> | null = null;
+    const ntAddPoll = document.getElementById('nt-add-poll');
+    if (ntAddPoll) {
+      ntAddPoll.addEventListener('click', () => {
+        const formContainer = document.getElementById('nt-poll-form-container')!;
+        if (topicPollFormRef) return;
+        topicPollFormRef = createPollForm(formContainer, { type: 'forum_topic', id: null });
+        ntAddPoll.classList.add('hidden');
+        const observer = new MutationObserver(() => {
+          if (formContainer.innerHTML === '') {
+            topicPollFormRef = null;
+            ntAddPoll.classList.remove('hidden');
+            observer.disconnect();
+          }
+        });
+        observer.observe(formContainer, { childList: true });
+      });
+    }
 
     // Bind new topic form
     const form = document.getElementById('new-topic-form');
@@ -244,13 +268,26 @@ import Portal from '../layouts/Portal.astro';
           btn.disabled = true;
           btn.textContent = 'Creating...';
 
-          await post('forum_topics', {
+          const [created] = await post('forum_topics', {
             title,
             body,
             author_id: memberId,
             author_name: session.user.member.display_name || session.user.email,
             category_id: categoryId,
           });
+
+          // Create attached poll if form is filled
+          if (topicPollFormRef) {
+            const pollData = topicPollFormRef.getPollData();
+            if (pollData) {
+              try {
+                await submitPoll(pollData, memberId, { type: 'forum_topic', id: created.id });
+              } catch (e) {
+                console.error('Failed to create attached poll:', e);
+              }
+            }
+            topicPollFormRef = null;
+          }
 
           await post('activity_log', { member_id: memberId, action: 'forum_post', metadata: { title } });
 
@@ -311,6 +348,16 @@ import Portal from '../layouts/Portal.astro';
         ${esc(topic.title)}
       </div>`;
 
+    // Fetch attached poll
+    const session = getSession();
+    const memberId = session?.user?.member?.id ?? null;
+    let topicPollData: any = null;
+    if (isFeatureEnabled('feature_polls')) {
+      try {
+        topicPollData = await fetchAttachedPoll('forum_topic', parseInt(topicId), session);
+      } catch {}
+    }
+
     // Topic post
     const hiddenLabel = topic.hidden ? ' hidden-post' : '';
     html += `
@@ -327,6 +374,7 @@ import Portal from '../layouts/Portal.astro';
           </div>
         </div>
         <div class="forum-post-body" data-translate-text="${esc(topic.body)}" data-ct="forum_topic" data-ci="${topic.id}" data-cf="body">${esc(topic.body)}</div>
+        ${topicPollData ? `<div data-topic-poll="${topicId}">${topicPollData.html}</div>` : ''}
         ${admin ? buildTopicAdminBar(topic) : ''}
       </div>`;
 
@@ -367,6 +415,14 @@ import Portal from '../layouts/Portal.astro';
     }
 
     root.innerHTML = html;
+
+    // Bind poll vote listeners
+    if (topicPollData) {
+      const pollContainer = root.querySelector(`[data-topic-poll="${topicId}"]`) as HTMLElement;
+      if (pollContainer) {
+        bindPollVoteListeners(pollContainer, topicPollData.poll, topicPollData.votes, memberId, () => renderTopicView(root, topicId));
+      }
+    }
 
     // Add translate buttons
     root.querySelectorAll('.forum-post-body[data-translate-text]').forEach((el) => {
@@ -459,6 +515,7 @@ import Portal from '../layouts/Portal.astro';
             await patch(`forum_topics?id=eq.${id}`, { hidden: !topic.hidden });
           } else if (action === 'delete') {
             if (!confirm('Delete this topic and all its replies?')) return;
+            try { await del(`polls?attached_to=eq.forum_topic&attached_id=eq.${id}`); } catch {}
             await del(`forum_replies?topic_id=eq.${id}`);
             await del(`forum_topics?id=eq.${id}`);
             const { navigate } = await import('astro:transitions/client');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,7 @@ import Portal from '../layouts/Portal.astro';
   import { getSession, isAdmin } from '../lib/auth';
   import { isFeatureEnabled, getTranslatedContent, translateItems, cacheHeroImage } from '../lib/config';
   import { getLocale } from '../lib/i18n';
+  import { bindPollVoteListeners, createPollForm, submitPoll, fetchAttachedPoll, fetchAndRenderPoll } from '../lib/poll-ui';
 
   function esc(s: string): string {
     const d = document.createElement('div');
@@ -65,7 +66,7 @@ import Portal from '../layouts/Portal.astro';
       container.style.minHeight = container.offsetHeight + 'px';
       document.getElementById('sections-skeleton')?.remove();
       for (const section of sections) {
-        container.appendChild(renderSection(section));
+        container.appendChild(await renderSection(section));
       }
       container.style.minHeight = '';
     } catch (e) {
@@ -75,7 +76,7 @@ import Portal from '../layouts/Portal.astro';
     }
   }
 
-  function renderSection(section: any): HTMLElement {
+  async function renderSection(section: any): Promise<HTMLElement> {
     const cfg = section.config;
     const el = document.createElement('section');
 
@@ -112,6 +113,37 @@ import Portal from '../layouts/Portal.astro';
         el.className = 'section';
         el.innerHTML = `<div class="container"><h2 class="mb-2">FAQ</h2>${(cfg.items || []).map((f: any) => `<details class="card mb-1" style="cursor:pointer"><summary style="font-weight:600">${esc(f.q || '')}</summary><p class="text-muted mt-1">${esc(f.a || '')}</p></details>`).join('')}</div>`;
         break;
+
+      case 'polls': {
+        if (!isFeatureEnabled('feature_polls')) break;
+        el.className = 'section section-polls';
+        const pollIds: number[] = cfg.poll_ids || [];
+        const session = getSession();
+        const memberId = session?.user?.member?.id ?? null;
+        let pollsHtml = '';
+        for (const pid of pollIds) {
+          try {
+            const result = await fetchAndRenderPoll(pid, session);
+            pollsHtml += `<div class="card mb-1" data-section-poll="${pid}">${result.html}</div>`;
+          } catch {}
+        }
+        el.innerHTML = `<div class="container">${cfg.heading ? `<h2 class="mb-2">${esc(cfg.heading)}</h2>` : ''}${pollsHtml || '<p class="text-muted">No polls to display.</p>'}</div>`;
+        // Bind vote listeners after inserting into DOM
+        requestAnimationFrame(() => {
+          for (const pid of pollIds) {
+            const container = el.querySelector(`[data-section-poll="${pid}"]`) as HTMLElement;
+            if (!container) continue;
+            // Re-fetch to get fresh data for binding
+            (async () => {
+              try {
+                const result = await fetchAndRenderPoll(pid, session);
+                bindPollVoteListeners(container, result.poll, result.votes, memberId, () => renderSections());
+              } catch {}
+            })();
+          }
+        });
+        break;
+      }
 
       default:
         el.className = 'section';
@@ -154,13 +186,41 @@ import Portal from '../layouts/Portal.astro';
       await translateItems('announcement', items, ['title', 'body']);
       if (items.length === 0) { feed.innerHTML = '<p class="text-muted">No announcements yet.</p>'; return; }
       feed.style.minHeight = feed.offsetHeight + 'px';
-      feed.innerHTML = items.map((a: any) => `
+      const session = getSession();
+      const memberId = session?.user?.member?.id ?? null;
+      const pollsEnabled = isFeatureEnabled('feature_polls');
+
+      // Fetch attached polls for all announcements
+      const attachedPolls: Record<number, any> = {};
+      if (pollsEnabled) {
+        for (const a of items) {
+          try {
+            const result = await fetchAttachedPoll('announcement', a.id, session);
+            if (result) attachedPolls[a.id] = result;
+          } catch {}
+        }
+      }
+
+      feed.innerHTML = items.map((a: any) => {
+        const pollHtml = attachedPolls[a.id] ? `<div data-ann-poll="${a.id}">${attachedPolls[a.id].html}</div>` : '';
+        return `
         <div class="announcement card mb-1 ${a.is_pinned ? 'pinned' : ''}" data-id="${a.id}">
           <div class="announcement-title" data-editable="announcements.${a.id}.title">${esc(a.title)}</div>
           <div class="announcement-body" data-editable-rich="announcements.${a.id}.body">${a.body}</div>
+          ${pollHtml}
           <div class="announcement-meta">${a.is_pinned ? '<span class="badge badge-primary">Pinned</span> ' : ''}<span>${formatDate(a.created_at)}</span></div>
           ${isAdmin() ? `<div class="mt-1 flex gap-1"><button class="btn btn-sm btn-secondary ann-pin" data-id="${a.id}" data-pinned="${a.is_pinned}">${a.is_pinned ? 'Unpin' : 'Pin'}</button><button class="btn btn-sm btn-danger ann-delete" data-id="${a.id}">Delete</button></div>` : ''}
-        </div>`).join('');
+        </div>`;
+      }).join('');
+
+      // Bind poll vote listeners
+      for (const [annId, pollData] of Object.entries(attachedPolls)) {
+        const container = feed.querySelector(`[data-ann-poll="${annId}"]`) as HTMLElement;
+        if (container) {
+          bindPollVoteListeners(container, (pollData as any).poll, (pollData as any).votes, memberId, () => renderAnnouncements());
+        }
+      }
+
       feed.querySelectorAll('.ann-pin').forEach((btn) => {
         btn.addEventListener('click', async () => {
           const el = btn as HTMLElement;
@@ -170,7 +230,10 @@ import Portal from '../layouts/Portal.astro';
       });
       feed.querySelectorAll('.ann-delete').forEach((btn) => {
         btn.addEventListener('click', async () => {
-          await del(`announcements?id=eq.${(btn as HTMLElement).dataset.id}`);
+          const annId = (btn as HTMLElement).dataset.id!;
+          // Delete attached poll if any
+          try { await del(`polls?attached_to=eq.announcement&attached_id=eq.${annId}`); } catch {}
+          await del(`announcements?id=eq.${annId}`);
           renderAnnouncements();
         });
       });
@@ -179,21 +242,63 @@ import Portal from '../layouts/Portal.astro';
   }
 
   // --- Admin: announcement creation ---
+  let annPollFormRef: ReturnType<typeof createPollForm> | null = null;
+
   function setupAnnouncementCreate() {
     if (!isAdmin()) return;
     const container = document.getElementById('announcement-create');
     if (!container) return;
     container.classList.remove('hidden');
-    container.innerHTML = `<div class="card"><h4 class="mb-1">New Announcement</h4><div class="form-group"><input class="form-input" id="ann-title" placeholder="Title"></div><div class="form-group"><textarea class="form-textarea" id="ann-body" placeholder="Write your announcement..."></textarea></div><button class="btn btn-primary" id="ann-post">Post</button></div>`;
+    const pollsEnabled = isFeatureEnabled('feature_polls');
+    container.innerHTML = `<div class="card"><h4 class="mb-1">New Announcement</h4><div class="form-group"><input class="form-input" id="ann-title" placeholder="Title"></div><div class="form-group"><textarea class="form-textarea" id="ann-body" placeholder="Write your announcement..."></textarea></div>${pollsEnabled ? '<div id="ann-poll-form-container"></div><button class="btn btn-sm btn-secondary mb-1" id="ann-add-poll" type="button">+ Add Poll</button>' : ''}<button class="btn btn-primary" id="ann-post">Post</button></div>`;
+
+    // Add poll button
+    if (pollsEnabled) {
+      document.getElementById('ann-add-poll')?.addEventListener('click', () => {
+        const formContainer = document.getElementById('ann-poll-form-container')!;
+        if (annPollFormRef) return; // already open
+        annPollFormRef = createPollForm(formContainer, { type: 'announcement', id: null });
+        document.getElementById('ann-add-poll')!.classList.add('hidden');
+        // Watch for form removal (user clicks X)
+        const observer = new MutationObserver(() => {
+          if (formContainer.innerHTML === '') {
+            annPollFormRef = null;
+            document.getElementById('ann-add-poll')?.classList.remove('hidden');
+            observer.disconnect();
+          }
+        });
+        observer.observe(formContainer, { childList: true });
+      });
+    }
+
     document.getElementById('ann-post')?.addEventListener('click', async () => {
       const title = (document.getElementById('ann-title') as HTMLInputElement).value.trim();
       const body = (document.getElementById('ann-body') as HTMLTextAreaElement).value.trim();
       if (!title || !body) return;
       const session = getSession();
       const memberId = session?.user?.member?.id;
-      await post('announcements', { title, body, author_id: memberId });
+      if (!memberId) return;
+
+      const [created] = await post('announcements', { title, body, author_id: memberId });
+
+      // Create attached poll if form is filled
+      if (annPollFormRef) {
+        const pollData = annPollFormRef.getPollData();
+        if (pollData) {
+          try {
+            await submitPoll(pollData, memberId, { type: 'announcement', id: created.id });
+          } catch (e) {
+            console.error('Failed to create attached poll:', e);
+          }
+        }
+        annPollFormRef = null;
+      }
+
       (document.getElementById('ann-title') as HTMLInputElement).value = '';
       (document.getElementById('ann-body') as HTMLTextAreaElement).value = '';
+      const formContainer = document.getElementById('ann-poll-form-container');
+      if (formContainer) formContainer.innerHTML = '';
+      document.getElementById('ann-add-poll')?.classList.remove('hidden');
       renderAnnouncements();
     });
   }

--- a/src/pages/polls.astro
+++ b/src/pages/polls.astro
@@ -1,0 +1,168 @@
+---
+import Portal from '../layouts/Portal.astro';
+---
+<Portal title="Polls">
+  <div class="container">
+    <h2 class="mb-2">Polls</h2>
+    <div id="poll-create" class="hidden mb-2"></div>
+    <div id="polls-list">
+      <div class="card mb-1"><div class="skeleton skeleton-heading"></div><div class="skeleton skeleton-text"></div></div>
+    </div>
+  </div>
+</Portal>
+
+<script>
+  import { del, get } from '../lib/api';
+  import { getSession, isAdmin, isAuthenticated } from '../lib/auth';
+  import { isFeatureEnabled, getConfig } from '../lib/config';
+  import {
+    renderPoll,
+    bindPollVoteListeners,
+    createPollForm,
+    submitPoll,
+    checkAutoClose,
+  } from '../lib/poll-ui';
+
+  let pollFormRef: ReturnType<typeof createPollForm> | null = null;
+
+  async function renderPollsList() {
+    const listEl = document.getElementById('polls-list');
+    if (!listEl) return;
+
+    try {
+      // Fetch standalone polls only (not attached)
+      const polls = await get('polls?attached_to=is.null&order=is_open.desc,created_at.desc');
+      if (polls.length === 0) {
+        listEl.innerHTML = '<p class="text-muted">No polls yet.</p>';
+        return;
+      }
+
+      const session = getSession();
+      const memberId = session?.user?.member?.id ?? null;
+
+      // Fetch options and votes for all polls
+      let html = '';
+      for (const poll of polls) {
+        await checkAutoClose(poll);
+        const options = await get(`poll_options?poll_id=eq.${poll.id}&order=position.asc`);
+        const votes = await get(`poll_votes?poll_id=eq.${poll.id}`);
+        const admin = isAdmin();
+
+        html += `<div class="card mb-1" data-poll-container="${poll.id}">`;
+        html += renderPoll(poll, options, votes, session);
+        if (admin) {
+          html += `<div class="mt-1 flex gap-1">`;
+          html += `<button class="btn btn-sm btn-secondary poll-toggle-close" data-poll-id="${poll.id}" data-is-open="${poll.is_open}">${poll.is_open ? 'Close Poll' : 'Reopen Poll'}</button>`;
+          html += `<button class="btn btn-sm btn-danger poll-delete" data-poll-id="${poll.id}">Delete</button>`;
+          html += `</div>`;
+        }
+        html += `</div>`;
+      }
+
+      listEl.innerHTML = html;
+
+      // Bind vote listeners for each poll
+      for (const poll of polls) {
+        const container = listEl.querySelector(`[data-poll-container="${poll.id}"]`) as HTMLElement;
+        if (!container) continue;
+        const pollVotes = await get(`poll_votes?poll_id=eq.${poll.id}`);
+        bindPollVoteListeners(container, poll, pollVotes, memberId, () => renderPollsList());
+      }
+
+      // Bind admin actions
+      listEl.querySelectorAll('.poll-toggle-close').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          const el = btn as HTMLElement;
+          const pollId = el.dataset.pollId!;
+          const isOpen = el.dataset.isOpen === 'true';
+          const { patch } = await import('../lib/api');
+          await patch(`polls?id=eq.${pollId}`, { is_open: !isOpen });
+          renderPollsList();
+        });
+      });
+
+      listEl.querySelectorAll('.poll-delete').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          if (!confirm('Delete this poll and all its votes?')) return;
+          const pollId = (btn as HTMLElement).dataset.pollId!;
+          await del(`polls?id=eq.${pollId}`);
+          renderPollsList();
+        });
+      });
+    } catch (e) {
+      console.error('Failed to load polls:', e);
+      listEl.innerHTML = '<p class="text-muted">Could not load polls.</p>';
+    }
+  }
+
+  function setupPollCreate() {
+    const canCreate = isAdmin() || getConfig('polls_member_create') === true;
+    if (!canCreate || !isAuthenticated()) return;
+
+    const container = document.getElementById('poll-create');
+    if (!container) return;
+    container.classList.remove('hidden');
+
+    // Show a "Create Poll" button that expands the form
+    container.innerHTML = '<button class="btn btn-primary" id="poll-create-toggle">Create Poll</button><div id="poll-form-container" class="hidden"></div>';
+
+    document.getElementById('poll-create-toggle')?.addEventListener('click', () => {
+      const formContainer = document.getElementById('poll-form-container')!;
+      const toggleBtn = document.getElementById('poll-create-toggle')!;
+
+      if (formContainer.classList.contains('hidden')) {
+        formContainer.classList.remove('hidden');
+        toggleBtn.classList.add('hidden');
+        pollFormRef = createPollForm(formContainer);
+
+        // Add submit button
+        const submitBtn = document.createElement('button');
+        submitBtn.className = 'btn btn-primary mt-1';
+        submitBtn.textContent = 'Create Poll';
+        submitBtn.addEventListener('click', async () => {
+          if (!pollFormRef) return;
+          const data = pollFormRef.getPollData();
+          if (!data) {
+            alert('Please fill in the question and at least 2 options.');
+            return;
+          }
+          const session = getSession();
+          const memberId = session?.user?.member?.id;
+          if (!memberId) return;
+
+          submitBtn.disabled = true;
+          submitBtn.textContent = 'Creating...';
+          try {
+            await submitPoll(data, memberId);
+            pollFormRef.remove();
+            pollFormRef = null;
+            formContainer.classList.add('hidden');
+            formContainer.innerHTML = '';
+            toggleBtn.classList.remove('hidden');
+            renderPollsList();
+          } catch (e) {
+            console.error('Failed to create poll:', e);
+            alert('Failed to create poll. Please try again.');
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Create Poll';
+          }
+        });
+        formContainer.appendChild(submitBtn);
+      }
+    });
+  }
+
+  async function initPolls() {
+    if (!isFeatureEnabled('feature_polls')) {
+      const listEl = document.getElementById('polls-list');
+      if (listEl) listEl.innerHTML = '';
+      return;
+    }
+    await renderPollsList();
+    setupPollCreate();
+  }
+
+  initPolls();
+  document.addEventListener('astro:after-swap', initPolls);
+  document.addEventListener('wl-auth-changed', initPolls);
+</script>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -4,3 +4,4 @@ export * from './event';
 export * from './forum';
 export * from './content';
 export * from './committee';
+export * from './poll';

--- a/src/schemas/poll.ts
+++ b/src/schemas/poll.ts
@@ -1,0 +1,35 @@
+import { z } from 'astro/zod';
+
+export const PollSchema = z.object({
+  id: z.number(),
+  question: z.string(),
+  description: z.string().nullable(),
+  poll_type: z.string(),
+  is_anonymous: z.boolean(),
+  results_visible: z.string(),
+  is_open: z.boolean(),
+  closes_at: z.string().nullable(),
+  attached_to: z.string().nullable(),
+  attached_id: z.number().nullable(),
+  created_by: z.number().nullable(),
+  created_at: z.string(),
+});
+
+export const PollOptionSchema = z.object({
+  id: z.number(),
+  poll_id: z.number(),
+  label: z.string(),
+  position: z.number(),
+});
+
+export const PollVoteSchema = z.object({
+  id: z.number(),
+  poll_id: z.number(),
+  option_id: z.number(),
+  member_id: z.number().nullable(),
+  created_at: z.string(),
+});
+
+export type Poll = z.infer<typeof PollSchema>;
+export type PollOption = z.infer<typeof PollOptionSchema>;
+export type PollVote = z.infer<typeof PollVoteSchema>;

--- a/tests/unit/polls.test.js
+++ b/tests/unit/polls.test.js
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+
+// renderPoll uses document.createElement for XSS escaping, needs DOM environment
+const { renderPoll } = await import('../../src/lib/poll-ui.ts');
+
+const basePoll = {
+  id: 1,
+  question: 'What should our next event be?',
+  description: null,
+  poll_type: 'single',
+  is_anonymous: false,
+  results_visible: 'after_vote',
+  is_open: true,
+  closes_at: null,
+  created_by: 1,
+  created_at: '2026-04-01T00:00:00Z',
+};
+
+const baseOptions = [
+  { id: 10, poll_id: 1, label: 'Workshop', position: 0 },
+  { id: 11, poll_id: 1, label: 'Social', position: 1 },
+  { id: 12, poll_id: 1, label: 'Talk', position: 2 },
+];
+
+describe('renderPoll', () => {
+  describe('results_visible = always', () => {
+    const poll = { ...basePoll, results_visible: 'always' };
+
+    it('shows bars and counts for unauthenticated users', () => {
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 2 },
+        { id: 2, poll_id: 1, option_id: 10, member_id: 3 },
+        { id: 3, poll_id: 1, option_id: 11, member_id: 4 },
+      ];
+      const html = renderPoll(poll, baseOptions, votes, null);
+      expect(html).toContain('poll-bar-fill');
+      expect(html).toContain('67%');
+      expect(html).toContain('33%');
+      expect(html).toContain('3 votes');
+    });
+
+    it('highlights user vote when authenticated', () => {
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
+      ];
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(poll, baseOptions, votes, session);
+      expect(html).toContain('poll-option-voted');
+      expect(html).toContain('\u2713');
+    });
+  });
+
+  describe('results_visible = after_vote', () => {
+    const poll = { ...basePoll, results_visible: 'after_vote' };
+
+    it('shows vote buttons before voting', () => {
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(poll, baseOptions, [], session);
+      expect(html).toContain('poll-vote-btn');
+      expect(html).not.toContain('poll-bar-fill');
+      expect(html).toContain('0 votes');
+    });
+
+    it('shows results after voting', () => {
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
+        { id: 2, poll_id: 1, option_id: 11, member_id: 5 },
+      ];
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(poll, baseOptions, votes, session);
+      expect(html).toContain('poll-bar-fill');
+      expect(html).toContain('50%');
+      expect(html).toContain('poll-option-voted');
+    });
+
+    it('shows readonly options for unauthenticated', () => {
+      const html = renderPoll(poll, baseOptions, [], null);
+      expect(html).toContain('poll-option-readonly');
+      expect(html).not.toContain('poll-vote-btn');
+    });
+  });
+
+  describe('results_visible = after_close', () => {
+    const poll = { ...basePoll, results_visible: 'after_close' };
+
+    it('hides results while open even after voting', () => {
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
+      ];
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(poll, baseOptions, votes, session);
+      expect(html).not.toContain('poll-bar-fill');
+      expect(html).toContain('Results after close');
+    });
+
+    it('shows results when closed', () => {
+      const closedPoll = { ...poll, is_open: false };
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
+      ];
+      const html = renderPoll(closedPoll, baseOptions, votes, null);
+      expect(html).toContain('poll-bar-fill');
+      expect(html).toContain('Closed');
+    });
+  });
+
+  describe('closed poll', () => {
+    it('does not show vote buttons', () => {
+      const closedPoll = { ...basePoll, is_open: false };
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(closedPoll, baseOptions, [], session);
+      expect(html).not.toContain('poll-vote-btn');
+      expect(html).toContain('poll-closed');
+      expect(html).toContain('Closed');
+    });
+  });
+
+  describe('anonymous poll', () => {
+    it('shows Anonymous label in meta', () => {
+      const anonPoll = { ...basePoll, is_anonymous: true, results_visible: 'always' };
+      const html = renderPoll(anonPoll, baseOptions, [], null);
+      expect(html).toContain('Anonymous');
+    });
+  });
+
+  describe('multiple choice poll', () => {
+    it('shows checkbox indicators', () => {
+      const multiPoll = { ...basePoll, poll_type: 'multiple' };
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(multiPoll, baseOptions, [], session);
+      expect(html).toContain('\u2610');
+      expect(html).toContain('Select multiple');
+    });
+
+    it('shows checked indicator for voted options', () => {
+      const multiPoll = { ...basePoll, poll_type: 'multiple' };
+      const votes = [
+        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
+      ];
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(multiPoll, baseOptions, votes, session);
+      // after_vote shows results since member voted
+      expect(html).toContain('poll-bar-fill');
+    });
+  });
+
+  describe('poll with closes_at', () => {
+    it('shows closes date for open poll', () => {
+      const poll = { ...basePoll, closes_at: '2026-12-31T23:59:59Z' };
+      const html = renderPoll(poll, baseOptions, [], null);
+      expect(html).toContain('Closes');
+    });
+
+    it('treats expired closes_at as closed', () => {
+      const poll = { ...basePoll, closes_at: '2020-01-01T00:00:00Z' };
+      const session = { user: { member: { id: 42 } } };
+      const html = renderPoll(poll, baseOptions, [], session);
+      expect(html).toContain('poll-closed');
+      expect(html).not.toContain('poll-vote-btn');
+    });
+  });
+
+  describe('question and description', () => {
+    it('renders question', () => {
+      const html = renderPoll(basePoll, baseOptions, [], null);
+      expect(html).toContain('What should our next event be?');
+    });
+
+    it('renders description when present', () => {
+      const poll = { ...basePoll, description: 'Choose wisely' };
+      const html = renderPoll(poll, baseOptions, [], null);
+      expect(html).toContain('Choose wisely');
+      expect(html).toContain('poll-description');
+    });
+
+    it('omits description when null', () => {
+      const html = renderPoll(basePoll, baseOptions, [], null);
+      expect(html).not.toContain('poll-description');
+    });
+  });
+});

--- a/tests/unit/polls.test.js
+++ b/tests/unit/polls.test.js
@@ -41,9 +41,7 @@ describe('renderPoll', () => {
     });
 
     it('highlights user vote when authenticated', () => {
-      const votes = [
-        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
-      ];
+      const votes = [{ id: 1, poll_id: 1, option_id: 10, member_id: 42 }];
       const session = { user: { member: { id: 42 } } };
       const html = renderPoll(poll, baseOptions, votes, session);
       expect(html).toContain('poll-option-voted');
@@ -85,9 +83,7 @@ describe('renderPoll', () => {
     const poll = { ...basePoll, results_visible: 'after_close' };
 
     it('hides results while open even after voting', () => {
-      const votes = [
-        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
-      ];
+      const votes = [{ id: 1, poll_id: 1, option_id: 10, member_id: 42 }];
       const session = { user: { member: { id: 42 } } };
       const html = renderPoll(poll, baseOptions, votes, session);
       expect(html).not.toContain('poll-bar-fill');
@@ -96,9 +92,7 @@ describe('renderPoll', () => {
 
     it('shows results when closed', () => {
       const closedPoll = { ...poll, is_open: false };
-      const votes = [
-        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
-      ];
+      const votes = [{ id: 1, poll_id: 1, option_id: 10, member_id: 42 }];
       const html = renderPoll(closedPoll, baseOptions, votes, null);
       expect(html).toContain('poll-bar-fill');
       expect(html).toContain('Closed');
@@ -135,9 +129,7 @@ describe('renderPoll', () => {
 
     it('shows checked indicator for voted options', () => {
       const multiPoll = { ...basePoll, poll_type: 'multiple' };
-      const votes = [
-        { id: 1, poll_id: 1, option_id: 10, member_id: 42 },
-      ];
+      const votes = [{ id: 1, poll_id: 1, option_id: 10, member_id: 42 }];
       const session = { user: { member: { id: 42 } } };
       const html = renderPoll(multiPoll, baseOptions, votes, session);
       // after_vote shows results since member voted

--- a/tests/unit/schemas.test.js
+++ b/tests/unit/schemas.test.js
@@ -6,6 +6,7 @@ const { SiteConfigRowSchema, NavItemSchema } = await import('../../src/schemas/c
 const { AnnouncementSchema, ResourceSchema, PageSchema, ReactionSchema } = await import('../../src/schemas/content.ts');
 const { ForumCategorySchema, ForumTopicSchema } = await import('../../src/schemas/forum.ts');
 const { CommitteeSchema, CommitteeMemberSchema } = await import('../../src/schemas/committee.ts');
+const { PollSchema, PollOptionSchema, PollVoteSchema } = await import('../../src/schemas/poll.ts');
 
 describe('Zod schemas', () => {
   describe('EventSchema', () => {
@@ -253,6 +254,72 @@ describe('Zod schemas', () => {
           created_at: '2026-04-01T00:00:00Z',
         }),
       ).toBeTruthy();
+    });
+  });
+
+  describe('PollSchema', () => {
+    const validPoll = {
+      id: 1,
+      question: 'What should our next event be?',
+      description: 'Vote for your preference',
+      poll_type: 'single',
+      is_anonymous: false,
+      results_visible: 'after_vote',
+      is_open: true,
+      closes_at: null,
+      attached_to: null,
+      attached_id: null,
+      created_by: 1,
+      created_at: '2026-04-01T00:00:00Z',
+    };
+
+    it('parses valid poll', () => {
+      expect(PollSchema.parse(validPoll)).toEqual(validPoll);
+    });
+
+    it('rejects poll missing question', () => {
+      const { question, ...noQuestion } = validPoll;
+      expect(() => PollSchema.parse(noQuestion)).toThrow();
+    });
+
+    it('accepts nullable fields as null', () => {
+      const poll = {
+        ...validPoll,
+        description: null,
+        closes_at: null,
+        attached_to: null,
+        attached_id: null,
+        created_by: null,
+      };
+      expect(PollSchema.parse(poll)).toBeTruthy();
+    });
+
+    it('parses attached poll', () => {
+      const poll = { ...validPoll, attached_to: 'announcement', attached_id: 5 };
+      expect(PollSchema.parse(poll)).toEqual(poll);
+    });
+  });
+
+  describe('PollOptionSchema', () => {
+    it('parses valid option', () => {
+      const option = { id: 1, poll_id: 1, label: 'Workshop', position: 0 };
+      expect(PollOptionSchema.parse(option)).toEqual(option);
+    });
+
+    it('rejects option missing label', () => {
+      expect(() => PollOptionSchema.parse({ id: 1, poll_id: 1, position: 0 })).toThrow();
+    });
+  });
+
+  describe('PollVoteSchema', () => {
+    it('parses valid vote', () => {
+      const vote = { id: 1, poll_id: 1, option_id: 2, member_id: 3, created_at: '2026-04-01T00:00:00Z' };
+      expect(PollVoteSchema.parse(vote)).toEqual(vote);
+    });
+
+    it('accepts nullable member_id', () => {
+      const vote = { id: 1, poll_id: 1, option_id: 2, member_id: null, created_at: '2026-04-01T00:00:00Z' };
+      expect(PollVoteSchema.parse(vote)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds polls as standalone entities that can be embedded in announcements, forum topics, and homepage sections
- Configurable per-poll: results visibility (always/after vote/after close), anonymous voting, single/multiple choice, auto-close on expiry
- Shared `poll-ui.ts` module with `renderPoll()` reused across all surfaces; inline creation forms in announcement and forum editors
- 3 new tables (`polls`, `poll_options`, `poll_votes`), feature-flagged via `feature_polls` + `polls_member_create`

## Test plan
- [x] 16 new unit tests for poll schemas and renderPoll() across all visibility/state combinations
- [x] Full test suite: 268 tests passing (26 files)
- [x] Astro type check: 0 errors
- [ ] Deploy and verify polls page in Chrome MCP
- [ ] Create poll from announcement editor, verify attachment
- [ ] Test vote flow: single-choice replace, multi-choice toggle
- [ ] Verify feature flag disables all poll UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)