### PR TITLE
Replace technical jargon with plain language across marketing site

### DIFF
--- a/marketing/about.html
+++ b/marketing/about.html
@@ -36,21 +36,21 @@
       <p class="t-body--lg" style="margin-bottom:3rem">The company behind Wild Lychee.</p>
 
       <h2>Who we are</h2>
-      <p>Wild Lychee is built and maintained by <strong>Kychee, Inc.</strong>, an AI-first software company. We build tools that let AI agents ship real software to real users - removing the friction between what agents can build and what actually gets deployed.</p>
+      <p>Wild Lychee is built and maintained by <strong>Kychee, Inc.</strong>, an AI-first software company. We build tools that let AI agents ship real software to real users - removing the friction between what agents can build and what actually goes live.</p>
 
       <h2>What is Wild Lychee?</h2>
       <p>Wild Lychee is an open-source community portal template. It gives associations, clubs, churches, HOAs, and sports leagues a complete member portal - directory, events, forum, announcements, resources - on software they own, for a flat monthly hosting fee.</p>
-      <p>There are no per-member fees, no vendor lock-in, and no proprietary black boxes. Every line of code is yours to fork, modify, and deploy on your own domain.</p>
+      <p>There are no per-member fees, no vendor lock-in, and no proprietary black boxes. Every line of code is yours to copy, customize, and run on your own domain.</p>
 
       <h2>How it works</h2>
-      <p>Wild Lychee runs on <a href="https://run402.com" target="_blank">Run402</a>, a serverless infrastructure platform also built by Kychee. Run402 provides the database, authentication, file storage, and hosting. Wild Lychee provides the portal template, AI features, and the Studio build experience.</p>
+      <p>Wild Lychee runs on <a href="https://run402.com" target="_blank">Run402</a>, a cloud platform also built by Kychee. Run402 provides the database, authentication, file storage, and hosting. Wild Lychee provides the portal template, AI features, and the Studio build experience.</p>
 
       <h2>Our approach</h2>
       <p>We believe community software should be affordable, transparent, and owned by the people who use it. Most membership platforms charge per-member fees that punish growth. We charge a flat $5-20/mo for hosting - whether you have 50 members or 5,000.</p>
       <p>We also believe AI should do the heavy lifting. Lychee Studio can investigate your existing website, ask a few questions, and generate a fully customized portal in minutes - not weeks.</p>
 
       <h2>Open source</h2>
-      <p>Wild Lychee is fully open source on <a href="https://github.com/kychee-com/wildlychee" target="_blank">GitHub</a>. You can fork it, read every line of code, and deploy it yourself. Studio and Pro are paid services that make the experience easier, but the core template is free forever.</p>
+      <p>Wild Lychee is fully open source on <a href="https://github.com/kychee-com/wildlychee" target="_blank">GitHub</a>. You can copy it, read every line of code, and set it up yourself. Studio and Pro are paid services that make the experience easier, but the core template is free forever.</p>
 
       <h2>Contact</h2>
       <p>Email: <a href="mailto:info@kychee.com">info@kychee.com</a></p>

--- a/marketing/associations.html
+++ b/marketing/associations.html
@@ -39,7 +39,7 @@
       </p>
       <div class="hero__ctas">
         <a href="#demo-placeholder" class="btn btn--primary btn--lg">Build Your Association Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Get the Template</a>
       </div>
     </div>
     <div class="hero__aside" aria-hidden="true"></div>
@@ -106,10 +106,10 @@
           <ul class="plan-card__features">
             <li>Full source code (open source)</li>
             <li>All features included</li>
-            <li>Self-deploy to Run402</li>
+            <li>Self-setup on Run402</li>
             <li>Community support</li>
           </ul>
-          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Fork on GitHub</a>
+          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Get the Template</a>
         </div>
 
         <div class="plan-card plan-card--featured">
@@ -122,7 +122,7 @@
             <li>Guided interview &rarr; custom portal</li>
             <li>Brand colors, logo, content migrated</li>
             <li>Multi-language translation</li>
-            <li>Chrome-verified deployment</li>
+            <li>AI-verified before launch</li>
           </ul>
           <a href="#demo-placeholder" class="btn btn--primary">Build My Portal &rarr;</a>
         </div>
@@ -151,7 +151,7 @@
       <p class="t-body--lg">Open source. Flat pricing. AI-powered. Yours forever.</p>
       <div class="final-cta__buttons">
         <a href="#demo-placeholder" class="btn btn--white btn--lg">Build Your Association Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Get the Template</a>
       </div>
     </div>
   </section>

--- a/marketing/churches.html
+++ b/marketing/churches.html
@@ -39,7 +39,7 @@
       </p>
       <div class="hero__ctas">
         <a href="#demo-placeholder" class="btn btn--primary btn--lg">Build Your Church Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Get the Template</a>
       </div>
     </div>
     <div class="hero__aside" aria-hidden="true"></div>
@@ -106,10 +106,10 @@
           <ul class="plan-card__features">
             <li>Full source code (open source)</li>
             <li>All features included</li>
-            <li>Self-deploy to Run402</li>
+            <li>Self-setup on Run402</li>
             <li>Community support</li>
           </ul>
-          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Fork on GitHub</a>
+          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Get the Template</a>
         </div>
 
         <div class="plan-card plan-card--featured">
@@ -122,7 +122,7 @@
             <li>Guided interview &rarr; custom portal</li>
             <li>Brand colors, logo, content migrated</li>
             <li>Multi-language translation</li>
-            <li>Chrome-verified deployment</li>
+            <li>AI-verified before launch</li>
           </ul>
           <a href="#demo-placeholder" class="btn btn--primary">Build My Portal &rarr;</a>
         </div>
@@ -151,7 +151,7 @@
       <p class="t-body--lg">Open source. Flat pricing. AI-powered. Yours forever.</p>
       <div class="final-cta__buttons">
         <a href="#demo-placeholder" class="btn btn--white btn--lg">Build Your Church Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Get the Template</a>
       </div>
     </div>
   </section>

--- a/marketing/hoa.html
+++ b/marketing/hoa.html
@@ -39,7 +39,7 @@
       </p>
       <div class="hero__ctas">
         <a href="#demo-placeholder" class="btn btn--primary btn--lg">Build Your HOA Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Get the Template</a>
       </div>
     </div>
     <div class="hero__aside" aria-hidden="true"></div>
@@ -106,10 +106,10 @@
           <ul class="plan-card__features">
             <li>Full source code (open source)</li>
             <li>All features included</li>
-            <li>Self-deploy to Run402</li>
+            <li>Self-setup on Run402</li>
             <li>Community support</li>
           </ul>
-          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Fork on GitHub</a>
+          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Get the Template</a>
         </div>
 
         <div class="plan-card plan-card--featured">
@@ -122,7 +122,7 @@
             <li>Guided interview &rarr; custom portal</li>
             <li>Brand colors, logo, content migrated</li>
             <li>Multi-language translation</li>
-            <li>Chrome-verified deployment</li>
+            <li>AI-verified before launch</li>
           </ul>
           <a href="#demo-placeholder" class="btn btn--primary">Build My Portal &rarr;</a>
         </div>
@@ -151,7 +151,7 @@
       <p class="t-body--lg">Open source. Flat pricing. AI-powered. Yours forever.</p>
       <div class="final-cta__buttons">
         <a href="#demo-placeholder" class="btn btn--white btn--lg">Build Your HOA Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Get the Template</a>
       </div>
     </div>
   </section>

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -84,7 +84,7 @@
       <div class="section-header section-header--center">
         <p class="t-overline">See It In Action</p>
         <h2 class="t-display t-display--lg">Real communities. Running right now.</h2>
-        <p class="t-body--lg mt-2" style="margin-left:auto;margin-right:auto;">Three live demo sites &mdash; each built and deployed in minutes. Browse them, no signup required.</p>
+        <p class="t-body--lg mt-2" style="margin-left:auto;margin-right:auto;">Three live demo sites &mdash; each built and launched in minutes. Browse them, no signup required.</p>
       </div>
 
       <div class="demos-grid">
@@ -171,12 +171,12 @@
         <div class="benefit-card">
           <div class="benefit-card__icon">&#128274;</div>
           <div class="benefit-card__title">You own everything</div>
-          <div class="benefit-card__desc">Your data, your branding, your domain. Open source &mdash; fork it, modify it, it's yours. No lock-in, no export fees, no surprises.</div>
+          <div class="benefit-card__desc">Your data, your branding, your domain. Open source &mdash; copy it, customize it, it's yours. No lock-in, no export fees, no surprises.</div>
         </div>
         <div class="benefit-card">
           <div class="benefit-card__icon">&#129302;</div>
           <div class="benefit-card__title">AI does the work</div>
-          <div class="benefit-card__desc">Studio builds your portal in 5 minutes. Pro keeps it evolving with ongoing AI customization. Or customize it yourself &mdash; it's just HTML and SQL.</div>
+          <div class="benefit-card__desc">Studio builds your portal in 5 minutes. Pro keeps it evolving with ongoing AI customization. Or customize it yourself &mdash; it's straightforward to change.</div>
         </div>
       </div>
 
@@ -208,7 +208,7 @@
         <div class="step-card">
           <div class="step-card__number">3</div>
           <div class="step-card__title">Launch and customize</div>
-          <div class="step-card__desc">Deploy to your domain. Edit content inline. Toggle features on and off. It's yours.</div>
+          <div class="step-card__desc">Go live on your domain. Edit content inline. Toggle features on and off. It's yours.</div>
         </div>
       </div>
     </div>
@@ -261,8 +261,8 @@
         </div>
         <div class="feature-card">
           <div class="feature-card__icon">&#9889;</div>
-          <div class="feature-card__name">Config-Driven</div>
-          <div class="feature-card__desc">Restructure your entire site with SQL. No code changes needed.</div>
+          <div class="feature-card__name">Fully Customizable</div>
+          <div class="feature-card__desc">Restructure your entire site with simple settings changes. No code changes needed.</div>
         </div>
       </div>
     </div>
@@ -332,24 +332,24 @@
       <div class="section-header section-header--center">
         <p class="t-overline">Open Source</p>
         <h2 class="t-display t-display--lg">100% open source. Coding agent friendly.</h2>
-        <p class="t-body--lg mt-2" style="margin-left:auto;margin-right:auto;">No vendor lock-in. No proprietary platform. Your code, your data, deployed on your domain.</p>
+        <p class="t-body--lg mt-2" style="margin-left:auto;margin-right:auto;">No vendor lock-in. No proprietary platform. Your code, your data, running on your domain.</p>
       </div>
 
       <div class="oss-grid">
         <div class="oss-card">
           <div class="oss-card__icon">&#128268;</div>
           <div class="oss-card__name">Fully Open Source</div>
-          <div class="oss-card__desc">Every line of code is yours. Fork it, modify it, own it forever. No hidden proprietary components, no black boxes, no surprises on your bill.</div>
+          <div class="oss-card__desc">Every line of code is yours. Copy it, customize it, own it forever. No hidden proprietary components, no black boxes, no surprises on your bill.</div>
         </div>
         <div class="oss-card">
           <div class="oss-card__icon">&#129302;</div>
           <div class="oss-card__name">Agent Friendly</div>
-          <div class="oss-card__desc">Designed for AI coding agents like Claude Code and Cursor. Config-driven architecture means an agent can rebrand, restructure, and add features with SQL and file edits.</div>
+          <div class="oss-card__desc">Designed for AI coding agents like Claude Code and Cursor. The architecture means an agent can rebrand, restructure, and add features automatically.</div>
         </div>
         <div class="oss-card">
           <div class="oss-card__icon">&#9889;</div>
-          <div class="oss-card__name">Deploy in Minutes</div>
-          <div class="oss-card__desc">One command to deploy. No build step, no Docker, no infrastructure to manage. Describe your community and go live &mdash; customized and running in under 5 minutes.</div>
+          <div class="oss-card__name">Live in Minutes</div>
+          <div class="oss-card__desc">One command to launch. No complex setup, no infrastructure to manage. Describe your community and go live &mdash; customized and running in under 5 minutes.</div>
         </div>
       </div>
 
@@ -376,10 +376,10 @@
           <ul class="plan-card__features">
             <li>Full source code (open source)</li>
             <li>All features included</li>
-            <li>Self-deploy to Run402</li>
+            <li>Self-setup on Run402</li>
             <li>Community support</li>
           </ul>
-          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Fork on GitHub</a>
+          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Get the Template</a>
         </div>
 
         <div class="plan-card plan-card--featured">
@@ -392,7 +392,7 @@
             <li>Guided interview &rarr; custom portal</li>
             <li>Brand colors, logo, content migrated</li>
             <li>Multi-language translation</li>
-            <li>Chrome-verified deployment</li>
+            <li>AI-verified before launch</li>
           </ul>
           <a href="https://eagles.kychon.com" class="btn btn--primary" target="_blank">See a Demo First &rarr;</a>
         </div>
@@ -425,11 +425,11 @@
       <div class="faq-list">
         <details class="faq-item">
           <summary>Is it really $5&ndash;20/mo?</summary>
-          <p>Yes. Kychon is open-source software. The $5&ndash;20/mo covers Run402 hosting (database, file storage, edge functions, subdomain). There are no per-member fees, no usage charges, and no hidden costs. The price scales with your hosting tier, not your member count.</p>
+          <p>Yes. Kychon is open-source software. The $5&ndash;20/mo covers Run402 hosting (database, file storage, cloud services, subdomain). There are no per-member fees, no usage charges, and no hidden costs. The price scales with your hosting tier, not your member count.</p>
         </details>
         <details class="faq-item">
           <summary>Do I need technical skills?</summary>
-          <p>Not with Studio. Tell us about your community, and AI builds your portal in minutes. For the DIY template, basic comfort with deploying web apps is helpful &mdash; but AI agents can handle that too.</p>
+          <p>Not with Studio. Tell us about your community, and AI builds your portal in minutes. For the DIY template, basic comfort with setting up web apps is helpful &mdash; but AI agents can handle that too.</p>
         </details>
         <details class="faq-item">
           <summary>Who owns the data?</summary>
@@ -441,11 +441,11 @@
         </details>
         <details class="faq-item">
           <summary>What does &ldquo;AI-powered&rdquo; actually mean?</summary>
-          <p>Six optional AI features run on your own API key (OpenAI or Anthropic): content moderation, auto-translation, newsletter drafts, smart onboarding, member insights, and event recaps. You control what runs, when, and at what cost.</p>
+          <p>Six optional AI features run on your own AI account (OpenAI or Anthropic): content moderation, auto-translation, newsletter drafts, smart onboarding, member insights, and event recaps. You control what runs, when, and at what cost.</p>
         </details>
         <details class="faq-item">
           <summary>Why is it so affordable?</summary>
-          <p>Because Kychon is open source and runs on Run402's serverless infrastructure. There's no sales team, no enterprise licensing, and no per-seat revenue model. You pay for hosting, not for software.</p>
+          <p>Because Kychon is open source and runs on Run402's cloud platform. There's no sales team, no enterprise licensing, and no per-seat revenue model. You pay for hosting, not for software.</p>
         </details>
       </div>
     </div>

--- a/marketing/privacy.html
+++ b/marketing/privacy.html
@@ -43,7 +43,7 @@
       <ul>
         <li><strong>Studio and Pro customers</strong> - email address, payment information (processed by Stripe), portal configuration preferences, and communication history related to your build</li>
         <li><strong>Marketing site visitors</strong> - standard web analytics (page views, referral sources) via privacy-respecting analytics, and any information you voluntarily submit through contact forms</li>
-        <li><strong>Open-source users</strong> - we collect no data from self-deployed forks. You're on your own infrastructure.</li>
+        <li><strong>Open-source users</strong> - we collect no data from self-hosted copies. You're on your own platform.</li>
       </ul>
 
       <h2>Data We Do Not Collect</h2>
@@ -69,7 +69,7 @@
       </ul>
 
       <h2>AI Features and API Keys</h2>
-      <p>Wild Lychee's optional AI features (content moderation, auto-translation, etc.) use your own API keys (OpenAI or Anthropic), stored as secrets in your Run402 project. Kychee, Inc. does not have access to your API keys or to the data processed by those AI services. Your AI usage is governed by the respective provider's terms.</p>
+      <p>Wild Lychee's optional AI features (content moderation, auto-translation, etc.) use your own AI account credentials (OpenAI or Anthropic), stored securely in your Run402 project. Kychee, Inc. does not have access to your AI credentials or to the data processed by those AI services. Your AI usage is governed by the respective provider's terms.</p>
 
       <h2>Data Storage and Security</h2>
       <p>Studio and Pro customer data is stored securely with encryption at rest and in transit. Payment information is handled entirely by Stripe - we never store credit card numbers. Portal data security is provided by Run402's infrastructure (AWS Aurora, S3, CloudFront) with per-project isolation and row-level security.</p>

--- a/marketing/sports.html
+++ b/marketing/sports.html
@@ -39,7 +39,7 @@
       </p>
       <div class="hero__ctas">
         <a href="#demo-placeholder" class="btn btn--primary btn--lg">Build Your League Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" target="_blank">Get the Template</a>
       </div>
     </div>
     <div class="hero__aside" aria-hidden="true"></div>
@@ -106,10 +106,10 @@
           <ul class="plan-card__features">
             <li>Full source code (open source)</li>
             <li>All features included</li>
-            <li>Self-deploy to Run402</li>
+            <li>Self-setup on Run402</li>
             <li>Community support</li>
           </ul>
-          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Fork on GitHub</a>
+          <a href="https://github.com/kychee-com/kychon" class="btn btn--outline" target="_blank">Get the Template</a>
         </div>
 
         <div class="plan-card plan-card--featured">
@@ -122,7 +122,7 @@
             <li>Guided interview &rarr; custom portal</li>
             <li>Brand colors, logo, content migrated</li>
             <li>Multi-language translation</li>
-            <li>Chrome-verified deployment</li>
+            <li>AI-verified before launch</li>
           </ul>
           <a href="#demo-placeholder" class="btn btn--primary">Build My Portal &rarr;</a>
         </div>
@@ -151,7 +151,7 @@
       <p class="t-body--lg">Open source. Flat pricing. AI-powered. Yours forever.</p>
       <div class="final-cta__buttons">
         <a href="#demo-placeholder" class="btn btn--white btn--lg">Build Your League Portal &rarr;</a>
-        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Fork on GitHub</a>
+        <a href="https://github.com/kychee-com/kychon" class="btn btn--outline btn--lg" style="border-color:#fff;color:#fff" target="_blank">Get the Template</a>
       </div>
     </div>
   </section>

--- a/marketing/terms.html
+++ b/marketing/terms.html
@@ -42,7 +42,7 @@
       <p>By using Wild Lychee - including deploying a portal, purchasing a Studio build, or subscribing to Lychee Pro - you agree to be bound by these Terms of Service and the <a href="/privacy.html">Privacy Policy</a>. If you do not agree, do not use the service.</p>
 
       <h2>3. Open-Source Template</h2>
-      <p>The Wild Lychee template is open-source software. You may fork, modify, and deploy it freely under its license terms. The open-source template is provided as-is, without warranty. Kychee, Inc. is not obligated to provide support for self-deployed forks.</p>
+      <p>The Wild Lychee template is open-source software. You may copy, modify, and use it freely under its license terms. The open-source template is provided as-is, without warranty. Kychee, Inc. is not obligated to provide support for self-hosted copies.</p>
 
       <h2>4. Pricing and Payment</h2>
       <p>Wild Lychee offers three tiers:</p>

--- a/site/marketing/index.html
+++ b/site/marketing/index.html
@@ -35,7 +35,7 @@
       <div class="m-hero-ctas">
         <a href="#build" class="m-btn m-btn-primary m-btn-lg">Build My Portal</a>
         <a href="#demos" class="m-btn m-btn-secondary m-btn-lg">See Demos</a>
-        <a href="#fork" class="m-btn m-btn-ghost m-btn-lg">Fork the Template</a>
+        <a href="#fork" class="m-btn m-btn-ghost m-btn-lg">Get the Template</a>
       </div>
       <div class="m-hero-mashup">
         <div class="m-hero-card m-hero-card-left">
@@ -159,7 +159,7 @@
     <div class="m-container">
       <div class="m-section-header">
         <h2>See it in action</h2>
-        <p>Real communities running on Kychon right now. Each one built and deployed in minutes.</p>
+        <p>Real communities running on Kychon right now. Each one built and launched in minutes.</p>
       </div>
       <div class="m-demos-grid">
 
@@ -235,23 +235,23 @@
     <div class="m-container">
       <div class="m-section-header">
         <h2>100% open source. Coding agent friendly.</h2>
-        <p>No vendor lock-in. No proprietary platform. Your code, your data, deployed on your domain.</p>
+        <p>No vendor lock-in. No proprietary platform. Your code, your data, running on your domain.</p>
       </div>
       <div class="m-oss-grid">
         <div class="m-oss-card">
           <div class="m-oss-icon">&#128268;</div>
           <h3>Fully Open Source</h3>
-          <p>Every line of code is yours. Fork it, modify it, own it forever. No hidden proprietary components, no black boxes, no surprises on your bill.</p>
+          <p>Every line of code is yours. Copy it, customize it, own it forever. No hidden proprietary components, no black boxes, no surprises on your bill.</p>
         </div>
         <div class="m-oss-card">
           <div class="m-oss-icon">&#129302;</div>
           <h3>Agent Friendly</h3>
-          <p>Designed for AI coding agents like Claude Code and Cursor. Config-driven architecture means an agent can rebrand, restructure, and add features with SQL and file edits.</p>
+          <p>Designed for AI coding agents like Claude Code and Cursor. The architecture means an agent can rebrand, restructure, and add features automatically.</p>
         </div>
         <div class="m-oss-card">
           <div class="m-oss-icon">&#9889;</div>
-          <h3>Deploy in Minutes</h3>
-          <p>One command to deploy. No build step, no Docker, no infrastructure to manage. Describe your community and go live - customized and running in under 5 minutes.</p>
+          <h3>Live in Minutes</h3>
+          <p>One command to launch. No complex setup, no infrastructure to manage. Describe your community and go live - customized and running in under 5 minutes.</p>
         </div>
       </div>
       <div class="m-oss-cta">
@@ -283,7 +283,7 @@
             <tr><td>5,000 members</td><td>$530/mo</td><td>$419/mo + 2% fees</td><td>$20/mo</td></tr>
             <tr><td>Transaction fees</td><td>2.9% + $0.30 + 20%</td><td>0.5-2%</td><td>$0</td></tr>
             <tr><td>AI builder</td><td class="m-compare-x">No</td><td class="m-compare-x">No</td><td class="m-compare-check">Yes</td></tr>
-            <tr><td>AI features</td><td class="m-compare-x">No</td><td class="m-compare-x">No</td><td class="m-compare-check">Yes (BYOK)</td></tr>
+            <tr><td>AI features</td><td class="m-compare-x">No</td><td class="m-compare-x">No</td><td class="m-compare-check">Yes (use your own AI account)</td></tr>
             <tr><td>Own your data</td><td class="m-compare-x">No</td><td class="m-compare-x">No</td><td class="m-compare-check">Yes</td></tr>
           </tbody>
         </table>
@@ -299,12 +299,12 @@
           <div class="m-plan-price">$5-20</div>
           <div class="m-plan-period">/mo hosting on Run402</div>
           <ul class="m-plan-features">
-            <li>Fork the template</li>
+            <li>Get the template</li>
             <li>Full source code</li>
             <li>All features included</li>
-            <li>You configure &amp; deploy</li>
+            <li>You configure &amp; launch</li>
           </ul>
-          <a href="#fork" class="m-btn m-btn-secondary" style="width:100%;justify-content:center">Fork Template</a>
+          <a href="#fork" class="m-btn m-btn-secondary" style="width:100%;justify-content:center">Get Template</a>
         </div>
         <div class="m-plan-card featured">
           <div class="m-plan-name">Studio + Starter</div>
@@ -382,7 +382,7 @@
       <p>Live in 5 minutes. Own it forever.</p>
       <div class="m-hero-ctas">
         <a href="#build" class="m-btn m-btn-primary m-btn-lg">Build My Portal</a>
-        <a href="#fork" class="m-btn m-btn-secondary m-btn-lg">Fork the Template</a>
+        <a href="#fork" class="m-btn m-btn-secondary m-btn-lg">Get the Template</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Simplify developer-facing terms so non-technical community leaders can
understand the site: fork→copy/get, deploy→launch/go live, edge functions→
cloud services, config-driven→fully customizable, BYOK→use your own AI
account, API keys→AI account, serverless infrastructure→cloud platform,
Chrome-verified deployment→AI-verified before launch, SQL references removed.

https://claude.ai/code/session_01CjvMND2PNcUq6TuVXvLDEd