### PR TITLE
revert(deploy): undo Eagles asset resize (actually) — push the fix to Run402

### DIFF
--- a/demo/eagles/deploy.sh
+++ b/demo/eagles/deploy.sh
@@ -19,21 +19,9 @@ ASSETS_DST="$ROOT/public/assets"
 trap '[ -d "$ASSETS_DST" ] && rm -rf "$ASSETS_DST"' EXIT
 
 if [ -d "$ASSETS_SRC" ]; then
-  echo "Resizing demo assets into public/assets..."
+  echo "Copying demo assets into public/assets..."
   mkdir -p "$ASSETS_DST"
-  for f in "$ASSETS_SRC"/avatar-*.jpg; do
-    [ -f "$f" ] && sips -Z 256 -s formatOptions 70 -s format jpeg "$f" --out "$ASSETS_DST/$(basename "$f")" >/dev/null 2>&1
-  done
-  for f in "$ASSETS_SRC"/event-*.jpg "$ASSETS_SRC"/committee-*.jpg; do
-    [ -f "$f" ] && sips -Z 800 -s formatOptions 70 -s format jpeg "$f" --out "$ASSETS_DST/$(basename "$f")" >/dev/null 2>&1
-  done
-  for f in "$ASSETS_SRC"/hero.jpg "$ASSETS_SRC"/about-hero.jpg "$ASSETS_SRC"/volunteer-hero.jpg; do
-    [ -f "$f" ] && sips -Z 1200 -s formatOptions 70 -s format jpeg "$f" --out "$ASSETS_DST/$(basename "$f")" >/dev/null 2>&1
-  done
-  for f in "$ASSETS_SRC"/logo.png; do
-    [ -f "$f" ] && sips -Z 256 "$f" --out "$ASSETS_DST/$(basename "$f")" >/dev/null 2>&1
-  done
-  echo "  $(ls "$ASSETS_DST" | wc -l | tr -d ' ') images ($(du -sh "$ASSETS_DST" | cut -f1) web-optimized)"
+  cp "$ASSETS_SRC"/* "$ASSETS_DST/"
 fi
 
 # Deploy site + images + seed (scripts/deploy.ts runs astro build + collects from dist/)


### PR DESCRIPTION
## Summary

Reverts the \`sips\` resize from [#11](https://github.com/kychee-com/kychon/pull/11). Kychon ships Eagles photos at full high-res; the deploy fails today because Run402's bundle-deploy returns HTTP 413 at ~91MB encoded, and that's the platform's bug to fix.

**Note:** [#15](https://github.com/kychee-com/kychon/pull/15) was a no-op due to a tooling slip (gh picked the wrong source branch when cwd reset between commands). This PR is the actual revert.

## Diff
- 1 file (\`demo/eagles/deploy.sh\`) — strip the sips loops, restore the original \`cp\` of the source assets

## Test plan
- [x] Single-file diff matches the inverse of #11
- [ ] After this lands: \`bash demo/eagles/deploy.sh\` returns HTTP 413 (expected; tracked in [run402#115](https://github.com/kychee-com/run402/issues/115)). eagles.kychon.com keeps the most recent successful deployment.