### PR TITLE
deploy: drop expose.tables cast, send rich manifest shape

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,7 +75,7 @@ When npm refuses to install a recently-published SDK release because of a `befor
 
 The deploy goes through `r.deploy.apply(spec)` — the v2 unified deploy primitive. The SDK builds a `ReleaseSpec` (migrations, expose manifest, functions, site, subdomains), uploads bytes through CAS (only the SHAs the gateway hasn't seen), commits, and polls until `ready`. Re-deploying an unchanged tree issues no S3 PUTs.
 
-We migrated off `apps.bundleDeploy()` in 1.50.1 because the compat shim's `translateRlsToExpose` emits `{name, expose, policy}` objects (matching the published manifest schema at https://run402.com/schemas/manifest.v1.json) but the gateway runtime validator now rejects that shape with `"tables must be an array of strings"`. We send `tables: string[]` directly via `r.deploy.apply()` — probe-verified on 2026-04-29. Tracked upstream at kychee-com/run402#154 / #155 / #156.
+We migrated off `apps.bundleDeploy()` in 1.50.1 (kychee-com/run402#154) because its compat shim was emitting an `expose.tables` shape the v2 deploy validator briefly rejected. The gateway validator was relaxed in 2026-04-30 to delegate to the same `validateManifest()` the imperative `/expose` route uses, so both bare strings and the rich `{name, expose, policy}` shape now work. We send the rich shape (matches the published schema, type-checks cleanly, and pins the policy explicitly).
 
 ## Service-key writes
 

--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -23,16 +23,18 @@ export { fileSetFromDir };
 export const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 /**
- * Tables reachable via `/rest/v1/*`. Sent as `database.expose.tables: string[]`
- * in the v2 release spec.
+ * Tables reachable via `/rest/v1/*`, sent as `database.expose.tables` in the
+ * v2 release spec. Rich-object shape per the published manifest schema at
+ * https://run402.com/schemas/manifest.v1.json.
  *
- * The SDK's `ExposeManifest.tables` type is `Array<Record<string, unknown>>`
- * (matching the published schema at https://run402.com/schemas/manifest.v1.json,
- * which describes objects with `{name, expose, policy}`), but the gateway
- * runtime validator rejects that shape with `"tables must be an array of strings"`.
- * Strings is what works today — see kychee-com/run402#155 / #156.
+ * The previous workaround (sending bare strings + structural cast) is no
+ * longer needed: the gateway's v2 validator was relaxed to delegate to the
+ * same `validateManifest()` the imperative `/expose` route uses (kychee-com/run402#154).
+ * Setting `policy` explicitly here also pins the RLS template — strings
+ * implicitly default to `public_read_authenticated_write` server-side, which
+ * is what we want, but explicit beats implicit.
  */
-export const EXPOSE_TABLES: readonly string[] = [
+const TABLE_NAMES = [
   "site_config",
   "pages",
   "sections",
@@ -54,7 +56,11 @@ export const EXPOSE_TABLES: readonly string[] = [
   "member_insights",
   "newsletter_drafts",
   "reactions",
-];
+] as const;
+
+export const EXPOSE_TABLES: ReadonlyArray<Record<string, unknown>> = TABLE_NAMES.map(
+  (name) => ({ name, expose: true, policy: "public_read_authenticated_write" }),
+);
 
 export interface CollectFunctionsOptions {
   /** Function names to skip (e.g. `["check-expirations"]` for demos). */
@@ -234,22 +240,11 @@ export async function runDeploy(
   const fnNames = Object.keys(functionsMap);
   const scheduledFns = fnNames.filter((n) => functionsMap[n]?.schedule);
 
-  // SDK type says `Array<Record<string, unknown>>`; gateway requires `string[]`.
-  // See kychee-com/run402#155 / #156.
-  const expose = {
-    version: "1",
-    tables: EXPOSE_TABLES,
-  } as unknown as ReleaseSpec["database"] extends infer D
-    ? D extends { expose?: infer E }
-      ? E
-      : never
-    : never;
-
   const spec: ReleaseSpec = {
     project: opts.projectId,
     database: {
       migrations: [{ id: migrationId, sql }],
-      expose,
+      expose: { version: "1", tables: [...EXPOSE_TABLES] },
     },
     site: { replace: fileSet },
     subdomains: { set: [opts.subdomain] },


### PR DESCRIPTION
## Summary
The v2 deploy validator was relaxed in run402-private#142 (commit `f8896352`) to delegate to the same `validateManifest()` the imperative `/expose` route uses. Both bare strings and the rich `{name, expose, policy}` shape are now accepted by the gateway. Strings expand server-side to `{ name, expose: true, policy: "public_read_authenticated_write" }`.

Switching `scripts/_lib.ts` to the rich shape so:
- The `as unknown as ...` structural cast in `runDeploy()` goes away
- The SDK type checks the payload cleanly (no cast needed)
- The RLS policy is pinned explicitly per-table — no longer relying on the server-side default for the implicit-string form

## Test plan
- [x] `npx tsc --project tsconfig.scripts.json` (typecheck clean)
- [x] `npm run test` (273 tests pass)
- [x] Probe: rich-shape manifest accepted by `r.deploy.apply()` (release `rel_1777534757407_f4dbfcde`)
- [x] All 3 demos redeployed clean from this branch
- [x] PostgREST anon-key reads return rows on members/announcements/pages for all 3 demos

## Upstream resolution
- kychee-com/run402#154 / #155 / #156 / #158 — moved to private repo and resolved by run402-private#142
- kychee-com/run402#157 — fixed independently in commit `083417f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)