### PR TITLE
fix(deploy): fail loud when demo assets dir is missing

### DIFF
--- a/scripts/deploy-demo.ts
+++ b/scripts/deploy-demo.ts
@@ -70,12 +70,29 @@ export const DEMOS: Record<string, DemoConfig> = {
  * Copy `<src>/*` (top-level files only, no recursion — matches `cp src/* dst/`)
  * into `<dst>/`. Returns a cleanup function that removes `<dst>` if it was
  * created here. Caller must run cleanup in a try/finally.
+ *
+ * `demo/<name>/assets/` is gitignored and machine-local (`generate-images.sh`
+ * produces it from OPENAI_API_KEY). Fail loud if it's missing for a demo
+ * deploy — silently skipping ships demo sites with broken /assets/ refs.
  */
 function copyAssets(src: string, dst: string): () => void {
-  if (!existsSync(src)) return () => undefined;
-  console.log("Copying demo assets into public/assets...");
+  if (!existsSync(src)) {
+    throw new Error(
+      `Demo assets dir not found: ${src}\n` +
+        "  Generate it via the demo's `bash demo/<name>/generate-images.sh` (needs OPENAI_API_KEY),\n" +
+        "  or symlink it from another checkout that already has the images.",
+    );
+  }
+  const entries = readdirSync(src);
+  if (entries.length === 0) {
+    throw new Error(
+      `Demo assets dir is empty: ${src}\n` +
+        "  Did `generate-images.sh` complete? Check for a partial run.",
+    );
+  }
+  console.log(`Copying ${entries.length} demo asset(s) into public/assets...`);
   mkdirSync(dst, { recursive: true });
-  for (const name of readdirSync(src)) {
+  for (const name of entries) {
     copyFileSync(join(src, name), join(dst, name));
   }
   return () => {


### PR DESCRIPTION
## Summary
`demo/<name>/assets/` is gitignored — produced locally by `generate-images.sh` (needs `OPENAI_API_KEY`). The previous `copyAssets()` silently skipped when the dir wasn't found, so a fresh worktree without locally-generated assets would ship demo deploys with every `/assets/*.{png,jpg}` 404'ing.

Fail loud with an actionable message instead.

## What surfaced this
After PR #19 merged from a fresh worktree, the user reported `/assets/logo.png` and `/assets/hero.jpg` 404'ing on barrio. The eagles dir happened to have its 2 referenced images locally; silver-pines and barrio (which have 41 assets each, including logo/hero) had no local assets dir at all.

## Fix
- `copyAssets()` throws `Demo assets dir not found: ...` with a hint pointing at `generate-images.sh` or a sibling-checkout symlink
- Also throws if the dir exists but is empty (partial `generate-images.sh` run)
- Logs the file count when the copy succeeds

## Test plan
- [x] `npx tsc --project tsconfig.scripts.json` clean
- [x] All 3 demos redeployed end-to-end after symlinking the assets in
- [x] `/assets/logo.png`, `/assets/hero.jpg` return HTTP 200 on all 3 demos now
- [x] Triggering a deploy without the assets dir produces the new fail-loud error (verified during diagnosis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)