### PR TITLE
docs(readme): note Git LFS pull for demo images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A forkable, AI-powered membership portal built on [Run402](https://run402.com). 
 ## Quick Start
 
 ```bash
+# Pull demo images (Git LFS, one-time per machine)
+git lfs install
+git lfs pull
+
 # Install dependencies
 npm install
 


### PR DESCRIPTION
Tiny follow-up to PR #21 (the LFS migration). Without LFS configured locally, a fresh clone gets 134-byte pointer files instead of the 132 demo images, and any demo deploy ships broken /assets/* refs.

Adds a 3-line `git lfs install && git lfs pull` step at the top of Quick Start so new contributors don't trip on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)