### PR TITLE
feat(nav): nested children with hover dropdowns + keyboard a11y

### DIFF
--- a/openspec/changes/nav-nested-children/.openspec.yaml
+++ b/openspec/changes/nav-nested-children/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/nav-nested-children/design.md
+++ b/openspec/changes/nav-nested-children/design.md
@@ -1,0 +1,204 @@
+## Context
+
+After [composable-layout](../composable-layout/proposal.md), navigation is rendered by the `nav` block in `src/lib/blocks.ts`. Today its `config.items` is a flat array of `{ label, href, icon, public, auth, feature, admin }`. This change adds an optional recursive `children: NavItem[]` field to that schema.
+
+Constraints:
+- The renderer must work in both bake (Node, build-time) and hydrate (browser) contexts; same `renderBlock(section, ctx): string` contract.
+- The dropdown must be operable via mouse, keyboard, touch, and screen reader, satisfying WCAG 2.1 AA. The standard ARIA pattern for menu buttons + menus applies.
+- Existing flat nav configs must continue to work unchanged. This is purely additive at the data layer.
+- The mobile experience uses the existing hamburger; nested items must expand inline rather than fly out, to match small-screen interaction conventions.
+- The block is rendered once per page and persists across SPA transitions via Astro's `transition:persist` (per composable-layout). Event handlers attach idempotently — re-binding on `astro:after-swap` must not double-bind.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Two-level minimum nesting (parent → children → optionally grandchildren).
+- Hover-open on pointer + focus-open on keyboard, with full keyboard navigation inside open menus.
+- Inline expansion on mobile.
+- Editor popover supports adding/removing/reordering children with the same drag UX as top-level items.
+- Idempotent runtime binding so SPA navigation doesn't break the menu.
+
+**Non-Goals:**
+- Mega-menus (multi-column dropdowns with rich content). Out of scope; keep dropdowns to a single column of links.
+- Click-to-open on desktop (every nav menu in this codebase uses hover-open; `aria-haspopup="menu"` + chevron click are sufficient affordances).
+- Animation choreography. A simple fade-in / slide-down (200ms) is enough; bounce/spring animations are not.
+- Per-item icons inside dropdowns. Top-level items keep their icons; child items are text-only for visual hierarchy.
+
+## Decisions
+
+### 1. The schema extension
+
+**Decision**: Extend the `NavItem` type in `src/lib/blocks.ts`:
+
+```ts
+interface NavItem {
+  label: string;
+  href?: string;
+  icon?: string;
+  public?: boolean;
+  auth?: boolean;
+  feature?: string;
+  admin?: boolean;
+  children?: NavItem[];   // NEW
+}
+```
+
+Rules:
+- If `children` is present and non-empty, the item is a parent.
+- If `href` and `children` are both present, the parent is a navigable link AND a dropdown trigger.
+- If only `children` is present, the parent is purely a trigger (`<button>`, no navigation).
+- Children inherit no defaults — each is independent and may itself carry `children`.
+
+**Why**: matches the issue's proposed config shape without schema migration. Recursion is natural; depth is implicit.
+
+### 2. ARIA pattern: disclosure-button + menu
+
+**Decision**: Use the disclosure-button pattern (`button[aria-haspopup="menu"][aria-expanded="false|true"]` + `ul[role="menu"]`), not the menubar pattern.
+
+```html
+<a class="nav-link" href="/marina">Marina</a>
+<button class="nav-chevron-toggle" aria-haspopup="menu" aria-expanded="false" aria-controls="nav-menu-marina">▾</button>
+<ul class="nav-dropdown" role="menu" id="nav-menu-marina" hidden>
+  <li role="none"><a role="menuitem" href="/marina/layout">Marina Layout</a></li>
+  <li role="none"><a role="menuitem" href="/marina/howto">How-To Guide</a></li>
+</ul>
+```
+
+**Why disclosure over menubar**: site nav with submenus is the standard disclosure pattern (per WAI-ARIA Authoring Practices, "Disclosure (Show/Hide)" section). Menubar implies app-style cursor management that isn't appropriate for a website nav. Screen readers handle disclosure correctly without requiring users to enter "menu mode."
+
+**Why `role="menu"` and not `role="navigation"` for the dropdown**: the dropdown specifically holds menuitems triggered by a menu button. The outer `<nav>` already has `aria-label="Primary navigation"`; the dropdown is a menu inside that nav.
+
+### 3. Top-level with both `href` and `children`: split affordances
+
+**Decision**: When an item has both `href` and `children`, render two separate elements: an `<a>` for the link, a `<button>` chevron for the menu trigger.
+
+**Why**: collapsing them into a single click target forces a choice (does click navigate or open menu?) that's bad either way. Splitting them mirrors the macOS Finder pattern (file row + disclosure triangle) and works on every input modality.
+
+**Hit targets**: chevron button minimum 32x32px; `<a>` link absorbs the rest of the row's hover area. CSS keeps them visually grouped.
+
+### 4. Hover for pointer, focus for keyboard
+
+**Decision**: CSS handles hover-open behind a `@media (hover: hover) and (pointer: fine)` query. JS handles focus-open and click-on-chevron for both modalities.
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  .nav-parent:hover + .nav-chevron-toggle + .nav-dropdown,
+  .nav-parent:focus + .nav-chevron-toggle + .nav-dropdown,
+  .nav-chevron-toggle:hover + .nav-dropdown,
+  .nav-chevron-toggle:focus + .nav-dropdown,
+  .nav-dropdown:hover { display: block; }
+}
+```
+
+The `.nav-dropdown:hover` rule keeps the dropdown open while the cursor is inside it (otherwise it closes the moment the cursor leaves the parent's bounding box).
+
+JS layer (loaded for everyone, ~3kB):
+- Listens to focusin/focusout on the parent + dropdown to set `aria-expanded` and toggle `[hidden]`
+- Listens to `click` on the chevron to toggle the dropdown
+- Listens to keydown for arrow/Escape/Enter handling
+
+**Why this split**: CSS hover-open is instant, has no JS dependency, and degrades gracefully if JS hasn't loaded. JS focus-open ensures keyboard parity. The two layers don't fight because each updates `aria-expanded` and `[hidden]` consistently.
+
+### 5. Keyboard navigation matrix
+
+**Decision**: standard menu-button keyboard model.
+
+| Key | When focus is on… | Behavior |
+|---|---|---|
+| `↓` (Down) | Top-level chevron | Open menu, focus first item |
+| `↑` (Up) | Top-level chevron | Open menu, focus last item |
+| `↓` | Menu item | Move focus to next item; wrap |
+| `↑` | Menu item | Move focus to previous item; wrap |
+| `Enter` / `Space` | Menu item | Activate item (navigate to its href) |
+| `Enter` / `Space` | Chevron | Toggle menu open/closed |
+| `Escape` | Inside menu | Close menu, focus trigger |
+| `Tab` | Inside menu | Close menu, advance focus to next top-level item |
+| `Shift+Tab` | Inside menu | Close menu, retreat focus to previous top-level item |
+
+**Why these specific behaviors**: matches the WAI-ARIA Authoring Practices `menu-button` pattern. The Tab → close-and-advance behavior is what users expect from site nav (vs. trapping inside menu indefinitely).
+
+### 6. Click-outside dismissal
+
+**Decision**: Single document-level click handler attached on first nav block hydration:
+
+```ts
+document.addEventListener('click', (e) => {
+  document.querySelectorAll('.nav-dropdown:not([hidden])').forEach((dropdown) => {
+    if (!dropdown.contains(e.target) && !dropdown.previousElementSibling?.contains(e.target)) {
+      closeDropdown(dropdown);
+    }
+  });
+});
+```
+
+Idempotent: if the handler is already attached (`window.__navDropdownClickHandler === true`), the second hydration skips re-attachment.
+
+**Why document-level**: simpler than tracking per-dropdown listeners. The handler is cheap (a single `querySelectorAll` per click), runs only when at least one dropdown is open in practice (the for-each is a no-op otherwise).
+
+### 7. Mobile (no hover)
+
+**Decision**: Under `@media (hover: none)` or `@media (max-width: 768px)`, dropdowns become inline accordions:
+
+- `.nav-parent` and `.nav-chevron-toggle` collapse into a single full-width row tap target.
+- Tapping the parent (anywhere on the row) toggles `aria-expanded` and reveals/hides the dropdown inline below it (no absolute positioning).
+- Children indent 1.5rem to indicate hierarchy.
+- Chevron rotates 180° via CSS transform when expanded.
+- The mobile menu container (the existing hamburger flyout) handles vertical scroll if the menu exceeds viewport height.
+
+**Why**: hover-fly-out is unusable on touch. Inline expansion matches every modern site's mobile nav pattern.
+
+### 8. Editor UX in `NavEditor` popover
+
+**Decision**: The nav block edit popover (from composable-layout's "edit popover replaces site_config nav editor" decision) gets:
+
+- An "Add child" button per row, rendering child rows indented 1.5rem under their parent.
+- Children are draggable using the existing sortable engine, scoped to their parent's children array.
+- Children can be added recursively (a child can itself have children, indented 3rem).
+- Removing a parent with children prompts: "Remove this item and its 4 children?" before deletion.
+- The visual hierarchy uses indentation + a vertical guide line on the left of children groups.
+
+**Why**: the popover already handles the flat case via the sortable engine. Adding children is a recursive UI extension, not a redesign — same row template, same handlers, scoped to a different array.
+
+### 9. Idempotent runtime binding
+
+**Decision**: All event handler attachment in the nav renderer's hydrator follows the existing pattern:
+
+```ts
+function bindNavBlock(blockEl: HTMLElement) {
+  if (blockEl.dataset.navBound === 'true') return;
+  blockEl.dataset.navBound = 'true';
+  // … attach handlers
+}
+```
+
+Re-binding triggered by `astro:after-swap` or `wl-content-rendered` events is safe and has no side effects.
+
+**Why**: same pattern used by AdminEditor and other modules. Avoids double-binding without a global registry.
+
+## Risks / Trade-offs
+
+### A. Hover-open dropdowns close when the cursor crosses a gap
+
+If there's any vertical space between the parent and its dropdown, the cursor leaving the parent before reaching the dropdown closes it. Mitigation: zero gap, with the dropdown directly attached to the parent's bottom edge. Slight visual trade-off (tight) but standard UX.
+
+### B. Two-element split for parent-with-href is visually busier
+
+A row with both `<a>` and chevron `<button>` looks more crowded than today's flat nav. Mitigation: chevron is small (12px), low-contrast, separated by 4px from the link.
+
+### C. Mobile inline expansion competes with the hamburger menu's existing scroll
+
+The mobile menu is already a vertical list inside a flyout. Adding nested expansion increases scroll length. Mitigation: cap mobile menu height at `100vh` with `overflow-y: auto` (already in place); accept that deeply-nested mobile menus require scrolling.
+
+### D. JS-disabled fallback
+
+If JS doesn't run, hover-open via CSS still works on desktop, but keyboard users lose dropdown access. Mitigation: progressive enhancement — render `[hidden]` attribute server-side via the bake; CSS removes hidden in hover/focus. Without JS, focus management is limited but core flat nav still works.
+
+## Migration / Rollout
+
+This change is purely additive — the renderer treats `children: undefined` and `children: []` identically to today's flat behavior. We can ship the renderer change, deploy, and adopt nested nav per-demo at our pace.
+
+1. Renderer + CSS land first.
+2. Editor popover updated to support adding children.
+3. One demo gains a nested nav config (e.g. silver-pines's "Resources" item gets sub-items: "Documents", "Forms", "Calendar"); deploy and visually verify on real device.
+4. Documentation updated.
+5. ODBC port re-runnable with nested nav (parallel with composable-layout's Phase 7 ODBC verification — this change unlocks the second half of that test).

--- a/openspec/changes/nav-nested-children/proposal.md
+++ b/openspec/changes/nav-nested-children/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+ODBC's source site at [olddominionboatclub.com](https://www.olddominionboatclub.com/) — and most Wild Apricot member-org sites — use cascading hover dropdowns in the header. Hovering `MARINA ▸` reveals four sub-items (Marina Layout, How-To Guide, M&B Application, Transient Dockage). The Kychon port at `odbc-port.run402.com` flattens this into 12+ top-level nav items because today's `nav` block (post-`composable-layout`) renders `config.items` as a flat list. Without nested nav, any port of a multi-section club site looks visibly degraded.
+
+This change extends the `nav` block introduced by [composable-layout](../composable-layout/proposal.md) to support a recursive `children: [...]` array on each item, renders the result as a hover dropdown with full keyboard a11y on desktop, and degrades to inline expansion under the existing hamburger toggle on mobile.
+
+Closes [#52 nav: nested children with hover dropdowns + keyboard a11y](https://github.com/kychee-com/kychon/issues/52).
+
+## What Changes
+
+- **Schema-free.** Nothing changes in the database. The `nav` block's `config.items` array gains an optional `children: NavItem[]` field per item. Existing flat configs keep working unchanged.
+- **Renderer.** `BLOCK_TYPES.nav.render` in `src/lib/blocks.ts` emits a top-level item with children as `<button class="nav-link nav-parent" aria-haspopup="menu" aria-expanded="false">{label} <span class="nav-chevron">▾</span></button>` followed by `<ul class="nav-dropdown" role="menu" hidden>` containing each child as `<li role="none"><a role="menuitem" href={child.href}>{child.label}</a></li>`. Recursive — children can themselves have children, supported at least two levels deep.
+- **Top-level item with both `href` and `children`.** The parent renders as a `<a>` link to `href`; a sibling `<button class="nav-chevron-toggle" aria-haspopup="menu">▾</button>` opens the dropdown. The link navigates; the chevron toggles the menu.
+- **Hover behavior on pointer devices.** A media query `@media (hover: hover) and (pointer: fine)` enables CSS-driven hover-open: `.nav-parent:hover ~ .nav-dropdown, .nav-parent:focus ~ .nav-dropdown { display: block }` — augmented by JS for keyboard parity (focus opens, blur with no focus inside closes).
+- **Keyboard navigation.** Arrow keys (↓/↑) navigate items inside an open menu, Enter activates the focused item, Escape closes the menu and returns focus to the trigger, Tab moves to the next top-level item (closing the current dropdown). Focus is trapped inside the open menu while it's open.
+- **Click-outside dismissal.** A single `document.addEventListener('click', …)` in the nav block's runtime handler closes any open dropdown when the click target isn't inside it.
+- **Mobile (no hover).** Under the existing `.nav-toggle` hamburger, dropdowns expand inline (vertical accordion) instead of hovering. The chevron rotates 180° to indicate expansion. Tapping the parent toggles its children's visibility; tapping a leaf navigates and closes the menu.
+- **`NavEditor` popover.** The block edit popover (introduced by composable-layout's nav-as-block) gains a "Add child" button per row. Children render as indented sub-rows beneath their parent, themselves draggable for reorder and editable for label/href. Removing a parent removes its entire subtree (with confirmation if children are present).
+- **Storybook + a11y test.** A new test verifies NVDA + VoiceOver announce the parent's role (`button`), `aria-expanded` state, and the menu's `role="menu"`. Programmatic test confirms keyboard arrow-key navigation lands on the right items.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `composable-layout`: extends the `nav` block-type to render nested children with full a11y, hover/focus opening on pointer devices, inline expansion on mobile, and keyboard navigation.
+
+## Impact
+
+- **New files**: none. Possible new CSS file `public/css/nav-dropdown.css` (~2kB) loaded alongside existing nav styles.
+- **Modified files**: `src/lib/blocks.ts` (extend `nav` renderer), `src/components/AdminEditor.astro` (nested children UI in nav popover), `public/css/styles.css` or new `nav-dropdown.css`, `tests/blocks-nav.test.ts` (a11y + keyboard tests).
+- **Dependencies**: none new. Standard ARIA patterns + HTML5 keyboard handlers.
+- **Bundle impact**: ~3kB extra JS for keyboard handling and click-outside, ~2kB extra CSS for the dropdown chrome. Loaded for everyone (the dropdown is member-facing, not admin-only).
+- **Demo update**: Optionally update silver-pines or eagles seed to demonstrate nested nav, so the feature is visible without re-running the ODBC port.
+- **Hard dep**: ships only after [composable-layout](../composable-layout/proposal.md) lands. The `nav` block must exist as the storage and render path before this change can extend it.

--- a/openspec/changes/nav-nested-children/specs/composable-layout/spec.md
+++ b/openspec/changes/nav-nested-children/specs/composable-layout/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: `nav` block carries the navigation that used to live in `site_config.nav`
+
+The `site_config.nav` key SHALL be removed from the system. Navigation SHALL be expressed as a `nav` block in `zone = 'header'`. The `nav` block's `config.items` SHALL be an array of nav items, each carrying `label`, `href`, `icon`, optional `public`, `auth`, `feature`, `admin` properties, AND an optional `children: NavItem[]` field that recursively contains nav items. When `children` is present and non-empty, the item SHALL be rendered as a hover/focus dropdown trigger; when `children` is absent, empty, or undefined, the item SHALL render as today's flat nav link. The block edit popover SHALL be the editor surface for nav items, replacing the separate nav editor that wrote to `site_config`. The popover SHALL support adding, removing, editing, and drag-reordering child items (scoped within their parent's `children` array).
+
+#### Scenario: Site nav comes from a sections row, not site_config
+- **WHEN** a Kychon page loads
+- **THEN** the navigation in the header zone is rendered by `BLOCK_TYPES.nav.render` against the `nav` block's `config.items`
+- **THEN** no code path reads `site_config.nav`
+
+#### Scenario: Admin edits nav via the block popover
+- **WHEN** an admin clicks the edit affordance on the `nav` block in the header
+- **THEN** a popover opens with the nav items as editable rows (label, href, visibility flags, drag-reorder)
+- **WHEN** the admin saves
+- **THEN** the system PATCHes the `nav` block's `config.items`
+
+#### Scenario: Flat nav configs continue to work
+- **WHEN** a `nav` block has items with no `children` field set
+- **THEN** the rendered nav is flat — each item is an `<a class="nav-link">` with no chevron and no dropdown
+
+#### Scenario: An item with children renders as a dropdown trigger
+- **WHEN** a `nav` block has an item `{ label: 'Marina', children: [{ label: 'Layout', href: '/marina/layout' }, { label: 'How-To', href: '/marina/howto' }] }`
+- **THEN** the rendered HTML contains a chevron toggle: `<button class="nav-chevron-toggle" aria-haspopup="menu" aria-expanded="false" aria-controls="..."`
+- **THEN** the rendered HTML contains an `<ul class="nav-dropdown" role="menu" hidden>` with two `<li role="none"><a role="menuitem" href>...</a></li>` children
+- **THEN** if the parent also has `href` set, an additional `<a class="nav-link" href={href}>` is rendered alongside the chevron
+
+#### Scenario: Hover opens the dropdown on pointer devices
+- **WHEN** a user with a pointer device hovers a parent nav item with children
+- **THEN** the dropdown becomes visible (CSS-driven via `@media (hover: hover) and (pointer: fine)`)
+- **THEN** `aria-expanded` is updated to `"true"` by the runtime handler
+
+#### Scenario: Focus opens the dropdown for keyboard users
+- **WHEN** a keyboard user tabs to the chevron of a parent nav item
+- **WHEN** the user presses `↓` (Down arrow) or `Enter`
+- **THEN** the dropdown opens and focus moves to the first menu item
+
+#### Scenario: Keyboard navigation inside an open dropdown
+- **WHEN** a user presses `↓` while focus is on a menu item
+- **THEN** focus moves to the next menu item (wrapping at the end)
+- **WHEN** a user presses `↑`
+- **THEN** focus moves to the previous menu item (wrapping at the start)
+- **WHEN** a user presses `Enter` or `Space` on a menu item
+- **THEN** the link is activated and the menu closes
+
+#### Scenario: Escape closes the menu and returns focus
+- **WHEN** a dropdown is open with a menu item focused
+- **WHEN** the user presses `Escape`
+- **THEN** the dropdown closes
+- **THEN** focus returns to the chevron trigger
+
+#### Scenario: Tab advances out of the menu
+- **WHEN** a dropdown is open with a menu item focused
+- **WHEN** the user presses `Tab`
+- **THEN** the dropdown closes
+- **THEN** focus advances to the next top-level nav item
+
+#### Scenario: Click outside closes any open dropdown
+- **WHEN** a dropdown is open
+- **WHEN** the user clicks anywhere outside the dropdown subtree (and outside the chevron)
+- **THEN** the dropdown closes
+
+#### Scenario: Mobile renders inline expansion, not hover fly-out
+- **WHEN** the viewport matches `@media (hover: none) or (max-width: 768px)`
+- **WHEN** a user taps the parent of a nav item with children
+- **THEN** the dropdown expands inline below the parent (not absolutely positioned)
+- **THEN** the chevron rotates 180° via CSS transform
+- **THEN** child items are indented to indicate hierarchy
+
+#### Scenario: Recursive children render at depth ≥ 2
+- **WHEN** a `nav` block has a parent item whose child has its own `children` array
+- **THEN** the rendered HTML supports a second-level dropdown
+- **THEN** keyboard and pointer handling work the same way at every depth
+
+#### Scenario: Removing a parent in the editor prompts about its children
+- **WHEN** an admin clicks the remove affordance on a parent nav item that has children
+- **THEN** the editor prompts: `"Remove this item and its N children?"`
+- **WHEN** the admin confirms
+- **THEN** the parent and its entire subtree are removed from `config.items`

--- a/openspec/changes/nav-nested-children/tasks.md
+++ b/openspec/changes/nav-nested-children/tasks.md
@@ -1,0 +1,57 @@
+## Tasks
+
+### Phase 1: Renderer + CSS
+
+- [x] **1.1 Extend `NavItem` type with optional recursive `children`**
+  Add `children?: NavItem[]` to the `NavItem` interface in `src/lib/blocks.ts`. No schema migration needed.
+
+- [x] **1.2 Update `BLOCK_TYPES.nav.render` to emit dropdown HTML for items with children**
+  Render top-level items per the disclosure-button pattern: `<a class="nav-link">label</a>` (if `href`), `<button class="nav-chevron-toggle" aria-haspopup="menu" aria-expanded="false" aria-controls="...">▾</button>`, `<ul class="nav-dropdown" role="menu" hidden>` containing children. Recursively handle children-of-children. Generate stable `aria-controls` IDs from item label + position.
+
+- [x] **1.3 CSS: hover-open behind pointer media query**
+  New `public/css/nav-dropdown.css` (or extend `styles.css`). Inside `@media (hover: hover) and (pointer: fine)`: open dropdown on parent hover/focus, dropdown hover, and chevron hover/focus. Outside that query: dropdown is hidden by default; expanded only when `aria-expanded="true"`. Add fade-in/slide-down 150ms transition.
+
+- [x] **1.4 Mobile inline expansion**
+  Under `@media (hover: none) or (max-width: 768px)`: dropdown is `display: block` only when `aria-expanded="true"`, indented 1.5rem, no absolute positioning, no fly-out. Chevron rotates 180° via `transform` when expanded. Tap target = full row.
+
+### Phase 2: Keyboard a11y + click-outside
+
+- [x] **2.1 Hydrator: focus-open + chevron-click + state sync**
+  In the nav block's runtime hydrator (`bindNavDropdowns` in `src/lib/nav-dropdown.ts`): bind `click` on chevron to toggle `aria-expanded` and `[hidden]`. Bind `focusout` on the parent + dropdown subtree to keep `aria-expanded` consistent (close when focus exits the subtree). Per WAI-ARIA menu-button pattern, focus alone does not auto-open — only ↓/↑/Enter/Space on the trigger does.
+
+- [x] **2.2 Keyboard handlers for inside-menu navigation**
+  On menu open: focus first item. Bind `keydown` on the dropdown: `↓` next item (wrap), `↑` previous item (wrap), `Enter`/`Space` activate, `Escape` close + return focus to chevron, `Tab`/`Shift+Tab` close + advance/retreat to next/prev top-level item. `Home`/`End` jump to first/last.
+
+- [x] **2.3 Document-level click-outside handler (idempotent)**
+  Single `document.addEventListener('click', ...)` attached once (guarded by `window.__navDropdownClickBound`). Closes any open `.nav-dropdown` whose subtree doesn't contain the click target.
+
+- [x] **2.4 Idempotent re-binding on `astro:after-swap`**
+  `bindNavDropdowns` checks per-element flags (`dataset.navBound`, `dataset.chevronBound`, `dataset.navHoverWrapBound`); each handler bails out if already bound. Re-runs harmlessly on `astro:after-swap` and `wl-content-rendered`. Confirmed safe across SPA navigations.
+
+### Phase 3: Editor popover supports children
+
+- [x] **3.1 `NavEditor` popover: nested rows**
+  In the nav block edit popover (`src/components/AdminEditor.astro`): render children as indented sub-rows. "+ child" button per row creates a new child item with empty defaults. Removing a parent with children prompts confirmation: `"Remove this item and its N children?"`.
+
+- [x] **3.2 Drag-reorder within children scope**
+  The drag handler now uses dotted paths (`0.children.2`) so children form a sibling group scoped to their parent's `children` array. Dragover only accepts drops with matching `parentPath`, so a child cannot be dragged across parent scopes in v1. Cross-level drag is a follow-up.
+
+- [x] **3.3 Visual hierarchy in popover**
+  Children indent 1.5rem per depth via inline `margin-left`; vertical guide line on their left edge (`.admin-nav-guide`). Grandchildren indent another 1.5rem. Beyond depth 2, a row warning is shown: "Nested deeper than 2 levels — may not render well on mobile". Deeper nesting still saves to DB.
+
+### Phase 4: Tests + demo
+
+- [x] **4.1 Renderer unit tests**
+  `tests/integration/blocks-nav.test.ts`: nav with no children renders flat (existing behavior preserved); nav with children renders chevron + dropdown; nav with both `href` and `children` renders both `<a>` and chevron `<button>`; recursive children render second-level dropdowns; children visibility gating correctly drops admin/auth/feature-gated children and collapses parents that lose all children.
+
+- [x] **4.2 Keyboard navigation test**
+  Programmatic test using happy-dom in `tests/integration/blocks-nav.test.ts`: simulate focus on chevron, `ArrowDown` to open + focus first item, repeated `ArrowDown` to navigate (wraps at end), `Escape` to close + return focus to chevron, click outside to close. All assertions pass.
+
+- [x] **4.3 A11y attribute audit**
+  Test confirms: chevron is `<button>` (implicit role=button), `aria-haspopup="menu"`, `aria-expanded` toggles `false`/`true`, `aria-controls` resolves to the dropdown's id, dropdown has `role="menu"`, items have `role="menuitem"` inside `role="none"` `<li>` wrappers. Verified via axe-core (`wcag2a, wcag2aa, wcag21aa`) on the live silver-pines build: 0 violations, 19 passes.
+
+- [x] **4.4 Update one demo with a nested nav**
+  Updated `src/seeds/silver-pines.ts`: the `Resources` item gains three children (Documents, Forms, Calendar). Visually verified via Chrome MCP on the built `astro preview` of silver-pines: hover-open, chevron rotation, ArrowDown/Escape keyboard flow, click-outside dismissal, mouseleave close.
+
+- [x] **4.5 ODBC port verification — nested nav from source** *(deferred, depends on composable-layout Phase 7)*
+  Composable-layout Phase 7 (re-running `/copy-website` against ODBC) is currently blocked. Once that runs, the resulting site will exercise this change's renderer end-to-end. The renderer/CSS/hydrator/editor work in this change supports cascading menus at any depth (verified via depth-2 unit test in `blocks-nav.test.ts` and the silver-pines demo above). When Phase 7 unblocks, no additional work is expected on this change — the import simply needs `children: [...]` populated on `nav` block items.

--- a/public/css/admin-editing.css
+++ b/public/css/admin-editing.css
@@ -328,8 +328,9 @@
 }
 
 .admin-nav-item-row {
+  position: relative;
   display: grid;
-  grid-template-columns: 28px 1fr 1.5fr auto auto;
+  grid-template-columns: 28px 1fr 1.5fr auto auto auto;
   gap: 0.5rem;
   align-items: center;
   padding: 0.5rem;
@@ -338,6 +339,37 @@
   margin-bottom: 0.5rem;
   background: white;
   transition: box-shadow 150ms ease;
+}
+
+.admin-nav-children {
+  /* Grouping container for nested rows. Inheritance of margin-left on the
+     individual rows handles indentation; the container itself is structural. */
+  margin-bottom: 0.5rem;
+}
+
+.admin-nav-row-depth-1,
+.admin-nav-row-depth-2 {
+  background: var(--color-surface, #f8fafc);
+}
+
+.admin-nav-guide {
+  position: absolute;
+  left: -0.75rem;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--color-border, #e2e8f0);
+  border-radius: 2px;
+}
+
+.admin-nav-row-depth-1 .admin-nav-guide,
+.admin-nav-row-depth-2 .admin-nav-guide {
+  background: var(--color-primary, #3b82f6);
+  opacity: 0.4;
+}
+
+.admin-nav-depth-warn {
+  grid-column: 2 / -1;
 }
 
 .admin-nav-item-row:hover {

--- a/public/css/nav-dropdown.css
+++ b/public/css/nav-dropdown.css
@@ -1,0 +1,197 @@
+/* nav-dropdown.css — disclosure-button dropdowns for the `nav` block.
+   Member-facing chrome. Hover-open on pointer devices, focus-open via JS,
+   inline expansion on touch / narrow viewports. */
+
+.nav-item-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.nav-link.nav-parent,
+.nav-link.nav-parent-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: none;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.nav-link.nav-parent-button {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.nav-chevron-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+  padding: 0.25rem;
+  margin-left: -0.25rem;
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-chevron-toggle:hover {
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.nav-chevron {
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: transform 150ms ease;
+  display: inline-block;
+}
+
+.nav-chevron-toggle[aria-expanded="true"] .nav-chevron,
+.nav-link.nav-parent-button[aria-expanded="true"] .nav-chevron {
+  transform: rotate(180deg);
+}
+
+.nav-dropdown {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.nav-dropdown[hidden] {
+  display: none;
+}
+
+.nav-dropdown li {
+  list-style: none;
+}
+
+.nav-menuitem {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: var(--radius);
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-menuitem:hover,
+.nav-menuitem:focus {
+  background: var(--color-surface);
+  color: var(--color-text);
+  outline: none;
+}
+
+.nav-menuitem.active {
+  color: var(--color-primary);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+[data-theme="dark"] .nav-menuitem.active {
+  color: #fff;
+  background: rgba(99, 102, 241, 0.35);
+}
+
+/* Desktop / pointer devices: absolute-positioned fly-out, hover + focus open */
+@media (hover: hover) and (pointer: fine) {
+  .nav-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    min-width: 12rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    z-index: 50;
+    /* Zero gap between trigger and menu — cursor must not cross dead space. */
+    margin-top: 0;
+  }
+
+  .nav-dropdown-nested {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    margin-left: 0.25rem;
+  }
+
+  .nav-dropdown-parent {
+    position: relative;
+  }
+
+  /* Hover-open: keep open while cursor is on trigger or inside menu.
+     `.nav-suppress-hover` is added briefly when JS closes the menu (Escape /
+     click-outside) so the close feels immediate even while still hovering. */
+  .nav-item-wrap:not(.nav-suppress-hover):hover > .nav-dropdown,
+  .nav-item-wrap:not(.nav-suppress-hover):focus-within > .nav-dropdown,
+  .nav-dropdown-parent:not(.nav-suppress-hover):hover > .nav-dropdown-nested,
+  .nav-dropdown-parent:not(.nav-suppress-hover):focus-within > .nav-dropdown-nested {
+    display: block;
+  }
+
+  /* JS-controlled aria-expanded="true" also forces open (covers focus + click). */
+  .nav-dropdown:not([hidden]) {
+    display: block;
+    animation: nav-dropdown-fade 150ms ease-out;
+  }
+
+  @keyframes nav-dropdown-fade {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+}
+
+/* Focus ring for keyboard users on all triggers + menuitems */
+.nav-chevron-toggle:focus-visible,
+.nav-link.nav-parent-button:focus-visible,
+.nav-menuitem:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Mobile / no-hover: inline accordion expansion under the hamburger */
+@media (hover: none), (max-width: 768px) {
+  .nav-item-wrap {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav-item-wrap > .nav-link.nav-parent,
+  .nav-item-wrap > .nav-link.nav-parent-button {
+    width: auto;
+    flex: 1 1 auto;
+  }
+
+  .nav-dropdown {
+    position: static;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding-left: 1.5rem;
+    width: 100%;
+  }
+
+  .nav-dropdown-nested {
+    padding-left: 1.5rem;
+  }
+
+  .nav-dropdown[hidden] {
+    display: none;
+  }
+
+  .nav-dropdown:not([hidden]) {
+    display: block;
+  }
+
+  .nav-menuitem {
+    padding: 0.625rem 0.75rem;
+  }
+}

--- a/src/components/AdminEditor.astro
+++ b/src/components/AdminEditor.astro
@@ -594,65 +594,170 @@
     document.body.appendChild(backdrop);
     document.body.appendChild(panel);
 
-    function renderItems() {
-      const container = panel.querySelector('#nav-editor-items')!;
-      container.innerHTML = navItems.map((item: any, i: number) => `
-        <div class="admin-nav-item-row" data-idx="${i}" draggable="true">
+    // Resolve a navItem object given its dotted path: e.g. "0" → navItems[0],
+    // "0.children.2" → navItems[0].children[2].
+    function getByPath(path: string): any {
+      const parts = path.split('.');
+      let cur: any = { children: navItems };
+      for (let i = 0; i < parts.length; i++) {
+        const key = parts[i];
+        if (key === 'children') {
+          cur = cur.children;
+        } else {
+          const idx = parseInt(key, 10);
+          cur = cur[idx];
+        }
+      }
+      return cur;
+    }
+    // Resolve the parent array (the array that contains the indexed item).
+    function getParentArray(path: string): { arr: any[]; idx: number } {
+      const parts = path.split('.');
+      const lastIdx = parseInt(parts[parts.length - 1], 10);
+      const parentParts = parts.slice(0, -1);
+      let cur: any = { children: navItems };
+      for (let i = 0; i < parentParts.length; i++) {
+        const key = parentParts[i];
+        if (key === 'children') {
+          cur = cur.children;
+        } else {
+          const idx = parseInt(key, 10);
+          cur = cur[idx];
+        }
+      }
+      // cur is the parent object. The array is cur (if we went into children/navItems).
+      const arr = Array.isArray(cur) ? cur : cur.children;
+      return { arr, idx: lastIdx };
+    }
+    function countDescendants(item: any): number {
+      const kids = Array.isArray(item.children) ? item.children : [];
+      let n = kids.length;
+      for (const k of kids) n += countDescendants(k);
+      return n;
+    }
+    function renderRow(item: any, path: string, depth: number): string {
+      const tooDeep = depth >= 2
+        ? `<div class="admin-nav-depth-warn" style="font-size:0.75rem;color:var(--color-warning,#b08000);margin:0.125rem 0 0.25rem 0">Nested deeper than 2 levels — may not render well on mobile</div>`
+        : '';
+      const childCount = Array.isArray(item.children) ? item.children.length : 0;
+      const guide = depth > 0 ? '<div class="admin-nav-guide" aria-hidden="true"></div>' : '';
+      const childRows = (Array.isArray(item.children) ? item.children : [])
+        .map((c: any, ci: number) => renderRow(c, `${path}.children.${ci}`, depth + 1))
+        .join('');
+      const childContainer = childCount > 0
+        ? `<div class="admin-nav-children" data-children-of="${path}">${childRows}</div>`
+        : '';
+      return `
+        <div class="admin-nav-item-row admin-nav-row-depth-${depth}" data-path="${path}" data-depth="${depth}" draggable="true" style="margin-left:${depth * 1.5}rem">
+          ${guide}
           <div class="drag-handle" title="Drag to reorder">&#9776;</div>
           <input type="text" value="${esc(item.label || '')}" data-field="label" placeholder="Label">
-          <input type="text" value="${esc(item.href || '')}" data-field="href" placeholder="/page.html">
+          <input type="text" value="${esc(item.href || '')}" data-field="href" placeholder="/page.html (optional if has children)">
           <select data-field="visibility">
             <option value="public"${item.public ? ' selected' : ''}>Public</option>
             <option value="auth"${item.auth ? ' selected' : ''}>Members</option>
             <option value="admin"${item.admin ? ' selected' : ''}>Admin</option>
           </select>
+          <button class="btn btn-secondary btn-sm" data-add-child="${path}" title="Add child item">+ child</button>
           <button class="remove-btn" title="Remove">&times;</button>
+          ${tooDeep}
         </div>
-      `).join('');
+        ${childContainer}
+      `;
+    }
+
+    function renderItems() {
+      const container = panel.querySelector('#nav-editor-items')!;
+      container.innerHTML = navItems
+        .map((item: any, i: number) => renderRow(item, String(i), 0))
+        .join('');
 
       // Bind row events
       container.querySelectorAll('.admin-nav-item-row').forEach((row) => {
-        const idx = parseInt((row as HTMLElement).dataset.idx!);
+        const path = (row as HTMLElement).dataset.path!;
 
         // Input changes
-        row.querySelectorAll('input, select').forEach((input) => {
+        row.querySelectorAll(':scope > input, :scope > select').forEach((input) => {
           input.addEventListener('change', () => {
             const field = (input as HTMLElement).dataset.field!;
+            const item = getByPath(path);
+            if (!item) return;
             if (field === 'visibility') {
               const val = (input as HTMLSelectElement).value;
-              delete navItems[idx].public;
-              delete navItems[idx].auth;
-              delete navItems[idx].admin;
-              if (val === 'public') navItems[idx].public = true;
-              else if (val === 'auth') navItems[idx].auth = true;
-              else if (val === 'admin') navItems[idx].admin = true;
+              delete item.public;
+              delete item.auth;
+              delete item.admin;
+              if (val === 'public') item.public = true;
+              else if (val === 'auth') item.auth = true;
+              else if (val === 'admin') item.admin = true;
             } else {
-              navItems[idx][field] = (input as HTMLInputElement).value;
+              item[field] = (input as HTMLInputElement).value;
             }
           });
         });
 
-        // Remove
-        row.querySelector('.remove-btn')?.addEventListener('click', () => {
-          navItems.splice(idx, 1);
+        // Add child
+        row.querySelector(':scope > [data-add-child]')?.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const item = getByPath(path);
+          if (!item) return;
+          if (!Array.isArray(item.children)) item.children = [];
+          item.children.push({ label: 'New Link', href: '/', public: true });
           renderItems();
         });
 
-        // Drag reorder
+        // Remove (with subtree confirmation if children present)
+        row.querySelector(':scope > .remove-btn')?.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const { arr, idx } = getParentArray(path);
+          const item = arr[idx];
+          if (!item) return;
+          const descendants = countDescendants(item);
+          if (descendants > 0) {
+            const word = descendants === 1 ? 'child' : 'children';
+            if (!confirm(`Remove this item and its ${descendants} ${word}?`)) return;
+          }
+          arr.splice(idx, 1);
+          renderItems();
+        });
+
+        // Drag reorder — scoped to the same parent array.
         row.addEventListener('dragstart', (e) => {
-          (e as DragEvent).dataTransfer!.setData('text/plain', String(idx));
+          (e as DragEvent).dataTransfer!.setData('text/plain', path);
+          (e as DragEvent).dataTransfer!.effectAllowed = 'move';
           (row as HTMLElement).style.opacity = '0.4';
         });
         row.addEventListener('dragend', () => {
           (row as HTMLElement).style.opacity = '1';
         });
-        row.addEventListener('dragover', (e) => { e.preventDefault(); });
+        row.addEventListener('dragover', (e) => {
+          const dt = (e as DragEvent).dataTransfer;
+          if (!dt) return;
+          const fromPath = dt.getData('text/plain') || '';
+          // Only accept drops within the same parent scope.
+          const fromParent = fromPath.split('.').slice(0, -1).join('.');
+          const toParent = path.split('.').slice(0, -1).join('.');
+          if (fromParent === toParent) {
+            e.preventDefault();
+            dt.dropEffect = 'move';
+          }
+        });
         row.addEventListener('drop', (e) => {
+          const dt = (e as DragEvent).dataTransfer;
+          if (!dt) return;
+          const fromPath = dt.getData('text/plain');
+          if (!fromPath || fromPath === path) return;
+          const fromParent = fromPath.split('.').slice(0, -1).join('.');
+          const toParent = path.split('.').slice(0, -1).join('.');
+          if (fromParent !== toParent) return;
           e.preventDefault();
-          const fromIdx = parseInt((e as DragEvent).dataTransfer!.getData('text/plain'));
-          if (fromIdx === idx) return;
-          const [moved] = navItems.splice(fromIdx, 1);
-          navItems.splice(idx, 0, moved);
+          const fromIdx = parseInt(fromPath.split('.').pop()!, 10);
+          const toIdx = parseInt(path.split('.').pop()!, 10);
+          const fromCtx = getParentArray(fromPath);
+          const [moved] = fromCtx.arr.splice(fromIdx, 1);
+          fromCtx.arr.splice(toIdx, 0, moved);
           renderItems();
         });
       });
@@ -660,7 +765,7 @@
 
     renderItems();
 
-    // Add item
+    // Add top-level item
     panel.querySelector('#nav-editor-add')?.addEventListener('click', () => {
       navItems.push({ label: 'New Link', href: '/', public: true });
       renderItems();

--- a/src/layouts/Portal.astro
+++ b/src/layouts/Portal.astro
@@ -72,6 +72,7 @@ const footerHtml = seedAsSections
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/nav-dropdown.css">
   <link rel="stylesheet" href="/css/a11y.css">
   <ClientRouter />
   <script is:inline>
@@ -197,6 +198,14 @@ const footerHtml = seedAsSections
 
     initAnimations();
     document.addEventListener('astro:after-swap', initAnimations);
+  </script>
+
+  <script>
+    import { bindNavDropdowns } from '../lib/nav-dropdown';
+    function bind() { bindNavDropdowns(); }
+    bind();
+    document.addEventListener('astro:after-swap', bind);
+    document.addEventListener('wl-content-rendered', bind);
   </script>
 
   <div id="wl-sr-live" class="wl-sr-live" aria-live="polite" aria-atomic="true"></div>

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -483,6 +483,17 @@ const ACTIVITY_FEED: BlockType = {
 
 // --- Header chrome renderers ---
 
+export interface NavItem {
+  label: string;
+  href?: string;
+  icon?: string;
+  public?: boolean;
+  auth?: boolean;
+  feature?: string;
+  admin?: boolean;
+  children?: NavItem[];
+}
+
 const NAV_LABEL_KEYS: Record<string, string> = {
   Home: 'nav.home',
   Inicio: 'nav.home',
@@ -512,6 +523,62 @@ const NAV_LABEL_KEYS: Record<string, string> = {
 
 export { NAV_LABEL_KEYS };
 
+function navItemVisible(item: NavItem, ctx: BlockRenderContext): boolean {
+  if (item.feature && ctx.isFeatureEnabled && !ctx.isFeatureEnabled(item.feature)) return false;
+  if (item.auth && !ctx.authenticated) return false;
+  if (item.admin && ctx.role !== 'admin') return false;
+  return true;
+}
+
+function navMenuId(item: NavItem, path: string): string {
+  const slug = String(item.label || 'menu')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'menu';
+  return `nav-menu-${slug}-${path}`;
+}
+
+function renderNavChildren(children: NavItem[], ctx: BlockRenderContext, parentPath: string, depth: number): string {
+  const visible = children.filter((c) => navItemVisible(c, ctx));
+  if (visible.length === 0) return '';
+  const items = visible
+    .map((child, i) => renderNavChild(child, ctx, `${parentPath}-${i}`, depth))
+    .join('');
+  return items;
+}
+
+function renderNavChild(item: NavItem, ctx: BlockRenderContext, path: string, depth: number): string {
+  const hasKids = Array.isArray(item.children) && item.children.length > 0
+    && item.children.some((c) => navItemVisible(c, ctx));
+  const href = item.href || '#';
+  const active = isPageActive(href, ctx.currentPath) ? ' active' : '';
+  if (!hasKids) {
+    return `<li role="none"><a role="menuitem" class="nav-menuitem${active}" href="${escAttr(href)}">${escHtml(item.label)}</a></li>`;
+  }
+  const menuId = navMenuId(item, path);
+  const childrenHtml = renderNavChildren(item.children!, ctx, path, depth + 1);
+  const linkPart = item.href
+    ? `<a role="menuitem" class="nav-menuitem${active}" href="${escAttr(href)}">${escHtml(item.label)}</a>`
+    : `<span class="nav-menuitem nav-menuitem-parent">${escHtml(item.label)}</span>`;
+  return `<li role="none" class="nav-dropdown-parent">${linkPart}<button class="nav-chevron-toggle" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="${menuId}" aria-label="Open ${escAttr(item.label)} submenu"><span class="nav-chevron" aria-hidden="true">▾</span></button><ul class="nav-dropdown nav-dropdown-nested" role="menu" id="${menuId}" hidden>${childrenHtml}</ul></li>`;
+}
+
+function renderNavTopItem(item: NavItem, ctx: BlockRenderContext, idx: number): string {
+  const hasKids = Array.isArray(item.children) && item.children.length > 0
+    && item.children.some((c) => navItemVisible(c, ctx));
+  const href = item.href || '';
+  const active = isPageActive(href, ctx.currentPath) ? ' active' : '';
+  if (!hasKids) {
+    return `<a class="nav-link${active}" href="${escAttr(href)}">${escHtml(item.label)}</a>`;
+  }
+  const menuId = navMenuId(item, `top-${idx}`);
+  const childrenHtml = renderNavChildren(item.children!, ctx, `top-${idx}`, 1);
+  const trigger = item.href
+    ? `<a class="nav-link nav-parent${active}" href="${escAttr(href)}">${escHtml(item.label)}</a><button class="nav-chevron-toggle" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="${menuId}" aria-label="Open ${escAttr(item.label)} submenu"><span class="nav-chevron" aria-hidden="true">▾</span></button>`
+    : `<button class="nav-link nav-parent nav-parent-button${active}" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="${menuId}">${escHtml(item.label)}<span class="nav-chevron" aria-hidden="true">▾</span></button>`;
+  return `<div class="nav-item-wrap">${trigger}<ul class="nav-dropdown" role="menu" id="${menuId}" hidden>${childrenHtml}</ul></div>`;
+}
+
 const NAV: BlockType = {
   label: 'Navigation',
   icon: '\u{1F9ED}',
@@ -524,19 +591,9 @@ const NAV: BlockType = {
   },
   render(section, ctx) {
     const cfg = section.config || {};
-    const items: any[] = cfg.items || [];
-    const visible = items.filter((item: any) => {
-      if (item.feature && ctx.isFeatureEnabled && !ctx.isFeatureEnabled(item.feature)) return false;
-      if (item.auth && !ctx.authenticated) return false;
-      if (item.admin && ctx.role !== 'admin') return false;
-      return true;
-    });
-    const links = visible
-      .map((item: any) => {
-        const active = isPageActive(item.href, ctx.currentPath) ? ' active' : '';
-        return `<a class="nav-link${active}" href="${escAttr(item.href)}">${escHtml(item.label)}</a>`;
-      })
-      .join('');
+    const items: NavItem[] = cfg.items || [];
+    const visible = items.filter((item) => navItemVisible(item, ctx));
+    const links = visible.map((item, i) => renderNavTopItem(item, ctx, i)).join('');
     const sid = section.id;
     const editAttrs = sid != null && ctx.admin
       ? ` data-block-id="${sid}" data-block-type="nav"`

--- a/src/lib/nav-dropdown.ts
+++ b/src/lib/nav-dropdown.ts
@@ -1,0 +1,309 @@
+// nav-dropdown.ts — runtime behavior for the `nav` block's dropdowns.
+//
+// Loaded once and bound at first call. Re-bind across SPA navigations is
+// idempotent: `el.dataset.navBound === 'true'` and `window.__navDropdownClickBound === true`
+// guard against double-attach.
+//
+// Wires:
+//   • chevron click → toggle aria-expanded + [hidden]
+//   • focusin/focusout → keep aria-expanded in sync with focus subtree
+//   • keydown on dropdown → ↑/↓ navigate items, Enter/Space activate,
+//     Escape closes + returns focus, Tab/Shift+Tab close + advance
+//   • document-level click → close any open dropdown when click is outside
+//
+// Touch / no-hover viewports: chevron click toggles inline expansion; focus
+// management is identical (focus-open works on every modality).
+
+const BOUND_FLAG = 'navBound';
+
+function getFocusableInMenu(menu: HTMLElement): HTMLElement[] {
+  // Items focusable via arrow keys: top-level menuitems + immediate chevron toggles.
+  // Selector intentionally avoids `:scope` (not supported by happy-dom) — we
+  // iterate direct <li> children and pick out each row's anchor + chevron.
+  const out: HTMLElement[] = [];
+  for (const child of Array.from(menu.children)) {
+    if (child.tagName.toLowerCase() !== 'li') continue;
+    for (const grand of Array.from(child.children)) {
+      const tag = grand.tagName.toLowerCase();
+      if (tag === 'a' && grand.getAttribute('role') === 'menuitem') {
+        out.push(grand as HTMLElement);
+      } else if (tag === 'button' && (grand as HTMLElement).classList.contains('nav-chevron-toggle')) {
+        out.push(grand as HTMLElement);
+      }
+    }
+  }
+  return out;
+}
+
+function directChildren(parent: HTMLElement, selector: string): HTMLElement[] {
+  return Array.from(parent.children).filter((c) => c.matches(selector)) as HTMLElement[];
+}
+
+function findControlled(toggle: HTMLElement): HTMLElement | null {
+  const id = toggle.getAttribute('aria-controls');
+  if (!id) return null;
+  return document.getElementById(id);
+}
+
+function findTrigger(menu: HTMLElement): HTMLElement | null {
+  // Triggers always sit immediately before the menu in the DOM.
+  // For top-level menus, the trigger may be a chevron-toggle button OR a parent button.
+  // For nested menus, the trigger is a chevron-toggle button inside the parent <li>.
+  const id = menu.id;
+  if (!id) return null;
+  return document.querySelector<HTMLElement>(`[aria-controls="${id}"]`);
+}
+
+function openMenu(menu: HTMLElement, focusFirst: 'first' | 'last' | null = 'first'): void {
+  if (!menu.hasAttribute('hidden') && focusFirst === null) return;
+  menu.removeAttribute('hidden');
+  const trigger = findTrigger(menu);
+  if (trigger) trigger.setAttribute('aria-expanded', 'true');
+  if (focusFirst) {
+    const items = getFocusableInMenu(menu);
+    const target = focusFirst === 'first' ? items[0] : items[items.length - 1];
+    target?.focus();
+  }
+}
+
+function closeMenu(menu: HTMLElement, returnFocus = false): void {
+  if (menu.hasAttribute('hidden')) return;
+  menu.setAttribute('hidden', '');
+  const trigger = findTrigger(menu);
+  if (trigger) trigger.setAttribute('aria-expanded', 'false');
+  // Recursively close any nested open submenus.
+  menu.querySelectorAll<HTMLElement>('.nav-dropdown-nested:not([hidden])').forEach((nested) => {
+    nested.setAttribute('hidden', '');
+    const nestedTrigger = findTrigger(nested);
+    if (nestedTrigger) nestedTrigger.setAttribute('aria-expanded', 'false');
+  });
+  // The CSS hover-open rule would otherwise keep the menu visible until the
+  // user moves their cursor off the trigger. Suppress hover-open until next
+  // mouseleave so Escape / click-outside closes feel immediate.
+  const wrap = menu.parentElement;
+  if (wrap?.classList.contains('nav-item-wrap') || wrap?.classList.contains('nav-dropdown-parent')) {
+    wrap.classList.add('nav-suppress-hover');
+    const cleanup = () => {
+      wrap.classList.remove('nav-suppress-hover');
+      wrap.removeEventListener('mouseleave', cleanup);
+    };
+    wrap.addEventListener('mouseleave', cleanup);
+  }
+  if (returnFocus && trigger) trigger.focus();
+}
+
+function closeAllOpenMenus(except?: HTMLElement): void {
+  document.querySelectorAll<HTMLElement>('.nav-dropdown:not([hidden])').forEach((menu) => {
+    if (except && (menu === except || except.contains(menu) || menu.contains(except))) return;
+    closeMenu(menu);
+  });
+}
+
+function focusSibling(current: HTMLElement, dir: 1 | -1, items: HTMLElement[]): void {
+  const idx = items.indexOf(current);
+  if (idx === -1) return;
+  const next = (idx + dir + items.length) % items.length;
+  items[next]?.focus();
+}
+
+function bindChevronToggles(root: HTMLElement): void {
+  root.querySelectorAll<HTMLElement>('.nav-chevron-toggle, .nav-link.nav-parent-button').forEach((trigger) => {
+    if (trigger.dataset.chevronBound === 'true') return;
+    trigger.dataset.chevronBound = 'true';
+    trigger.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const menu = findControlled(trigger);
+      if (!menu) return;
+      const wasOpen = !menu.hasAttribute('hidden');
+      // Close sibling dropdowns at the same level for cleanliness.
+      const parentList = menu.parentElement?.parentElement;
+      if (parentList) {
+        // Iterate direct children to find sibling .nav-dropdowns (avoids :scope).
+        Array.from(parentList.children).forEach((sibling) => {
+          if (sibling === menu.parentElement) return;
+          const otherMenu = sibling.querySelector(':scope > .nav-dropdown') as HTMLElement | null
+            || (sibling.tagName.toLowerCase() === 'li'
+              ? Array.from(sibling.children).find((c) => c.classList.contains('nav-dropdown')) as HTMLElement | undefined
+              : undefined);
+          if (otherMenu && otherMenu !== menu && !otherMenu.hasAttribute('hidden')) {
+            closeMenu(otherMenu);
+          }
+        });
+      }
+      if (wasOpen) closeMenu(menu);
+      else openMenu(menu, 'first');
+    });
+  });
+}
+
+function bindKeyboard(root: HTMLElement): void {
+  if (root.dataset.navKeyboardBound === 'true') return;
+  root.dataset.navKeyboardBound = 'true';
+
+  root.addEventListener('keydown', (e: KeyboardEvent) => {
+    const target = e.target as HTMLElement;
+    if (!target) return;
+
+    const isTrigger = target.classList.contains('nav-chevron-toggle')
+      || target.classList.contains('nav-parent-button');
+    const insideMenu = target.closest('.nav-dropdown') as HTMLElement | null;
+
+    if (isTrigger) {
+      const menu = findControlled(target);
+      if (!menu) return;
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(menu, 'first');
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(menu, 'last');
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeMenu(menu);
+      }
+      return;
+    }
+
+    if (insideMenu) {
+      const items = getFocusableInMenu(insideMenu);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        focusSibling(target, 1, items);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        focusSibling(target, -1, items);
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        items[0]?.focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        items[items.length - 1]?.focus();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeMenu(insideMenu, true);
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        if (target.tagName.toLowerCase() === 'a') {
+          // Native anchor activation; menu closes after navigation. Close
+          // proactively for SPA-style links.
+          if (e.key === ' ') {
+            e.preventDefault();
+            (target as HTMLAnchorElement).click();
+          }
+          // Close all menus along the chain.
+          closeAllOpenMenus();
+        } else if (target.classList.contains('nav-chevron-toggle')) {
+          // Already handled above as trigger.
+        }
+      } else if (e.key === 'Tab') {
+        // Close current menu when tabbing out — let native focus order continue.
+        closeMenu(insideMenu);
+      }
+    }
+  });
+}
+
+function bindFocusSync(root: HTMLElement): void {
+  if (root.dataset.navFocusBound === 'true') return;
+  root.dataset.navFocusBound = 'true';
+
+  // Per WAI-ARIA menu-button pattern, focus alone does NOT open the menu —
+  // only ArrowDown/ArrowUp/Enter/Space on the trigger does (handled in
+  // bindKeyboard). focusout DOES close the menu when focus leaves the wrap
+  // subtree (e.g., user tabbed away).
+  root.addEventListener('focusout', (e) => {
+    const t = e.target as HTMLElement;
+    if (!t) return;
+    const wrap = t.closest('.nav-item-wrap') as HTMLElement | null;
+    if (!wrap) return;
+    // Defer to allow focusin elsewhere to fire first.
+    setTimeout(() => {
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || !wrap.contains(active)) {
+        const menu = directChildren(wrap, '.nav-dropdown')[0] || null;
+        if (menu && !menu.hasAttribute('hidden')) closeMenu(menu);
+      }
+    }, 0);
+  });
+}
+
+function bindHoverSync(root: HTMLElement): void {
+  if (root.dataset.navHoverBound === 'true') return;
+  root.dataset.navHoverBound = 'true';
+
+  // CSS handles visual hover-open via the @media (hover) query, but we still
+  // need to keep `aria-expanded` in sync with hover state for assistive tech.
+  root.querySelectorAll<HTMLElement>('.nav-item-wrap, .nav-dropdown-parent').forEach((wrap) => {
+    if ((wrap as any).dataset.navHoverWrapBound === 'true') return;
+    (wrap as any).dataset.navHoverWrapBound = 'true';
+    wrap.addEventListener('mouseenter', () => {
+      const menu = directChildren(wrap, '.nav-dropdown')[0] || null;
+      if (!menu) return;
+      const trigger = findTrigger(menu);
+      if (trigger) trigger.setAttribute('aria-expanded', 'true');
+      menu.removeAttribute('hidden');
+    });
+    wrap.addEventListener('mouseleave', () => {
+      const menu = directChildren(wrap, '.nav-dropdown')[0] || null;
+      if (!menu) return;
+      // Don't close if focus is still inside the menu (keyboard user).
+      if (wrap.contains(document.activeElement)) return;
+      const trigger = findTrigger(menu);
+      if (trigger) trigger.setAttribute('aria-expanded', 'false');
+      menu.setAttribute('hidden', '');
+    });
+  });
+}
+
+function bindClickOutside(): void {
+  if ((window as any).__navDropdownClickBound === true) return;
+  (window as any).__navDropdownClickBound = true;
+  document.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    document.querySelectorAll<HTMLElement>('.nav-dropdown:not([hidden])').forEach((menu) => {
+      const trigger = findTrigger(menu);
+      const inMenu = menu.contains(target);
+      const inTrigger = trigger ? trigger.contains(target) : false;
+      // Also keep open if click is inside the same nav-item-wrap (covers
+      // clicks on the parent <a class="nav-link nav-parent"> that opens
+      // alongside its chevron).
+      const wrap = menu.parentElement?.classList.contains('nav-item-wrap')
+        ? (menu.parentElement as HTMLElement)
+        : null;
+      const inWrap = wrap ? wrap.contains(target) : false;
+      if (!inMenu && !inTrigger && !inWrap) closeMenu(menu);
+    });
+  });
+}
+
+export function bindNavDropdowns(navRoot?: HTMLElement | null): void {
+  const root = navRoot || (document.getElementById('nav-links') as HTMLElement | null);
+  if (!root) return;
+  if (root.dataset[BOUND_FLAG] === 'true') {
+    // Re-scan: new nav items may have appeared via SPA re-render. The flags on
+    // individual elements (chevronBound / focusBound) keep this idempotent.
+    bindChevronToggles(root);
+    bindHoverSync(root);
+    bindClickOutside();
+    return;
+  }
+  root.dataset[BOUND_FLAG] = 'true';
+  bindChevronToggles(root);
+  bindKeyboard(root);
+  bindFocusSync(root);
+  bindHoverSync(root);
+  bindClickOutside();
+}
+
+export function rebindNavDropdowns(): void {
+  // Called after SPA swap or section re-render. Resets per-element flags so a
+  // freshly-rendered nav block picks up the bindings.
+  const root = document.getElementById('nav-links') as HTMLElement | null;
+  if (!root) return;
+  // The root-level flags persist (the listeners are on the root element which
+  // doesn't get replaced — only innerHTML changes). For inner triggers we
+  // already rely on per-element `dataset.chevronBound` to gate.
+  bindChevronToggles(root);
+  bindHoverSync(root);
+}

--- a/src/seeds/silver-pines.ts
+++ b/src/seeds/silver-pines.ts
@@ -6,7 +6,17 @@ const SILVER_PINES_NAV = [
   { label: 'Getting Here', href: '/page.html?slug=getting-here', icon: 'map', public: true },
   { label: 'Our Members', href: '/directory.html', icon: 'users', public: true },
   { label: 'Events', href: '/events.html', icon: 'calendar', feature: 'feature_events' },
-  { label: 'Resources', href: '/resources.html', icon: 'book-open', feature: 'feature_resources' },
+  {
+    label: 'Resources',
+    href: '/resources.html',
+    icon: 'book-open',
+    feature: 'feature_resources',
+    children: [
+      { label: 'Documents', href: '/resources.html#documents', public: true },
+      { label: 'Forms', href: '/resources.html#forms', public: true },
+      { label: 'Calendar', href: '/resources.html#calendar', public: true },
+    ],
+  },
   { label: 'Forum', href: '/forum.html', icon: 'message-circle', feature: 'feature_forum' },
   { label: 'Committees', href: '/committees.html', icon: 'briefcase', feature: 'feature_committees' },
   { label: 'Announcements', href: '/#announcements-section', icon: 'bell', public: true },

--- a/tests/integration/blocks-nav.test.ts
+++ b/tests/integration/blocks-nav.test.ts
@@ -160,9 +160,7 @@ describe('nav block — nested children', () => {
 
 describe('nav block — ARIA attributes', () => {
   it('chevron carries role=button (implicit), aria-haspopup=menu, aria-expanded=false', () => {
-    const section = makeSection([
-      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
-    ]);
+    const section = makeSection([{ label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] }]);
     const html = BLOCK_TYPES.nav.render(section, baseCtx);
     const root = renderInto(`<div>${html}</div>`);
     const chevron = root.querySelector('.nav-chevron-toggle, .nav-parent-button') as HTMLElement;
@@ -173,9 +171,7 @@ describe('nav block — ARIA attributes', () => {
   });
 
   it('dropdown carries role=menu and items have role=menuitem with role=none on <li>', () => {
-    const section = makeSection([
-      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
-    ]);
+    const section = makeSection([{ label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] }]);
     const html = BLOCK_TYPES.nav.render(section, baseCtx);
     const root = renderInto(`<div>${html}</div>`);
     const ul = root.querySelector('.nav-dropdown') as HTMLElement;
@@ -187,13 +183,11 @@ describe('nav block — ARIA attributes', () => {
   });
 
   it('aria-controls links chevron to its own dropdown id', () => {
-    const section = makeSection([
-      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
-    ]);
+    const section = makeSection([{ label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] }]);
     const html = BLOCK_TYPES.nav.render(section, baseCtx);
     const root = renderInto(`<div>${html}</div>`);
     const chevron = root.querySelector('.nav-chevron-toggle, .nav-parent-button') as HTMLElement;
-    const controls = chevron.getAttribute('aria-controls')!;
+    const controls = chevron.getAttribute('aria-controls') ?? '';
     expect(controls).toBeTruthy();
     const menu = root.querySelector(`#${CSS.escape(controls)}`);
     expect(menu).toBeTruthy();
@@ -231,7 +225,7 @@ describe('nav block — runtime keyboard + click', () => {
 
   it('clicking the chevron opens the dropdown (sets aria-expanded=true, removes [hidden])', () => {
     const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
     expect(menu.hasAttribute('hidden')).toBe(true);
     chevron.click();
     expect(menu.hasAttribute('hidden')).toBe(false);
@@ -242,7 +236,7 @@ describe('nav block — runtime keyboard + click', () => {
     const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
     chevron.focus();
     chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
     expect(menu.hasAttribute('hidden')).toBe(false);
     const items = menu.querySelectorAll('a[role="menuitem"]');
     expect(document.activeElement).toBe(items[0]);
@@ -252,7 +246,7 @@ describe('nav block — runtime keyboard + click', () => {
     const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
     chevron.focus();
     chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
     const items = Array.from(menu.querySelectorAll<HTMLElement>('a[role="menuitem"]'));
     items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
     expect(document.activeElement).toBe(items[1]);
@@ -267,8 +261,8 @@ describe('nav block — runtime keyboard + click', () => {
     const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
     chevron.focus();
     chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
-    const firstItem = menu.querySelector<HTMLElement>('a[role="menuitem"]')!;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
+    const firstItem = menu.querySelector<HTMLElement>('a[role="menuitem"]') as HTMLElement;
     firstItem.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(menu.hasAttribute('hidden')).toBe(true);
     expect(document.activeElement).toBe(chevron);
@@ -277,7 +271,7 @@ describe('nav block — runtime keyboard + click', () => {
   it('clicking outside the dropdown closes it', () => {
     const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
     chevron.click();
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
     expect(menu.hasAttribute('hidden')).toBe(false);
     // Click elsewhere.
     const outside = document.createElement('button');
@@ -292,7 +286,7 @@ describe('nav block — runtime keyboard + click', () => {
     bindNavDropdowns(host);
     bindNavDropdowns(host);
     chevron.click();
-    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls') ?? '') as HTMLElement;
     // After a single click, menu should be open (toggled once, not three times).
     expect(menu.hasAttribute('hidden')).toBe(false);
     chevron.click();

--- a/tests/integration/blocks-nav.test.ts
+++ b/tests/integration/blocks-nav.test.ts
@@ -1,0 +1,301 @@
+// blocks-nav.test.ts — coverage for the `nav` block-type's renderer + hydrator.
+// Verifies flat behavior, nested children, ARIA pattern, keyboard handlers,
+// and click-outside dismissal.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BLOCK_TYPES, type BlockRenderContext, type Section } from '../../src/lib/blocks';
+import { bindNavDropdowns } from '../../src/lib/nav-dropdown';
+
+const baseCtx: BlockRenderContext = {
+  admin: false,
+  locale: 'en',
+  authenticated: false,
+  role: null,
+  isFeatureEnabled: () => true,
+  currentPath: '/',
+};
+
+function makeSection(items: any[]): Section {
+  return {
+    page_slug: '*',
+    zone: 'header',
+    scope: 'global',
+    section_type: 'nav',
+    config: { items },
+    position: 1,
+  };
+}
+
+function renderInto(html: string): HTMLElement {
+  const wrap = document.createElement('div');
+  // Wrap as Portal does — `nav#zone-header > .container > <html>`.
+  wrap.innerHTML = html;
+  return wrap.firstElementChild as HTMLElement;
+}
+
+describe('nav block — flat behavior preserved', () => {
+  it('renders flat items as plain anchors', () => {
+    const section = makeSection([
+      { label: 'Home', href: '/', public: true },
+      { label: 'About', href: '/about', public: true },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toContain('<a class="nav-link"');
+    expect(html).toContain('href="/"');
+    expect(html).toContain('>Home<');
+    expect(html).toContain('>About<');
+    expect(html).not.toContain('nav-chevron-toggle');
+    expect(html).not.toContain('nav-dropdown');
+  });
+
+  it('respects feature/auth/admin gates for top-level items', () => {
+    const section = makeSection([
+      { label: 'Public', href: '/', public: true },
+      { label: 'Members', href: '/m', auth: true },
+      { label: 'Admin', href: '/a', admin: true },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toContain('Public');
+    expect(html).not.toContain('Members');
+    expect(html).not.toContain('Admin');
+  });
+});
+
+describe('nav block — nested children', () => {
+  it('renders chevron + dropdown for items with children', () => {
+    const section = makeSection([
+      {
+        label: 'Marina',
+        children: [
+          { label: 'Layout', href: '/marina/layout' },
+          { label: 'How-To', href: '/marina/howto' },
+        ],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('role="menu"');
+    expect(html).toContain('hidden');
+    expect(html).toContain('Layout');
+    expect(html).toContain('How-To');
+  });
+
+  it('renders both <a> and chevron for parent with both href and children', () => {
+    const section = makeSection([
+      {
+        label: 'Marina',
+        href: '/marina',
+        children: [{ label: 'Layout', href: '/marina/layout' }],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toMatch(/<a class="nav-link nav-parent[^"]*" href="\/marina">/);
+    expect(html).toContain('nav-chevron-toggle');
+  });
+
+  it('renders parent-only (no href) as a button trigger', () => {
+    const section = makeSection([
+      {
+        label: 'Marina',
+        children: [{ label: 'Layout', href: '/marina/layout' }],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toContain('nav-parent-button');
+    expect(html).toContain('aria-haspopup="menu"');
+  });
+
+  it('supports recursive children at depth ≥ 2', () => {
+    const section = makeSection([
+      {
+        label: 'Resources',
+        children: [
+          {
+            label: 'Documents',
+            children: [
+              { label: 'Forms', href: '/r/forms' },
+              { label: 'Reports', href: '/r/reports' },
+            ],
+          },
+        ],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    // Outer dropdown.
+    expect(html).toMatch(/<ul class="nav-dropdown" role="menu"/);
+    // Nested dropdown inside.
+    expect(html).toContain('nav-dropdown nav-dropdown-nested');
+    expect(html).toContain('Forms');
+    expect(html).toContain('Reports');
+  });
+
+  it('hides children that fail auth/admin/feature gates but keeps their parent if it has visible siblings', () => {
+    const section = makeSection([
+      {
+        label: 'Resources',
+        children: [
+          { label: 'Forms', href: '/forms', public: true },
+          { label: 'AdminOnly', href: '/admin', admin: true },
+        ],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    expect(html).toContain('Forms');
+    expect(html).not.toContain('AdminOnly');
+  });
+
+  it('drops parent entirely when no children survive gating and parent has no href', () => {
+    const section = makeSection([
+      {
+        label: 'AdminMenu',
+        children: [{ label: 'X', href: '/x', admin: true }],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    // Parent (no href) collapses to plain link rendering — no chevron.
+    expect(html).not.toContain('nav-chevron-toggle');
+  });
+});
+
+describe('nav block — ARIA attributes', () => {
+  it('chevron carries role=button (implicit), aria-haspopup=menu, aria-expanded=false', () => {
+    const section = makeSection([
+      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    const root = renderInto(`<div>${html}</div>`);
+    const chevron = root.querySelector('.nav-chevron-toggle, .nav-parent-button') as HTMLElement;
+    expect(chevron).toBeTruthy();
+    expect(chevron.tagName.toLowerCase()).toBe('button');
+    expect(chevron.getAttribute('aria-haspopup')).toBe('menu');
+    expect(chevron.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('dropdown carries role=menu and items have role=menuitem with role=none on <li>', () => {
+    const section = makeSection([
+      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    const root = renderInto(`<div>${html}</div>`);
+    const ul = root.querySelector('.nav-dropdown') as HTMLElement;
+    expect(ul.getAttribute('role')).toBe('menu');
+    const li = ul.querySelector('li') as HTMLElement;
+    expect(li.getAttribute('role')).toBe('none');
+    const a = li.querySelector('a') as HTMLAnchorElement;
+    expect(a.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('aria-controls links chevron to its own dropdown id', () => {
+    const section = makeSection([
+      { label: 'Marina', children: [{ label: 'Layout', href: '/m/l' }] },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    const root = renderInto(`<div>${html}</div>`);
+    const chevron = root.querySelector('.nav-chevron-toggle, .nav-parent-button') as HTMLElement;
+    const controls = chevron.getAttribute('aria-controls')!;
+    expect(controls).toBeTruthy();
+    const menu = root.querySelector(`#${CSS.escape(controls)}`);
+    expect(menu).toBeTruthy();
+    expect(menu?.classList.contains('nav-dropdown')).toBe(true);
+  });
+});
+
+describe('nav block — runtime keyboard + click', () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (window as any).__navDropdownClickBound = false;
+    const section = makeSection([
+      { label: 'Home', href: '/', public: true },
+      {
+        label: 'Marina',
+        children: [
+          { label: 'Layout', href: '/m/layout' },
+          { label: 'How-To', href: '/m/howto' },
+          { label: 'App', href: '/m/app' },
+        ],
+      },
+    ]);
+    const html = BLOCK_TYPES.nav.render(section, baseCtx);
+    document.body.innerHTML = `<nav id="zone-header"><div class="container">${html}</div></nav>`;
+    host = document.getElementById('nav-links') as HTMLElement;
+    bindNavDropdowns(host);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete (window as any).__navDropdownClickBound;
+  });
+
+  it('clicking the chevron opens the dropdown (sets aria-expanded=true, removes [hidden])', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    expect(menu.hasAttribute('hidden')).toBe(true);
+    chevron.click();
+    expect(menu.hasAttribute('hidden')).toBe(false);
+    expect(chevron.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('ArrowDown on chevron opens the menu and focuses the first item', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    chevron.focus();
+    chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    expect(menu.hasAttribute('hidden')).toBe(false);
+    const items = menu.querySelectorAll('a[role="menuitem"]');
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('ArrowDown on a menu item moves focus to the next item; wraps at end', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    chevron.focus();
+    chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const items = Array.from(menu.querySelectorAll<HTMLElement>('a[role="menuitem"]'));
+    items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[1]);
+    items[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[2]);
+    // Wrap.
+    items[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('Escape inside open menu closes it and returns focus to the chevron', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    chevron.focus();
+    chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    const firstItem = menu.querySelector<HTMLElement>('a[role="menuitem"]')!;
+    firstItem.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(menu.hasAttribute('hidden')).toBe(true);
+    expect(document.activeElement).toBe(chevron);
+  });
+
+  it('clicking outside the dropdown closes it', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    chevron.click();
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    expect(menu.hasAttribute('hidden')).toBe(false);
+    // Click elsewhere.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.click();
+    expect(menu.hasAttribute('hidden')).toBe(true);
+    expect(chevron.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('rebinding does not double-bind: a second bindNavDropdowns call is a no-op', () => {
+    const chevron = host.querySelector('.nav-parent-button, .nav-chevron-toggle') as HTMLElement;
+    bindNavDropdowns(host);
+    bindNavDropdowns(host);
+    chevron.click();
+    const menu = document.getElementById(chevron.getAttribute('aria-controls')!) as HTMLElement;
+    // After a single click, menu should be open (toggled once, not three times).
+    expect(menu.hasAttribute('hidden')).toBe(false);
+    chevron.click();
+    expect(menu.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Extends the `nav` block (post-composable-layout) with optional recursive `children: NavItem[]` per item.
- Emits the disclosure-button + `role=menu` pattern for items with children; flat configs unchanged.
- Hover-open on pointer devices via CSS, focus/keyboard on every modality, inline accordion on mobile, click-outside dismissal, idempotent re-binding on SPA swap.
- AdminEditor nav popover gains "+ child", recursive indented sub-rows, scoped drag-reorder, and a confirmation prompt before removing a parent with descendants.
- Demo: silver-pines's `Resources` item now cascades into Documents / Forms / Calendar.
- Tests: `tests/integration/blocks-nav.test.ts` (17 cases) — flat preservation, nested rendering, ARIA attributes, recursive depth, gating, click toggle, keyboard arrows + Escape, click-outside, idempotent rebinding.
- A11y: axe-core (`wcag2a`/`wcag2aa`/`wcag21aa`) clean on the live silver-pines build — 0 violations.
- OpenSpec: `nav-nested-children`, validated strict.

## Test plan
- [x] `npx vitest run` — 290/290 pass
- [x] `npx astro check` — 0 errors / 0 warnings on source
- [x] Browser hover open + chevron rotation
- [x] Browser keyboard: Tab → ArrowDown opens menu, ArrowDown navigates, Escape closes + returns focus
- [x] Browser click-outside dismissal
- [x] axe-core scan: 0 violations
- [ ] ODBC port verification — deferred to composable-layout Phase 7 (see tasks.md 4.5)
- [ ] Live deploy verification on staging (user's call after review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)