### PR TITLE
fix(nav): isPageActive ignores anchor hash, lighting up multiple items

### DIFF
--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -122,15 +122,17 @@ function featureIcon(name: string): string {
   return FEATURE_ICONS[name] || '✦';
 }
 
-function isPageActive(href: string, current?: string): boolean {
+export function isPageActive(href: string, current?: string): boolean {
   if (!current) return false;
   try {
     const a = new URL(href, 'https://kychon.local');
     const b = new URL(current, 'https://kychon.local');
-    if (a.pathname === b.pathname) {
-      if (!a.search) return true;
-      return a.search === b.search;
-    }
+    if (a.pathname !== b.pathname) return false;
+    if (a.search && a.search !== b.search) return false;
+    // Hash-aware: an item linking to "/#x" is active only when the current
+    // URL has the same hash. Items without a hash ignore the current hash.
+    if (a.hash && a.hash !== b.hash) return false;
+    return true;
   } catch {}
   return false;
 }

--- a/src/lib/page-render.ts
+++ b/src/lib/page-render.ts
@@ -62,7 +62,9 @@ function getRenderContext(): BlockRenderContext {
     authenticated: !!session,
     role: (role as BlockRenderContext['role']) ?? null,
     isFeatureEnabled,
-    currentPath: typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/',
+    currentPath: typeof window !== 'undefined'
+      ? window.location.pathname + window.location.search + window.location.hash
+      : '/',
     session,
   };
 }

--- a/tests/integration/blocks-nav.test.ts
+++ b/tests/integration/blocks-nav.test.ts
@@ -3,7 +3,7 @@
 // and click-outside dismissal.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { BLOCK_TYPES, type BlockRenderContext, type Section } from '../../src/lib/blocks';
+import { BLOCK_TYPES, type BlockRenderContext, isPageActive, type Section } from '../../src/lib/blocks';
 import { bindNavDropdowns } from '../../src/lib/nav-dropdown';
 
 const baseCtx: BlockRenderContext = {
@@ -32,6 +32,35 @@ function renderInto(html: string): HTMLElement {
   wrap.innerHTML = html;
   return wrap.firstElementChild as HTMLElement;
 }
+
+describe('isPageActive — hash-aware active link detection', () => {
+  it('matches the same pathname when no hash and no search', () => {
+    expect(isPageActive('/', '/')).toBe(true);
+    expect(isPageActive('/about', '/about')).toBe(true);
+  });
+
+  it('does not mark anchor-only links active when no hash on current path', () => {
+    // The original bug: at `/`, both `/` and `/#announcements-section` lit up.
+    expect(isPageActive('/#announcements-section', '/')).toBe(false);
+    expect(isPageActive('/', '/')).toBe(true);
+  });
+
+  it('marks an anchor link active only when current path has the same hash', () => {
+    expect(isPageActive('/#announcements-section', '/#announcements-section')).toBe(true);
+    expect(isPageActive('/#announcements-section', '/#other')).toBe(false);
+    expect(isPageActive('/#announcements-section', '/about')).toBe(false);
+  });
+
+  it('hash-less links remain active regardless of current URL hash', () => {
+    // Home should still be active when user has scrolled to /#announcements
+    expect(isPageActive('/', '/#announcements-section')).toBe(true);
+  });
+
+  it('respects search param mismatches', () => {
+    expect(isPageActive('/page.html?slug=foo', '/page.html?slug=foo')).toBe(true);
+    expect(isPageActive('/page.html?slug=foo', '/page.html?slug=bar')).toBe(false);
+  });
+});
 
 describe('nav block — flat behavior preserved', () => {
   it('renders flat items as plain anchors', () => {


### PR DESCRIPTION
## Summary
At `/`, both `Home` (`href="/"`) and `Announcements` (`href="/#announcements-section"`) got the `.active` class because `isPageActive` only compared `pathname` + `search`, ignoring `hash`.

Fix: `isPageActive` now treats hash as a tiebreaker — items with a hash are active only when the current URL has the same hash; items without a hash ignore the URL's hash. `getRenderContext` in page-render.ts now includes `window.location.hash` in `currentPath` so the runtime sees it.

Pre-existing bug surfaced by the silver-pines nested-nav demo.

## Test plan
- [x] 5 new vitest cases in `tests/integration/blocks-nav.test.ts`
- [x] Full suite: 295/295
- [x] biome: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)