### PR TITLE
fix: close 5 open bugs (#12, #13, #14, #74, #75)

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -35,7 +35,7 @@ Or use `npm run check` which runs all three. If any fail, fix before proceeding.
 #### Portal (community template)
 - **Project:** Set `RUN402_PROJECT_ID` env var (or check `run402 projects list`)
 - **Subdomain:** `eagles.kychon.com`
-- **Command:** `RUN402_PROJECT_ID=$PORTAL_PROJECT_ID SUBDOMAIN=eagles node deploy.js`
+- **Command:** `RUN402_PROJECT_ID=$PORTAL_PROJECT_ID SUBDOMAIN=eagles npx tsx scripts/deploy.ts`
 - **Includes:** schema.sql + seed.sql, site files, edge functions, RLS
 - **IMPORTANT:** Always pass explicit project ID and subdomain — do NOT rely on the active project, which may have changed
 
@@ -45,8 +45,10 @@ Or use `npm run check` which runs all three. If any fail, fix before proceeding.
 - **Command:** `MARKETING_PROJECT_ID=$MARKETING_PROJECT_ID node marketing/deploy-marketing.js`
 - **Includes:** Static HTML/CSS/assets only
 
-#### Eagles Demo Seed (after portal deploy)
-- **Command:** `run402 projects sql $PORTAL_PROJECT_ID --file demo/eagles/seed-eagles-reactions-activity.sql`
+#### Demo Sites (Eagles, Silver Pines, Barrio Unido)
+- **Command:** `bash deploy-all.sh` — deploys all three demos (eagles, silver-pines, barrio)
+- **Single demo:** `bash deploy-all.sh eagles` (or `silver-pines` / `barrio`)
+- **Requires:** `EAGLES_PROJECT_ID`, `SILVER_PINES_PROJECT_ID`, `BARRIO_PROJECT_ID` env vars (set in `.env`)
 
 #### Screenshots (before marketing deploy)
 - **Capture:** `./marketing/capture-screenshots.sh`
@@ -126,7 +128,7 @@ EOF
 **CRITICAL: Report ANY issues encountered during the entire pipeline as GitHub issues.** This includes bugs, unexpected behavior, missing features, confusing error messages, documentation gaps, and workarounds you had to use.
 
 File issues on the appropriate repo:
-- **Platform/backend** (deploy behavior, SQL, storage, RLS, seed, CDN, subdomains, demo mode) → `gh issue create --repo MajorTal/run402`
+- **Platform/backend** (deploy behavior, SQL, storage, RLS, seed, CDN, subdomains, demo mode) → `gh issue create --repo kychee-com/run402`
 - **CLI/tooling** (argument order, error messages, missing flags, docs) → `gh issue create --repo kychee-com/run402`
 
 Include in each issue:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-smoke.yml
+++ b/.github/workflows/deploy-smoke.yml
@@ -30,9 +30,9 @@ jobs:
     # check after the scratch project + secrets are in place.
     if: ${{ false }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ seed.sql
 
 # Claude Code worktree-local launch config (preview server, etc.)
 .claude/launch.json
+# Claude Code git worktrees (each is a full checkout — biome must not traverse them)
+.claude/worktrees/

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,11 @@
       "trailingCommas": "all"
     }
   },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
     "includes": [
       "site/**",

--- a/src/layouts/Portal.astro
+++ b/src/layouts/Portal.astro
@@ -257,6 +257,15 @@ const isSvgFavicon = /\.svg($|\?)/i.test(faviconUrl) || faviconUrl.startsWith('d
     document.addEventListener('wl-content-rendered', bind);
   </script>
 
+  <script>
+    import { hydratePage, currentPageSlug } from '../lib/page-render';
+    function hydrateChrome() { void hydratePage(currentPageSlug()); }
+    hydrateChrome();
+    document.addEventListener('astro:after-swap', hydrateChrome);
+    document.addEventListener('wl-locale-changed', hydrateChrome);
+    document.addEventListener('wl-auth-changed', hydrateChrome);
+  </script>
+
   <div id="wl-sr-live" class="wl-sr-live" aria-live="polite" aria-atomic="true"></div>
 </body>
 </html>

--- a/src/layouts/Portal.astro
+++ b/src/layouts/Portal.astro
@@ -118,11 +118,11 @@ const isSvgFavicon = /\.svg($|\?)/i.test(faviconUrl) || faviconUrl.startsWith('d
     ? <link rel="icon" type="image/svg+xml" href={faviconUrl} />
     : <link rel="icon" href={faviconUrl} />}
   {fontHead && <Fragment set:html={fontHead} />}
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="/css/nav-dropdown.css">
-  <link rel="stylesheet" href="/css/zone-grid.css">
-  <link rel="stylesheet" href="/css/a11y.css">
+  <link rel="stylesheet" href={`/css/theme.css?b=${BUILD_ID}`}>
+  <link rel="stylesheet" href={`/css/styles.css?b=${BUILD_ID}`}>
+  <link rel="stylesheet" href={`/css/nav-dropdown.css?b=${BUILD_ID}`}>
+  <link rel="stylesheet" href={`/css/zone-grid.css?b=${BUILD_ID}`}>
+  <link rel="stylesheet" href={`/css/a11y.css?b=${BUILD_ID}`}>
   <ClientRouter />
   <script is:inline>
     (function applyTheme() {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,17 +10,13 @@ import Portal from '../layouts/Portal.astro';
 </Portal>
 
 <script>
-  import { hydratePage, currentPageSlug } from '../lib/page-render';
   import { preloadHeroImage } from '../lib/config';
 
-  async function boot() {
+  function boot() {
     preloadHeroImage();
     document.getElementById('sections-skeleton')?.remove();
-    await hydratePage(currentPageSlug());
   }
 
   boot();
   document.addEventListener('astro:after-swap', boot);
-  document.addEventListener('wl-locale-changed', boot);
-  document.addEventListener('wl-auth-changed', boot);
 </script>

--- a/src/pages/page.astro
+++ b/src/pages/page.astro
@@ -13,7 +13,6 @@ import Portal from '../layouts/Portal.astro';
   import { get } from '../lib/api';
   import { isAdmin, isAuthenticated } from '../lib/auth';
   import { translateItems } from '../lib/config';
-  import { hydratePage } from '../lib/page-render';
 
   async function initPage() {
     const titleEl = document.getElementById('page-title');
@@ -62,8 +61,6 @@ import Portal from '../layouts/Portal.astro';
       titleEl.textContent = 'Error loading page';
       return;
     }
-
-    await hydratePage(slug);
   }
 
   initPage();


### PR DESCRIPTION
## Summary

- **#74 chrome hydration** — Move `hydratePage()` from per-page boot scripts into `Portal.astro`. Was: only `index.astro` and `page.astro` refreshed chrome from the live DB; the other 12 pages kept the build-time-baked default forever. Now: all 14 pages re-hydrate chrome on initial load and on `astro:after-swap` / `wl-locale-changed` / `wl-auth-changed`. Fixes the "wrong brand on /events.html" regression on ports.
- **#75 stylesheet cache-bust** — Extend the existing `?b=${BUILD_ID}` query (already used for `/js/env.js`) to all 5 stylesheet `<link>`s. Stops returning visitors from seeing stale CSS for up to a year against Run402's default `immutable` cache header on `/css/*.css`.
- **#13 /deploy skill stale** — `node deploy.js` → `npx tsx scripts/deploy.ts`; "Eagles only" → all three demos (Eagles, Silver Pines, Barrio) via `bash deploy-all.sh`; archived `MajorTal/run402` → `kychee-com/run402`.
- **#12 biome nested-root** — Set `vcs.useIgnoreFile: true` in `biome.json` and add `.claude/worktrees/` to `.gitignore` so biome 2.x stops tripping on local worktree checkouts.
- **#14 Node 20 deprecation** — Bump `actions/checkout` and `actions/setup-node` from v4 → v6 in both `ci.yml` and `deploy-smoke.yml`. Off the Node 20 action runtime well ahead of the 2026-09-16 deadline. `node-version: 22` (job runtime) untouched.

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings (2 pre-existing hints unrelated)
- [x] `npx astro build` — 14 pages built in 797 ms
- [x] `npx biome check .` — 0 errors, 34 pre-existing warnings
- [x] `grep -rn 'hydratePage' src/pages/` — empty (per-page hydration calls fully removed)
- [ ] CI green
- [ ] Live verification post-deploy on `kychon.run402.com`, `eagles.run402.com`, `silver-pines.run402.com`, `barrio.run402.com`