### PR TITLE
fix(auth): replace silent redirects with inline auth gate

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1824,3 +1824,33 @@ tr:hover td {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+/* Auth gate (inline empty-state shown by src/lib/auth-gate.ts) */
+.auth-gate {
+  display: flex;
+  justify-content: center;
+}
+.auth-gate__card {
+  max-width: 32rem;
+  margin: 2rem auto;
+  text-align: center;
+  padding: 2rem 1.5rem;
+}
+.auth-gate__icon {
+  font-size: 2.5rem;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+.auth-gate__title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.25rem;
+}
+.auth-gate__body {
+  margin: 0 0 1.25rem 0;
+}
+.auth-gate__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/public/custom/strings/en.json
+++ b/public/custom/strings/en.json
@@ -25,6 +25,15 @@
   "auth.login_error": "Couldn't sign you in. Please check your credentials and try again.",
   "auth.password_mismatch": "Those passwords don't match. Give it another try.",
 
+  "auth.gate.directory.title": "Sign in to view the member directory",
+  "auth.gate.directory.body": "The member directory is private. Sign in to see who else is part of the community.",
+  "auth.gate.profile.title": "Sign in to view your profile",
+  "auth.gate.profile.body": "Your profile is private. Sign in to view and edit it.",
+  "auth.gate.admin.title": "Admin access required",
+  "auth.gate.admin.body": "This page is for site admins. If you think you should have access, ask a current admin to invite you.",
+  "auth.gate.signIn": "Sign in",
+  "auth.gate.backHome": "Back to home",
+
   "profile.title": "Your Profile",
   "profile.display_name": "Display name",
   "profile.email": "Email",

--- a/public/custom/strings/es.json
+++ b/public/custom/strings/es.json
@@ -25,6 +25,15 @@
   "auth.login_error": "No pudimos iniciar sesi\u00f3n. Verifica tus datos e int\u00e9ntalo de nuevo.",
   "auth.password_mismatch": "Las contrase\u00f1as no coinciden. Int\u00e9ntalo de nuevo.",
 
+  "auth.gate.directory.title": "Inicia sesi\u00f3n para ver el directorio de miembros",
+  "auth.gate.directory.body": "El directorio de miembros es privado. Inicia sesi\u00f3n para ver qui\u00e9n forma parte de la comunidad.",
+  "auth.gate.profile.title": "Inicia sesi\u00f3n para ver tu perfil",
+  "auth.gate.profile.body": "Tu perfil es privado. Inicia sesi\u00f3n para verlo y editarlo.",
+  "auth.gate.admin.title": "Acceso de administrador requerido",
+  "auth.gate.admin.body": "Esta p\u00e1gina es solo para administradores. Si crees que deber\u00edas tener acceso, pide a un administrador actual que te invite.",
+  "auth.gate.signIn": "Iniciar sesi\u00f3n",
+  "auth.gate.backHome": "Volver al inicio",
+
   "profile.title": "Tu Perfil",
   "profile.display_name": "Nombre",
   "profile.email": "Correo",

--- a/src/lib/auth-gate.ts
+++ b/src/lib/auth-gate.ts
@@ -1,0 +1,84 @@
+// auth-gate.ts — Inline empty-state card shown to anonymous or non-admin users
+// in place of the silent `window.location.href = '/'` redirect that requireAuth
+// / requireAdmin used to perform. Page chrome (header / footer) stays put so
+// the user keeps their bearings and sees a clear next action.
+
+import { t } from './i18n';
+
+export type AuthGateKind = 'auth' | 'admin';
+export type AuthGateContext = 'directory' | 'profile' | 'admin';
+
+interface GateCopy {
+  title: string;
+  body: string;
+  showSignIn: boolean;
+}
+
+const ICON_AUTH = '\u{1F512}'; // 🔒
+const ICON_ADMIN = '\u{1F6E1}\u{FE0F}'; // 🛡️
+
+function escHtml(s: string): string {
+  const d = document.createElement('div');
+  d.textContent = String(s);
+  return d.innerHTML;
+}
+
+function gateCopy(kind: AuthGateKind, context?: AuthGateContext): GateCopy {
+  if (kind === 'admin') {
+    return {
+      title: t('auth.gate.admin.title'),
+      body: t('auth.gate.admin.body'),
+      showSignIn: false,
+    };
+  }
+  const ctx = context === 'profile' ? 'profile' : 'directory';
+  return {
+    title: t(`auth.gate.${ctx}.title`),
+    body: t(`auth.gate.${ctx}.body`),
+    showSignIn: true,
+  };
+}
+
+export function showAuthGate(
+  targetSelector: string,
+  kind: AuthGateKind,
+  context?: AuthGateContext,
+): void {
+  const target = document.querySelector(targetSelector) as HTMLElement | null;
+  if (!target) return;
+
+  const { title, body, showSignIn } = gateCopy(kind, context);
+  const icon = kind === 'admin' ? ICON_ADMIN : ICON_AUTH;
+  const signInLabel = t('auth.gate.signIn');
+  const backLabel = t('auth.gate.backHome');
+
+  const signInBtn = showSignIn
+    ? `<button type="button" class="btn btn-primary" data-auth-gate-action="sign-in">${escHtml(signInLabel)}</button>`
+    : '';
+
+  target.innerHTML = `
+    <div class="container auth-gate">
+      <div class="auth-gate__card card" role="status" aria-live="polite">
+        <div class="auth-gate__icon" aria-hidden="true">${icon}</div>
+        <h2 class="auth-gate__title">${escHtml(title)}</h2>
+        <p class="auth-gate__body text-muted">${escHtml(body)}</p>
+        <div class="auth-gate__actions">
+          ${signInBtn}
+          <a class="btn btn-secondary" href="/" data-auth-gate-action="home">${escHtml(backLabel)}</a>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const signInEl = target.querySelector('[data-auth-gate-action="sign-in"]');
+  signInEl?.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.getElementById('auth-modal')?.classList.remove('hidden');
+    // The gate wiped the page's interactive elements, so the page's own
+    // wl-auth-changed listener can't repaint them. Reload once the modal
+    // completes sign-in so the page boots fresh against the new session.
+    document.addEventListener('wl-auth-changed', () => window.location.reload(), {
+      once: true,
+    });
+  });
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -48,20 +48,12 @@ export function isAuthenticated(): boolean {
   return !!getSession();
 }
 
-export function requireAuth(redirectTo = '/'): boolean {
-  if (!isAuthenticated()) {
-    window.location.href = redirectTo;
-    return false;
-  }
-  return true;
+export function requireAuth(): boolean {
+  return isAuthenticated();
 }
 
-export function requireAdmin(redirectTo = '/'): boolean {
-  if (!isAdmin()) {
-    window.location.href = redirectTo;
-    return false;
-  }
-  return true;
+export function requireAdmin(): boolean {
+  return isAdmin();
 }
 
 // Google OAuth

--- a/src/pages/admin-members.astro
+++ b/src/pages/admin-members.astro
@@ -44,7 +44,8 @@ import Portal from '../layouts/Portal.astro';
 
 <script>
   import { get, patch } from '../lib/api';
-  import { requireAdmin } from '../lib/auth';
+  import { isAdmin } from '../lib/auth';
+  import { showAuthGate } from '../lib/auth-gate';
   import { ready } from '../lib/config';
 
   let allMembers: any[] = [];
@@ -195,7 +196,10 @@ import Portal from '../layouts/Portal.astro';
 
   async function initAdminMembers() {
     await ready;
-    if (!requireAdmin()) return;
+    if (!isAdmin()) {
+      showAuthGate('#main-content', 'admin');
+      return;
+    }
 
     // Load tiers
     try {

--- a/src/pages/admin-settings.astro
+++ b/src/pages/admin-settings.astro
@@ -187,7 +187,8 @@ import Portal from '../layouts/Portal.astro';
 
 <script>
   import { del, get, patch, post } from '../lib/api';
-  import { requireAdmin } from '../lib/auth';
+  import { isAdmin } from '../lib/auth';
+  import { showAuthGate } from '../lib/auth-gate';
   import { ready, applyTheme, clearCache } from '../lib/config';
 
   const configMap: Record<string, any> = {};
@@ -601,7 +602,10 @@ import Portal from '../layouts/Portal.astro';
 
   async function initAdminSettings() {
     await ready;
-    if (!requireAdmin()) return;
+    if (!isAdmin()) {
+      showAuthGate('#main-content', 'admin');
+      return;
+    }
 
     // Load current config
     try {

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -49,7 +49,8 @@ import Portal from '../layouts/Portal.astro';
 
 <script>
   import { count, get, patch } from '../lib/api';
-  import { requireAdmin } from '../lib/auth';
+  import { isAdmin } from '../lib/auth';
+  import { showAuthGate } from '../lib/auth-gate';
   import { isFeatureEnabled, ready } from '../lib/config';
 
   function esc(s: string): string {
@@ -151,7 +152,10 @@ import Portal from '../layouts/Portal.astro';
 
   async function initDashboard() {
     await ready;
-    if (!requireAdmin()) return;
+    if (!isAdmin()) {
+      showAuthGate('#main-content', 'admin');
+      return;
+    }
 
     const statPromises: Promise<number>[] = [
       count('members?status=eq.active').catch(() => 0),

--- a/src/pages/directory.astro
+++ b/src/pages/directory.astro
@@ -31,7 +31,8 @@ import Portal from '../layouts/Portal.astro';
 
 <script>
   import { get } from '../lib/api';
-  import { requireAuth } from '../lib/auth';
+  import { isAuthenticated } from '../lib/auth';
+  import { showAuthGate } from '../lib/auth-gate';
   import { getConfig, ready } from '../lib/config';
 
   let allMembers: any[] = [];
@@ -133,7 +134,10 @@ import Portal from '../layouts/Portal.astro';
   async function initDirectory() {
     await ready;
     const isPublic = getConfig('directory_public') === true;
-    if (!isPublic && !requireAuth()) return;
+    if (!isPublic && !isAuthenticated()) {
+      showAuthGate('#main-content', 'auth', 'directory');
+      return;
+    }
 
     // Load tiers
     try {

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -28,7 +28,8 @@ import Portal from '../layouts/Portal.astro';
 
 <script>
   import { get, patch } from '../lib/api';
-  import { getSession, requireAuth } from '../lib/auth';
+  import { getSession, isAuthenticated } from '../lib/auth';
+  import { showAuthGate } from '../lib/auth-gate';
   import { ready } from '../lib/config';
 
   function esc(s: string): string {
@@ -91,7 +92,10 @@ import Portal from '../layouts/Portal.astro';
     if (!nameEl || !bioEl) return;
 
     await ready;
-    if (!requireAuth()) return;
+    if (!isAuthenticated()) {
+      showAuthGate('#main-content', 'auth', 'profile');
+      return;
+    }
 
     const session = getSession();
     const member = session.user?.member;


### PR DESCRIPTION
## Summary

Anonymous and non-admin users hitting `directory.html`, `profile.html`, `admin.html`, `admin-members.html`, or `admin-settings.html` were silently bounced to `/` by `requireAuth()` / `requireAdmin()` with no explanation. [PR #74](https://github.com/kychee-com/kychon/pull/76) made the page chrome stable on every page, which exposed this UX gap (you can now navigate around without losing context, except these five pages still teleport you home with no message).

This PR replaces the silent redirect with an inline empty-state card.

- `requireAuth` / `requireAdmin` are now pure boolean predicates (no `window.location.href` side effect, no `redirectTo` arg).
- New helper `src/lib/auth-gate.ts` exposes `showAuthGate(target, kind, context?)`. It clears `#main-content` and renders an icon + title + body + CTA card.
- Two variants:
  - `auth` — anonymous user on member-only page (lock icon, Sign in + Back to home).
  - `admin` — non-admin on admin page (shield icon, Back to home only — admin access requires being a member already, not just signing in).
- Gate's "Sign in" CTA opens the existing `#auth-modal`. Once auth completes, the listener reloads the page so the original page boots fresh (the gate wiped the page's interactive elements, so the per-page `wl-auth-changed` listener can't recover them in place).
- Spanish translations added (Barrio is es-default).

## Files

- `src/lib/auth.ts` — strip redirects from `requireAuth` / `requireAdmin`.
- `src/lib/auth-gate.ts` — new helper.
- `src/pages/{directory,profile,admin,admin-members,admin-settings}.astro` — switch to `isAuthenticated()` / `isAdmin()` + `showAuthGate(...)`.
- `public/custom/strings/{en,es}.json` — `auth.gate.*` keys.
- `public/css/styles.css` — `.auth-gate__*` styles.

## Verification matrix

Verified against the local build (`npx astro build` + http-server on `dist/`):

| Page | State | Expected | Result |
|------|-------|----------|--------|
| `directory.html` | anonymous, `directory_public` unset | auth gate (lock) | gate shown; chrome intact |
| `directory.html` | anonymous, `wl_locale=es` | gate in Spanish | "Inicia sesión para ver el directorio de miembros" |
| `directory.html` | authenticated member | normal directory | grid + search render |
| `profile.html` | anonymous | auth gate (lock, "Sign in to view your profile") | gate shown |
| `admin.html` | anonymous | admin gate (shield) | gate shown |
| `admin.html` | authenticated `role: member` | admin gate | gate shown |
| `admin-members.html` | non-admin | admin gate | gate shown |
| `admin-settings.html` | non-admin | admin gate | gate shown |
| Click "Sign in" CTA | — | `#auth-modal` opens | confirmed via JS-dispatched click |
| Mobile / dark mode | — | card centered, readable | screenshots captured |

Other checks:

- `npm run typecheck` — green (pre-existing 2 unused-import hints unchanged).
- `npx astro build` — green, all 14 pages built.
- `npm test` — 529/529 passing.

## Test plan

- [ ] After merge + `bash deploy-all.sh`: visit `https://barrio.kychon.com/directory.html` anonymously → gate appears in Spanish (no redirect).
- [ ] `https://eagles.kychon.com/profile.html` anonymously → gate appears.
- [ ] `https://silver-pines.kychon.com/directory.html` anonymously → directory still loads (it has `directory_public=true`).
- [ ] Sign in via the gate's CTA → page reloads → directory content shows.
- [ ] Sign in as a member, visit `/admin.html` → admin gate shows (not directory gate).