### PR TITLE
feat(events): events_calendar block with month/week/agenda views (#78)

### DIFF
--- a/openspec/changes/events-calendar-view/design.md
+++ b/openspec/changes/events-calendar-view/design.md
@@ -1,0 +1,303 @@
+# Design: events-calendar-view
+
+## Context
+
+Kychon's events surface today is two routes: `/events.html` (vertical list) and `/event.html?id=N` (detail). The block registry already has `events_list` (a sidebar/grid/list block) and `event_countdown` (next-event widget). The composable layout system means any new "view" of events is just another block type.
+
+The hero use case is **a member orienting themselves**: opening the site on a phone Sunday morning, asking "what's this month?" — not an admin curating events. Every design decision is anchored there.
+
+## Goals
+
+1. Replace Wild Apricot's month-grid widget cleanly so port-handoff has zero visible regression on the calendar surface.
+2. Land the calendar as a *block*, not a one-off page — admins can place "Glance" sidebar calendars on the home page and a "Rich" full-width one at `/calendar.html` from the same code.
+3. Hit a 2026 standard for community calendars (multi-lens, social, frictionless add-to-personal-calendar) without bloating member page weight.
+4. Preserve every existing event flow (`/events.html`, `/event.html`, RSVP, members-only, capacity) unchanged.
+
+## Non-goals
+
+- Recurring events (tracked separately at [#79](https://github.com/kychee-com/kychon/issues/79); ships immediately after this change).
+- Map view (needs geocoding strategy + Leaflet).
+- AI summaries.
+- Year-at-a-glance ribbon (deferred until v1 has real usage).
+- Drag-to-create (paint a range to make a new event).
+
+## Architecture
+
+### Block + Page
+
+```
+                       events_calendar BLOCK
+                                │
+        ┌───────────────────────┼───────────────────────┐
+        ▼                       ▼                       ▼
+┌────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+│ render()       │    │  hydrate()       │    │   /calendar.html │
+│   skeleton +   │    │   lazy load      │    │   single-section │
+│   data-config  │    │   blocks/events- │    │   page hosting   │
+│                │    │   calendar.ts    │    │   one block      │
+└────────────────┘    └────────┬─────────┘    └──────────────────┘
+                               │
+        ┌──────────────────────┼─────────────────────────────┐
+        ▼                      ▼                             ▼
+┌─────────────┐      ┌──────────────────┐          ┌───────────────────┐
+│  data       │      │  view modes      │          │   side effects    │
+│             │      │                  │          │                   │
+│ PostgREST   │      │  month-grid      │          │   ICS gen         │
+│ window      │      │  week-strip      │          │   (browser)       │
+│ query       │      │  agenda-list     │          │                   │
+│             │      │                  │          │   ICS feed        │
+│ wl_cache_   │      │  density:        │          │   (edge fn)       │
+│  events_    │      │   glance/light/  │          │                   │
+│  yyyy-mm-   │      │   rich           │          │   inline editing  │
+│  window     │      │                  │          │   drag-to-resched │
+│ (SWR)       │      │  responsive      │          │                   │
+└─────────────┘      │  fall-through    │          │   keyboard / ⌘K   │
+                     └──────────────────┘          └───────────────────┘
+```
+
+The dedicated page `/calendar.html` is just a Portal-wrapped single section that hosts an `events_calendar` block. Identical code path to placing the block via the composer.
+
+### File map
+
+```
+src/
+├── lib/
+│   ├── blocks.ts                       (+EVENTS_CALENDAR registry entry)
+│   ├── block-hydrators.ts              (+hydrateEventsCalendar wrapper)
+│   └── blocks/
+│       └── events-calendar.ts          NEW ~10-12 kB minified
+├── pages/
+│   └── calendar.astro                  NEW
+└── components/
+    └── AdminEditor.astro               (+cross-day drag handler)
+
+public/
+├── css/
+│   └── block-events-calendar.css       NEW ~3 kB
+└── custom/
+    └── strings/{en,es,pt,fr,de,zh}.json (+~30 keys)
+
+functions/
+└── calendar-ics.js                     NEW Run402 edge function
+
+tests/
+├── blocks/
+│   └── events-calendar.test.ts         NEW
+└── lib/
+    └── ics-generator.test.ts           NEW
+```
+
+### Data layer
+
+One PostgREST query per visible window:
+
+```ts
+// 6-week visible window (with leading/trailing days from prev/next month)
+const start = startOfWeek(startOfMonth(currentMonth), firstDayOfWeek);
+const end = endOfWeek(endOfMonth(currentMonth), firstDayOfWeek);
+const query = `events?starts_at=gte.${start.toISOString()}&starts_at=lt.${end.toISOString()}&order=starts_at.asc`;
+```
+
+For RSVP avatars, we need attendees per event. We do NOT join in the per-month query (would balloon payload). Instead, on hover-peek of a day cell or on rendering Rich density, we fire one extra query:
+
+```ts
+const ids = visibleEventIds.join(',');
+const rsvps = await get(`event_rsvps?event_id=in.(${ids})&status=eq.going&select=event_id,members(id,display_name,avatar_url)&limit=300`);
+```
+
+This is one extra request per visible window, gated on density. Cached separately as `wl_cache_rsvps_{window}`.
+
+### Cache strategy (stale-while-revalidate)
+
+```
+Read:    cache hit → render immediately
+              ↓
+              fire fetch in background
+              ↓
+              if response differs → re-render
+
+Write:   admin RSVP / drag-resched / inline-edit
+              ↓
+              optimistic update local state
+              ↓
+              PATCH/POST
+              ↓
+              on success → invalidate the affected window cache
+              on failure → revert + toast
+```
+
+### Rendering pipeline (month view)
+
+```
+build-time     ─── nothing ───  (block is dynamic, emits skeleton only)
+                                                │
+                                                ▼
+runtime hydrate → readSWRCache(window) → paint immediately
+                                                │
+                                                ▼
+                  fetch(window) ─── compare ─── repaint if changed
+                                                │
+                                                ▼
+                  fetch(rsvps for window) ─── paint avatars on chips
+                                                │
+                                                ▼
+                  on idle: prefetch(prev_window, next_window)
+```
+
+### Responsive behavior
+
+```
+Container width        Default view              Density override
+─────────────────────  ───────────────────────  ───────────────────
+≥ 900px (full)         Month grid               Rich (admin override → Light/Glance)
+600–899px (medium)     Month grid (smaller)     Light
+< 600px (mobile)       Agenda (forced)          Light
+```
+
+Container queries (`@container (min-width: 600px)`) on the block root drive this. Admin can pin a view via config but the renderer respects container floor — Glance density at 1/3 column never tries to draw 7 columns.
+
+### View transitions
+
+```
+Month → next month       slide-fade (CSS transitions, gated on prefers-reduced-motion)
+View mode toggle         crossfade (200ms)
+Day cell → bottom sheet  slide-up (mobile) / fade-in popover (desktop)
+```
+
+We use the View Transitions API where supported (already shipping via Astro's `ClientRouter` — but for in-block transitions we call the API directly). Fallback: instant swap when `document.startViewTransition` is undefined.
+
+### Keyboard map
+
+```
+←  →           prev / next day
+↑  ↓           prev / next week (or prev / next event in agenda)
+⏎              open peek popover (desktop) or bottom sheet (mobile)
+Esc            close peek / bottom sheet
+T              jump to today
+M / W / A      switch to Month / Week / Agenda view
+⌘K (Ctrl+K)    open fuzzy search across visible events
+←  →   (when peek open)   navigate between events on the same day
+```
+
+ARIA: month grid uses `role="grid"`, rows use `role="row"`, cells use `role="gridcell"`. Cell focus management via roving `tabindex`. Live region announces month change ("May 2026, week 18, 12 events this month").
+
+### ICS subscription (`functions/calendar-ics.js`)
+
+Run402 edge function. Two modes:
+
+**Public** — anonymous GET, returns only events where `is_members_only = false`:
+```
+GET /api/calendar.ics
+Cache-Control: public, max-age=300
+Content-Type: text/calendar
+```
+
+**Members-only** — token-bound GET, returns all events:
+```
+GET /api/calendar.ics?token={signed-token-for-member-id}
+Cache-Control: private, no-store
+```
+
+Token is generated when a member clicks "Subscribe to my calendar feed" in their profile — server-signed JWT bound to `member_id`, no expiry (revocable via a `calendar_feed_revoked_at` column on `members`, set null by default; revocation is V2 — for V1 the token is bound to the auth account and can be regenerated by the member, invalidating the old one).
+
+The feed body uses RFC 5545 `VEVENT` per event:
+```
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Kychon//ODBC//EN
+NAME:Old Dominion Boat Club
+X-WR-CALNAME:Old Dominion Boat Club
+REFRESH-INTERVAL;VALUE=DURATION:PT1H
+BEGIN:VEVENT
+UID:event-{id}@{domain}
+DTSTART:{starts_at-utc}
+DTEND:{ends_at-utc}
+SUMMARY:{title}
+LOCATION:{location}
+DESCRIPTION:{description-stripped}
+URL:https://{domain}/event.html?id={id}
+END:VEVENT
+...
+END:VCALENDAR
+```
+
+Single-event one-tap export uses the same builder running in the browser — no server call needed.
+
+### Drag-to-reschedule (admin)
+
+Builds on existing `AdminEditor.astro` cross-zone drag pattern. New: when an `events_calendar` block detects a drop on a different day cell (vs. a different zone):
+
+1. Compute time-of-day from `starts_at` (and duration to `ends_at` if present).
+2. Anchor the drop day to that time-of-day → new `starts_at`.
+3. New `ends_at = new_starts_at + (old_ends_at - old_starts_at)`.
+4. PATCH single event row.
+5. Invalidate window cache, re-render.
+6. On error: revert + toast.
+
+DST is handled implicitly because we shift by absolute duration, not by `Date.setDate`.
+
+### Container Q&A
+
+Q: What if the admin places `events_calendar` at `column_span: '1/3'` and pins view mode to "month"?
+A: Container query forces agenda. Tooltip on the admin pill explains: "This view auto-switches to Agenda below 600px width."
+
+Q: What about overlapping multi-day events in week view?
+A: Stacked horizontal bars, max 3 visible + "+N more" link to peek. Same pattern as Apple Calendar.
+
+Q: How does this interact with `feature_events`?
+A: Block hides itself when `feature_events` is disabled (same as `events_list` and `event_countdown`).
+
+Q: What about the existing `/events.html`?
+A: Untouched. We add a "View as calendar →" link at the top, linking to `/calendar.html`. Visitors who prefer a list still have it.
+
+## Risks / Trade-offs
+
+### A. Bundle size
+
+~12 kB calendar JS + ~3 kB CSS lazy-loaded only when an `events_calendar` block hydrates. A page without the block pays nothing. A page with the block pays once (cached after).
+
+**Mitigation**: Internal date math uses native `Intl.DateTimeFormat` and `Date` — no `date-fns` or `dayjs` dep.
+
+### B. ICS feed is new infra
+
+This is the first edge function in Kychon that returns a non-JSON content type. We follow the existing pattern from `reset-demo.js` for boilerplate but the response uses `Content-Type: text/calendar` and a custom body builder.
+
+**Mitigation**: The builder is pure — testable in isolation as `tests/lib/ics-generator.test.ts`. The edge function is a thin wrapper.
+
+### C. Drag-to-reschedule conflicts with cross-zone drag
+
+The composer already supports dragging blocks across zones. Inside a calendar block, dragging an event chip should NOT trigger a cross-zone block move.
+
+**Mitigation**: Event chips have `draggable="true"` with `data-event-id` and stop propagation on `dragstart`. The cross-zone handler explicitly ignores drags originating from `[data-event-id]`. Documented in `AdminEditor.astro`.
+
+### D. Hover popover on touch devices
+
+Touch devices fire `mouseenter` weirdly. Day-cell hover should not trigger anything on touch.
+
+**Mitigation**: `(hover: hover) and (pointer: fine)` media query gates the popover. Touch devices get tap → bottom sheet directly (no peek state).
+
+### E. RSVP avatars query is a second round-trip
+
+For Rich density, we make a second request per window for RSVP attendees. On a slow connection, the chips render without avatars first, then avatars pop in.
+
+**Mitigation**: Avatars use `<img loading="lazy">` and a fade-in transition (gated on reduced-motion). The "card without avatars yet" state still has the count number, so it's never wrong — just thinner.
+
+### F. Subscribed iPhone calendar doesn't get recurring events right (yet)
+
+Without RRULE expansion (recurring events deferred to [#79](https://github.com/kychee-com/kychon/issues/79)), each event is a one-off VEVENT. Members subscribed via webcal:// will see every weekly board meeting as a separate one-off, which is fine for this version but suboptimal.
+
+**Mitigation**: Document on the "Subscribe" UX that subscriptions get all events as one-offs until recurring lands. Once #79 lands, the ICS feed emits proper RRULEs and existing subscriptions self-update.
+
+## Migration
+
+No data migration. No schema changes. No deprecations.
+
+The existing `/events.html` and `/event.html` routes are unchanged. The block registry gains one entry. The composer immediately offers `events_calendar` as a placement option in any zone (with `zoneHints: ['main']`).
+
+Demo seeds (`silver-pines`, `eagles`, `barrio-unido`, `kychon`) get an optional `events_calendar` block on their home pages — pre-seeded only on first deploy after this change lands. Existing deploys are unaffected unless the admin manually adds the block.
+
+## Open questions
+
+1. **Should the "Subscribe to feed" link live on `/profile`, in the page footer, or as a button inside the calendar block?** My instinct: button inside the calendar block (next to the view/density toggle), labeled "Subscribe in your calendar app". Discoverable where it matters.
+2. **Do we want a "Featured" filter chip** for events with a `is_featured` flag? The schema doesn't have that column today (noted in the archived `block-types-catalog` design). Defer until real demand.
+3. **Should multi-day events render as bars in month view (Google Cal style) or as repeated chips per day (Apple Cal style)?** Bars are cleaner visually; chips are simpler to implement. v1 ships chips, v2 considers bars if real events have multi-day spans.

--- a/openspec/changes/events-calendar-view/proposal.md
+++ b/openspec/changes/events-calendar-view/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Today Kychon shows events as a vertical list (`/events.html`) and per-event detail (`/event.html?id=N`). Every club we're absorbing from Wild Apricot has had a **month-grid calendar** as its primary "what's happening?" surface for years — losing it on port-handoff is a visible regression. ODBC's home-nav explicitly groups "Club Calendar" as a top-level item.
+
+Wild Apricot's calendar is competent but unremarkable. The opportunity isn't to copy it — it's to ship the calendar a 2026 club would actually want: multi-lens (month / week / agenda), social-rich (RSVP avatars on cells), frictionless (one-tap add to personal calendar, subscribable feed), inline-editable (drag to reschedule), and natively responsive (real mobile agenda, not a cramped grid). See [#78](https://github.com/kychee-com/kychon/issues/78).
+
+The hero use case is a member opening this on their phone Sunday morning thinking *"what's happening this month?"* — every UX decision is anchored there.
+
+## What Changes
+
+- **New `events_calendar` block** registered in `src/lib/blocks.ts`, lazy-loaded hydrator at `src/lib/blocks/events-calendar.ts` (~10–12 kB minified). Renders the existing `events` table — no schema changes.
+- **Three view modes**: Month grid (default desktop), Week strip with horizontal event bars, Agenda (default mobile, vertical day-by-day list). Toggleable via segmented control.
+- **Three density modes** for the same data: Glance (1–3 dots per day, fits in 1/3 column), Light (1-line summaries), Rich (cards with thumbnails + RSVP avatars + capacity badges). Container-query driven with admin override.
+- **Filter chips**: All / Members-only / Open / My RSVPs / Past — uses existing event flags + `event_rsvps` join for "My RSVPs".
+- **Hover peek popover** on day cells (desktop) — see all events on a day without leaving the grid.
+- **Bottom sheet** for event peek (mobile) — taller-than-modal, tap "More" to fully navigate to `/event.html?id=N`.
+- **Stacked RSVP avatars** on event chips (3 visible + count) for social proof at a glance.
+- **Live-now indicator** (pulsing dot) on events currently in `[starts_at, ends_at)`.
+- **Capacity badges**: "Filling fast" at ≥80% full, "Sold out" when capped.
+- **Today highlight** + dedicated "Today" jump button.
+- **Keyboard navigation**: ↑↓←→ to move between days, ⏎ to peek, Esc to close, T = today, M/W/A = view modes, ⌘K = fuzzy search across visible event titles + descriptions.
+- **One-tap "Add to my calendar"** — browser-side `.ics` generation per event, no server roundtrip.
+- **Subscribable `.ics` feed** via new Run402 edge function `functions/calendar-ics.js` — public events served anonymously, members-only events served via signed token URL. Members get an "Subscribe to this calendar" link in their profile that resolves to `webcal://...`.
+- **Locale-aware first day of week** (Sun/Mon based on `getLocale()`) and **visitor's local timezone** for all date/time labels — addresses F9 friction.
+- **Inline editing** via existing `data-editable` pattern: title and location editable on event chips for admins.
+- **Drag-to-reschedule** (admin) — drag a chip to another day, PATCH `starts_at` / `ends_at` preserving the time-of-day delta. Multi-day events shift both endpoints by the same delta.
+- **`/calendar.html` page** — single-section page hosting one full-width `events_calendar` block; provides a deep-linkable surface for the home-nav.
+- **LocalStorage SWR cache** keyed `wl_cache_events_yyyy-mm-window` (each cache covers the visible 6-week window). Prefetch ±1 month on idle.
+- **Reduced motion respected** — `prefers-reduced-motion: reduce` disables month-transition animations, hover-scale, and the live pulsing dot.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `events` — new requirements for calendar view, ICS feed, calendar page, drag-to-reschedule, RSVP avatar surfacing, and live-now / capacity indicators. Existing requirements (CRUD, RSVP, /events.html list, /event.html detail, capacity enforcement, members-only) are preserved unchanged.
+
+## Impact
+
+- **New files**:
+  - `src/lib/blocks/events-calendar.ts` (~10–12 kB minified, lazy-loaded view controller)
+  - `src/pages/calendar.astro` (one-section page)
+  - `public/css/block-events-calendar.css` (grid + chips + popover + bottom sheet)
+  - `functions/calendar-ics.js` (Run402 edge function emitting RFC 5545 feed)
+  - `tests/blocks/events-calendar.test.ts`
+  - `tests/lib/ics-generator.test.ts`
+- **Modified files**:
+  - `src/lib/blocks.ts` — register `events_calendar` in `BLOCK_TYPES`, add `EVENTS_CALENDAR` definition
+  - `src/lib/block-hydrators.ts` — add `hydrateEventsCalendar` thin wrapper
+  - `src/components/AdminEditor.astro` — drag-to-reschedule cross-day handler (additive to existing cross-zone drag)
+  - `public/custom/strings/{en,es,pt,fr,de,zh}.json` — ~30 new keys for view/density/filter labels and ARIA strings
+  - `src/seeds/types.ts` — `events_calendar` added to `BlockType` union
+  - `astro.config.mjs` — no changes needed
+- **No schema changes** — `events` and `event_rsvps` tables unchanged. Recurring events tracked at [#79](https://github.com/kychee-com/kychon/issues/79) ships separately.
+- **New Run402 dep**: 1 additional edge function (`calendar-ics.js`). Each demo project has 1 prototype-tier function slot already used by `reset-demo.js`; production tiers allow more. Adds `production` to the deploy step's function list.
+- **Bundle impact**: Member page load unchanged (calendar JS lazy-loaded only when an `events_calendar` block is present and visible). When loaded, ~12 kB additional + ~3 kB CSS. No Tiptap-style heavy deps.
+- **Accessibility**: ARIA `role="grid"` for month view, live region for month-change announcements, full keyboard support, reduced-motion gates.
+- **Out of scope** (deferred to follow-up changes):
+  - Recurring events ([#79](https://github.com/kychee-com/kychon/issues/79))
+  - Map view (needs geocoding)
+  - AI "month at a glance" summary
+  - Year-at-a-glance ribbon
+  - Per-filter subscribable URLs (the v1 feed is whole-calendar)
+  - Photo gallery on past events
+  - Drag-to-create (paint a date range for a new event)

--- a/openspec/changes/events-calendar-view/specs/events/spec.md
+++ b/openspec/changes/events-calendar-view/specs/events/spec.md
@@ -1,0 +1,309 @@
+## ADDED Requirements
+
+### Requirement: Events Calendar Block
+
+The system SHALL register an `events_calendar` block in the block registry. The block SHALL render the existing `events` table as a calendar surface with three switchable view modes (Month / Week / Agenda) and three switchable density modes (Glance / Light / Rich) without requiring schema changes. The block SHALL be placeable in any zone supporting `main` zoneHint and SHALL adhere to the same lazy-hydration pattern as `events_list` and `event_countdown`.
+
+#### Scenario: Composer offers events_calendar as a placement option
+
+- **WHEN** an admin opens the block picker on a page with `feature_events` enabled
+- **THEN** `events_calendar` SHALL appear as a selectable block type
+- **AND** placing it SHALL emit a skeleton at build time and hydrate at runtime via the lazy view controller
+
+#### Scenario: Block hides when feature flag disabled
+
+- **WHEN** a member loads a page containing an `events_calendar` block
+- **AND** `feature_events` is `false` in `site_config`
+- **THEN** the block SHALL set `display: none` and SHALL NOT fetch event data
+
+#### Scenario: Visitor switches view mode
+
+- **WHEN** a member clicks the Week button in the segmented view-mode control
+- **THEN** the block SHALL re-render the visible window as a 7-column day strip
+- **AND** the selected view SHALL persist for the page session
+
+### Requirement: Calendar Page Route
+
+The system SHALL expose a dedicated `/calendar.html` route that hosts a single full-width `events_calendar` block in Rich density. The route SHALL share all rendering code with composer-placed instances and SHALL be deep-linkable from the navigation.
+
+#### Scenario: Visitor opens /calendar.html
+
+- **WHEN** a visitor navigates to `/calendar.html`
+- **THEN** the page SHALL render with the standard Portal layout chrome
+- **AND** the main content area SHALL contain one `events_calendar` block configured for full width and Rich density
+
+### Requirement: Responsive Density Fall-Through
+
+The block SHALL respect a container-width floor: at container widths below 600px the block SHALL render in Agenda view regardless of the admin-configured `view` setting, unless the admin sets `density_lock: true` in the block config. Above 900px the block SHALL render in the admin-configured view; between 600px and 900px the block MAY apply a smaller font scale but SHALL preserve the configured view.
+
+#### Scenario: Sidebar block in narrow column
+
+- **WHEN** an admin places `events_calendar` in a 1/3-column slot with `view: 'month'` configured
+- **THEN** the block SHALL fall through to Agenda view at runtime
+- **AND** SHALL NOT attempt to render a 7-column grid
+
+#### Scenario: Mobile viewport
+
+- **WHEN** a visitor with a viewport width of 360px loads a page with `events_calendar`
+- **THEN** the block SHALL render in Agenda view
+- **AND** the day-by-day list SHALL use sticky day headers on scroll
+
+### Requirement: Filter Chips for Visible Events
+
+The block SHALL render a filter chip row above the grid offering: All, Members-only, Open, My RSVPs, and Past. The "My RSVPs" chip SHALL be hidden for unauthenticated visitors. The active filter SHALL persist in `localStorage` per block instance.
+
+#### Scenario: Visitor filters to open events
+
+- **WHEN** a visitor clicks the Open chip
+- **THEN** the block SHALL hide events with `is_members_only = true`
+- **AND** the chip SHALL display an active state
+
+#### Scenario: Authenticated member filters to their RSVPs
+
+- **WHEN** an authenticated member clicks My RSVPs
+- **THEN** the block SHALL re-query events filtered by the member's `event_rsvps`
+- **AND** SHALL display only events where the member has any RSVP status (going or maybe)
+
+#### Scenario: Anonymous visitor sees no My RSVPs chip
+
+- **WHEN** an anonymous visitor loads the calendar
+- **THEN** the My RSVPs chip SHALL NOT be rendered
+
+### Requirement: Live-Now Indicator
+
+Events whose current time falls within `[starts_at, ends_at)` (or whose `ends_at` is null and `starts_at` is within the last 2 hours) SHALL display a "Live now" indicator on their chip — a colored pulsing dot plus a localized "Live" label visible to assistive tech via ARIA. The pulsing animation SHALL be removed when `prefers-reduced-motion: reduce` is set, but the dot itself SHALL remain visible.
+
+#### Scenario: Event currently in progress
+
+- **WHEN** the current time is between an event's `starts_at` and `ends_at`
+- **THEN** the chip SHALL show a Live indicator
+- **AND** screen-reader users SHALL hear "Live now"
+
+#### Scenario: Reduced-motion user sees indicator without animation
+
+- **WHEN** a visitor with `prefers-reduced-motion: reduce` views a live event chip
+- **THEN** the indicator dot SHALL be visible and colored
+- **AND** the dot SHALL NOT pulse or animate
+
+### Requirement: Capacity Badges
+
+Events with `capacity` set SHALL display a contextual badge: "Filling fast" when the going-count is at least 80% of capacity, and "Sold out" when going-count equals or exceeds capacity. Events without a capacity SHALL display no capacity badge.
+
+#### Scenario: Event near capacity
+
+- **WHEN** an event has `capacity = 50` and 41 going RSVPs
+- **THEN** the chip SHALL display a "Filling fast" badge
+
+#### Scenario: Event at capacity
+
+- **WHEN** an event has `capacity = 50` and 50 going RSVPs
+- **THEN** the chip SHALL display a "Sold out" badge
+
+### Requirement: Stacked RSVP Avatars
+
+In Rich density mode, event chips SHALL display up to 3 stacked attendee avatars plus a `+N` count for additional going RSVPs. Avatars SHALL be drawn from `members.avatar_url`; members without avatars SHALL be represented by a colored initial circle. Avatars SHALL fade in after the chip renders to avoid blocking initial paint.
+
+#### Scenario: Event with 8 attendees in Rich density
+
+- **WHEN** an event has 8 going RSVPs and the block is in Rich density
+- **THEN** the chip SHALL show 3 avatars stacked
+- **AND** the chip SHALL show "+5" next to the avatars
+
+#### Scenario: Event with no attendees in Rich density
+
+- **WHEN** an event has 0 going RSVPs
+- **THEN** the chip SHALL omit the avatar block entirely
+- **AND** SHALL NOT show "+0"
+
+### Requirement: Hover Peek Popover (Desktop)
+
+On devices reporting `(hover: hover) and (pointer: fine)`, hovering a day cell with at least one event SHALL display a popover after a 200ms delay listing all events on that day with thumbnails, RSVP avatars, and inline RSVP buttons. The popover SHALL auto-flip its position when near a viewport edge. The popover SHALL close on Escape, on click outside, or when the cursor leaves both cell and popover for more than 150ms.
+
+#### Scenario: Desktop user hovers a day with three events
+
+- **WHEN** a user hovers a day cell containing three events for at least 200ms
+- **THEN** a popover SHALL appear showing all three events
+- **AND** each event SHALL show its title, time, and going count
+
+#### Scenario: Touch device tapping a day
+
+- **WHEN** a touch user taps a day cell
+- **THEN** a peek popover SHALL NOT appear
+- **AND** the bottom sheet SHALL open instead
+
+### Requirement: Bottom Sheet for Event Detail (Mobile)
+
+On mobile viewports (width <600px), tapping an event chip SHALL open a bottom sheet sliding up from the bottom of the viewport showing full event detail (title, formatted date/time in the visitor's timezone, location, description, RSVP buttons for authenticated members, attendee avatars). The bottom sheet SHALL include a "Open full event →" link to `/event.html?id={id}` and SHALL be dismissible by tap-on-backdrop or drag-down gesture.
+
+#### Scenario: Mobile user taps an event chip
+
+- **WHEN** a mobile user taps an event chip
+- **THEN** the bottom sheet SHALL slide up from the bottom of the viewport
+- **AND** SHALL display the event detail without navigating away from the calendar
+
+#### Scenario: Drag-down dismisses the bottom sheet
+
+- **WHEN** the bottom sheet is open and the user drags it downward by at least 100px
+- **THEN** the sheet SHALL animate closed
+- **AND** the user SHALL remain on the calendar page
+
+### Requirement: Today Highlight and Jump Button
+
+The block SHALL visually distinguish today's date in the grid (e.g., a colored border or background tint using `--color-accent`). A dedicated "Today" button SHALL be visible in the block's control row; clicking it SHALL set the visible window to the current month and focus today's cell.
+
+#### Scenario: Visitor jumps to today from a past month
+
+- **WHEN** a visitor is viewing March 2026 and clicks the Today button
+- **AND** the current month is May 2026
+- **THEN** the visible window SHALL change to May 2026
+- **AND** focus SHALL move to today's cell
+
+### Requirement: Keyboard Navigation
+
+The Month and Week views SHALL support keyboard navigation conforming to the ARIA grid pattern. The Agenda view SHALL support arrow-key navigation between event cards. The block SHALL globally support: `T` jumps to today, `M`/`W`/`A` switch between Month/Week/Agenda views, `⌘K` (or `Ctrl+K` on non-Mac) opens fuzzy search, and `Esc` closes any open peek/sheet.
+
+#### Scenario: Keyboard user navigates the month grid
+
+- **WHEN** a keyboard user has focus on a day cell
+- **AND** presses ArrowRight
+- **THEN** focus SHALL move to the next day cell
+- **AND** the previously-focused cell SHALL release `tabindex=0`
+
+#### Scenario: Keyboard user opens search
+
+- **WHEN** a user presses `Cmd+K` on Mac or `Ctrl+K` on other platforms while the calendar block has focus
+- **THEN** a fuzzy search input SHALL appear
+- **AND** typing SHALL filter visible events by title and description
+
+### Requirement: Local Timezone and Locale-Aware Display
+
+All date and time labels in the calendar block SHALL render in the visitor's local timezone using `Intl.DateTimeFormat` with the active locale. The first day of the week SHALL default per locale (Sunday for en-US/pt-BR, Monday for en-GB/fr/de/es/zh) and SHALL be overridable via the block's `first_day_of_week` config.
+
+#### Scenario: Visitor in en-GB sees Monday as first column
+
+- **WHEN** a visitor with locale `en-GB` loads a Month view
+- **AND** the block has no `first_day_of_week` override
+- **THEN** the first weekday column SHALL be Monday
+
+#### Scenario: Event time displays in visitor's timezone
+
+- **WHEN** an event has `starts_at = "2026-05-09T15:00:00Z"`
+- **AND** the visitor's browser timezone is `America/New_York`
+- **THEN** the chip SHALL display the time as 11:00 AM (or local equivalent)
+
+### Requirement: One-Tap Add to Calendar (Browser-Side ICS)
+
+Each event chip and the bottom sheet detail SHALL provide an "Add to my calendar" affordance. Clicking it SHALL generate an RFC 5545–compliant `.ics` file in the browser without a server roundtrip and offer it as a download named `event-{id}.ics`. Special characters in title, description, and location SHALL be properly escaped per RFC 5545.
+
+#### Scenario: Visitor downloads a single-event ICS
+
+- **WHEN** a visitor clicks "Add to my calendar" on an event chip
+- **THEN** a `.ics` file SHALL be downloaded immediately
+- **AND** the file SHALL parse correctly when opened in iCal, Outlook, and Google Calendar
+
+#### Scenario: Event with special characters in title
+
+- **WHEN** an event title contains commas, semicolons, or newlines
+- **THEN** the generated VEVENT SUMMARY SHALL escape them per RFC 5545
+- **AND** parsing the file SHALL recover the original title verbatim
+
+### Requirement: Subscribable Calendar Feed (Edge Function)
+
+The system SHALL expose a `/api/calendar.ics` endpoint via the Run402 edge function `functions/calendar-ics.js`. Without a `token` query parameter, the endpoint SHALL return only events where `is_members_only = false`. With a valid signed `token` parameter bound to a `member_id`, the endpoint SHALL return all events including members-only. The response SHALL set `Content-Type: text/calendar; charset=utf-8` and SHALL include `REFRESH-INTERVAL;VALUE=DURATION:PT1H`.
+
+#### Scenario: Anonymous subscriber gets public events only
+
+- **WHEN** a request is made to `/api/calendar.ics` without a `token` query
+- **THEN** the response SHALL include only events with `is_members_only = false`
+- **AND** the `Content-Type` header SHALL be `text/calendar; charset=utf-8`
+
+#### Scenario: Member subscriber with valid token gets all events
+
+- **WHEN** a request is made to `/api/calendar.ics?token=...` with a token signed for `member_id = 42`
+- **AND** member 42 has access to members-only events
+- **THEN** the response SHALL include all events including members-only
+
+#### Scenario: Invalid token degrades to public feed
+
+- **WHEN** a request is made with a malformed or expired `token`
+- **THEN** the response SHALL fall back to the anonymous public-events feed
+- **AND** SHALL NOT return a 4xx error
+
+### Requirement: Subscription URL Surfaced to Members
+
+Members SHALL be able to obtain their personal `webcal://` subscription URL from the calendar block via a "Subscribe in your calendar app" button. Clicking the button SHALL copy the URL (with the member's signed token) to the clipboard and surface a toast confirmation. The same URL SHALL also be surfaced on the `/profile` page with a "Regenerate token" affordance that invalidates the prior token.
+
+#### Scenario: Member copies their subscription URL
+
+- **WHEN** an authenticated member clicks "Subscribe in your calendar app"
+- **THEN** the member's personal `webcal://` URL SHALL be written to the clipboard
+- **AND** a success toast SHALL appear
+
+#### Scenario: Member regenerates their token
+
+- **WHEN** a member clicks "Regenerate token" on /profile
+- **THEN** a new token SHALL be issued
+- **AND** the previously-issued token SHALL no longer authenticate the feed endpoint
+
+### Requirement: Inline Event Editing on Chips
+
+When an admin views the calendar block, event chips SHALL expose `data-editable` attributes on the title and location elements consistent with the existing inline-editing system. Date and time editing SHALL be available via a popover with native `datetime-local` inputs reachable from a click on the chip's date label.
+
+#### Scenario: Admin edits a chip title in place
+
+- **WHEN** an admin clicks the title text of an event chip and types
+- **THEN** the change SHALL be saved via the existing inline-editing PATCH flow
+- **AND** the chip SHALL update without a page reload
+
+### Requirement: Drag-to-Reschedule (Admin)
+
+Admins SHALL be able to drag an event chip from one day cell to another. On drop, the system SHALL preserve the time-of-day and duration of the event and PATCH the affected event's `starts_at` and `ends_at` (where present) by the same date delta. Multi-day events SHALL move both endpoints by the same delta. Failed PATCHes SHALL revert the optimistic update and surface a toast.
+
+#### Scenario: Admin drags single-day event to a new date
+
+- **WHEN** an admin drags an event scheduled for Tuesday May 5 at 10:00 AM to the cell for Thursday May 7
+- **THEN** the event's `starts_at` SHALL update to Thursday May 7 at 10:00 AM (visitor-local)
+- **AND** the event's `ends_at` (if set) SHALL shift by the same +2-day delta
+
+#### Scenario: Multi-day event drag preserves duration
+
+- **WHEN** an admin drags a 3-day event from May 5–7 to May 12
+- **THEN** the event SHALL be rescheduled to May 12–14
+- **AND** the duration SHALL remain exactly 3 days
+
+#### Scenario: Drag onto same day is a no-op
+
+- **WHEN** an admin drags an event chip back onto its original day cell
+- **THEN** no PATCH SHALL be issued
+- **AND** the chip SHALL render in its original position
+
+#### Scenario: Drag does not trigger cross-zone block move
+
+- **WHEN** an admin drags an event chip across calendar day cells
+- **THEN** the cross-zone drag handler defined in `AdminEditor.astro` SHALL NOT relocate the calendar block itself
+
+### Requirement: Stale-While-Revalidate Cache Per Window
+
+The block SHALL cache the events fetched per visible window in `localStorage` under key `wl_cache_events_{yyyy-mm-window}`. On hydrate, the block SHALL render from cache immediately when present, fetch fresh data in parallel, and re-render only when the response differs. The block SHALL prefetch the previous and next month windows using `requestIdleCallback` (with a `setTimeout` fallback) on initial load.
+
+#### Scenario: Cache hit renders without flicker
+
+- **WHEN** a visitor returns to the calendar page within the cache window
+- **THEN** the calendar SHALL paint from cached data on first frame
+- **AND** SHALL re-fetch in the background, repainting only if data has changed
+
+#### Scenario: Idle prefetch warms adjacent months
+
+- **WHEN** the calendar finishes its initial render
+- **THEN** within the next idle period the block SHALL fetch the previous and next month windows
+- **AND** navigating to those months SHALL render instantly from cache
+
+### Requirement: Reduced-Motion Compliance
+
+All animations introduced by the block (month-transition slide, view-mode crossfade, hover scale on chips, live-now pulse, bottom-sheet slide, popover fade) SHALL be gated on `(prefers-reduced-motion: no-preference)`. When the user prefers reduced motion the block SHALL still function fully but state changes SHALL apply instantly.
+
+#### Scenario: Reduced-motion user changes month
+
+- **WHEN** a user with `prefers-reduced-motion: reduce` clicks the next-month arrow
+- **THEN** the new month SHALL replace the previous month instantly
+- **AND** no slide or fade animation SHALL play

--- a/openspec/changes/events-calendar-view/tasks.md
+++ b/openspec/changes/events-calendar-view/tasks.md
@@ -1,0 +1,179 @@
+# Tasks: events-calendar-view
+
+## 1. Data + cache layer
+
+- [x] 1.1 Add `getEventWindow(start, end)` helper in `src/lib/api.ts` — single PostgREST call for the visible window, sorted by `starts_at` ascending.
+- [x] 1.2 Add `getRsvpsForEvents(ids[])` helper — batched join of `event_rsvps` + `members` for visible events; only `status=going`, capped at 300.
+- [x] 1.3 Add `wl_cache_events_{yyyy-mm-window}` SWR cache layer in a new `src/lib/calendar-cache.ts` (read-on-mount, fetch-on-mount, repaint-if-changed). Mirror existing `wl_cache_sections_*` pattern from `src/lib/page-render.ts`.
+- [x] 1.4 Add idle-prefetch for ±1 month using `requestIdleCallback` (with timeout fallback for browsers without it).
+- [ ] 1.5 Add cache invalidation on POST/PATCH/DELETE to `events` (called from inline edit + drag-resched + admin form). Helper `invalidateAllEventCaches` shipped; callers in `events.astro` / `event.astro` not yet dispatching `wl-events-changed`. Follow-up.
+
+## 2. Block scaffolding
+
+- [x] 2.1 Add `EVENTS_CALENDAR: BlockType` to `src/lib/blocks.ts` with `dynamic: true`, `zoneHints: ['main']`, `supportedSpans: ['1', '2/3', '1/2']` (1/3 column always falls through to agenda at runtime via container query).
+- [x] 2.2 Default config: `{ heading: 'Calendar', view: 'month', density: 'light', filter: 'all', first_day_of_week: 0, show_filter_chips: true, density_lock: false, agenda_show_empty_days: false }`.
+- [x] 2.3 `render()` emits skeleton with `data-block-hydrate="events_calendar"` and `data-config="{...}"` JSON attribute — mirrors `events_list` pattern.
+- [x] 2.4 `hydrate()` lazy-imports `./block-hydrators.js` → `hydrateEventsCalendar`. Hide block when `feature_events` disabled.
+- [x] 2.5 Register `events_calendar: EVENTS_CALENDAR` in `BLOCK_TYPES`.
+- [x] 2.6 Add icon `'\u{1F5D3}'` (🗓 spiral calendar pad) to differentiate from `events_list` (📅).
+- [x] 2.7 `src/seeds/types.ts` `SeedSection.section_type` is already `string`-typed — no union update needed.
+
+## 3. View controller (`src/lib/blocks/events-calendar.ts`)
+
+- [x] 3.1 Module entry `initCalendar(root, section, ctx)` — reads config, mounts state, attaches listeners, paints initial view from cache.
+- [x] 3.2 State machine: `{ currentMonth, view, effectiveView, density, filter, focusDate, peekDayKey, peekEventId, myRsvpEventIds, events, rsvps }`.
+- [x] 3.3 Container-query observer (`ResizeObserver`) — auto-switch to agenda when container width <600px regardless of `view` config; restore on resize. Honors `density_lock` config.
+- [x] 3.4 Repaint on `wl-locale-changed`, `wl-auth-changed`, `wl-events-changed`, `astro:after-swap`.
+- [x] 3.5 Cleanup on `astro:before-swap` (remove listeners, cancel idle prefetches).
+
+## 4. Month view
+
+- [x] 4.1 Render 6-row × 7-column grid with weekday headers, today highlighted, prev/next-month days dimmed.
+- [x] 4.2 Event chips per cell sorted by `starts_at`. Cap at 3 visible per cell + "+N more" affordance.
+- [x] 4.3 Live-now indicator (pulsing dot, `prefers-reduced-motion` strips animation but keeps dot visible).
+- [x] 4.4 Capacity badges: ≥80% full = "Filling fast"; capped = "Sold out"; otherwise omitted.
+- [x] 4.5 Members-only badge (`🔒` glyph) per chip when `is_members_only`.
+- [x] 4.6 ARIA `role="grid"`, `role="row"`, `role="gridcell"`. Roving `tabindex` for cell focus.
+- [x] 4.7 Live region announces month change ("May 2026, N events").
+
+## 5. Week view
+
+- [x] 5.1 Render 7 columns (one per day), sticky day headers. Hour-grid background omitted per design (agenda is cleaner for short events).
+- [x] 5.2 Event chips arranged top-to-bottom by `starts_at`. Multi-day events render as repeated chips on each day they span.
+- [x] 5.3 Today highlight + live-now indicator (same as month view).
+
+## 6. Agenda view (mobile default)
+
+- [x] 6.1 Render vertical list grouped by day. `agenda_show_empty_days: false` default skips days with no events.
+- [x] 6.2 Sticky day header on scroll (CSS `position: sticky`).
+- [ ] 6.3 Pull-to-refresh gesture detection — deferred to v2 (browsers handle this natively for the page anyway).
+- [ ] 6.4 Thin month strip at top with dot indicators — deferred to v2 once user feedback warrants it.
+
+## 7. Density modes (CSS-driven)
+
+- [x] 7.1 `block-events-calendar--density-glance` class — chips become 0.5-rem colored dots, info hidden. Live-now dots use danger color.
+- [x] 7.2 `block-events-calendar--density-light` — 1-line summary (default).
+- [x] 7.3 `block-events-calendar--density-rich` — card with thumbnail + RSVP avatars + capacity badge.
+- [x] 7.4 Density override config flag `density_lock: false` — when true, respects admin's view choice even at small container widths.
+
+## 8. Filter chips
+
+- [x] 8.1 Render chip row above grid: All / Members / Open / My RSVPs / Past.
+- [x] 8.2 "My RSVPs" chip hidden when not authenticated; on click, fetches the member's `event_rsvps` once and scopes the visible window to that ID set.
+- [x] 8.3 "Past" filter shows events older than today (client-side filter on the visible window).
+- [x] 8.4 Active chip persists in `localStorage` per block instance (`wl_calendar_filter_{section_id}`).
+
+## 9. Hover peek (desktop)
+
+- [x] 9.1 `(hover: hover) and (pointer: fine)` media query gates the peek.
+- [x] 9.2 200ms delay on hover-in; close on hover-out.
+- [ ] 9.3 Popover positions auto-flip when near viewport edges — currently centered on the block; v1 acceptable.
+- [x] 9.4 Popover renders all events for the day with locations, RSVP avatars (when present), and "Add to my calendar" buttons. Inline RSVP buttons deferred.
+- [x] 9.5 Popover Esc-closeable; clicking outside (backdrop) closes.
+
+## 10. Bottom sheet (mobile)
+
+- [x] 10.1 Peek popover transforms into a bottom sheet on `<600px` viewport via `@media (max-width: 600px)` rule with `bec-slide-up` animation. Tap-to-dismiss on backdrop / close button.
+- [x] 10.2 Sheet shows event details (title, time, location, capacity, members-only flag).
+- [x] 10.3 "Open full event →" implicit via the chip anchor `href="/event.html?id=N"`.
+- [ ] 10.4 Drag-down-to-dismiss gesture — deferred to v2 (close button + backdrop tap cover dismissal).
+
+## 11. Keyboard navigation + ⌘K search
+
+- [x] 11.1 ↑↓←→ moves focus between cells (month view); cross-month nav loads adjacent window.
+- [x] 11.2 Enter opens peek for the focused day.
+- [x] 11.3 T jumps to today; M/W/A switch view modes (segmented buttons also bound).
+- [x] 11.4 Esc closes any open peek/sheet.
+- [ ] 11.5 ⌘K fuzzy search — deferred to v2.
+
+## 12. ICS export + subscription
+
+- [x] 12.1 ICS generator inline at `src/lib/blocks/events-calendar.ts` (`escIcs`, `fmtIcsDate`, `eventToIcs`). Per RFC 5545, escapes `\\`, `;`, `,`, newlines.
+- [x] 12.2 "Add to my calendar" button in the peek/bottom sheet — generates `event-{id}.ics` via `Blob` + `<a download>` with no server roundtrip.
+- [ ] 12.3 `functions/calendar-ics.js` Run402 edge function — deferred. Single-event export covers the common case; subscribable feed scoped for the next iteration.
+- [ ] 12.4 `Content-Type: text/calendar` headers — deferred (ships with edge function in 12.3).
+- [ ] 12.5 Cache headers — deferred with edge function.
+- [ ] 12.6 "Subscribe in your calendar app" button — deferred with edge function.
+- [ ] 12.7 Profile-page calendar feed token section — deferred with edge function.
+- [ ] 12.8 `members.calendar_feed_token` column — deferred with edge function.
+
+## 13. Inline editing + drag-to-reschedule
+
+- [ ] 13.1 Event chip title/location use existing `data-editable` — chips currently render as anchor links with no `data-editable` attrs in the block (would conflict with chip click → /event.html). Path forward: render an admin-only edit pencil overlay rather than making the chip text editable.
+- [ ] 13.2 Date-time editing popover — deferred.
+- [ ] 13.3 Cross-day drag detection in `AdminEditor.astro` — deferred.
+- [ ] 13.4 Multi-day event drag preserves duration — deferred.
+- [ ] 13.5 Tests — deferred with the implementation.
+
+> Note: Phase 13 (admin authoring features) is deferred to a follow-up iteration in favor of shipping a complete reading experience first. The admin can still create/edit events via the existing `/events.html` modal and `/event.html` detail page; the calendar reflects those changes via the standard cache invalidation hook.
+
+## 14. Page route
+
+- [x] 14.1 `src/pages/calendar.astro` — Portal-wrapped, single section that mounts an `events_calendar` block at full width with Rich density.
+- [x] 14.2 "View as calendar →" link added to `src/pages/events.astro` heading.
+- [ ] 14.3 Default nav config — leave to per-seed customization rather than templating in the global default.
+- [ ] 14.4 Per-seed updates — deferred. Demos can place the block via the composer once the change is deployed.
+
+## 15. CSS
+
+- [x] 15.1 `public/css/block-events-calendar.css` covers grid, chips, density variants, filter chips, peek/bottom sheet.
+- [x] 15.2 Container queries (`@container events-calendar`) drive responsive density fall-through.
+- [x] 15.3 `prefers-reduced-motion: reduce` strips live-pulse animation and bottom-sheet slide.
+- [x] 15.4 Theme integration via `--color-primary`, `--color-accent`, `--color-surface`, `--color-border`, etc. No new theme keys introduced.
+- [x] 15.5 Stylesheet lazy-loaded by the hydrator via `ensureCss()` (one `<link>` per page session).
+
+## 16. i18n
+
+- [ ] 16.1 ~30 calendar strings table inline in TS for v1; full-spec move to `public/custom/strings/en.json` deferred to follow-up.
+- [ ] 16.2 Mirror to non-en locales — deferred (en-only fallback works for all locales until then).
+- [ ] 16.3 First-day-of-week per locale — block defaults via `first_day_of_week` config (admin can override per instance). Locale-driven default deferred.
+
+## 17. Tests
+
+- [ ] 17.1 `tests/blocks/events-calendar.test.ts` — deferred to a focused test pass.
+- [ ] 17.2 `tests/lib/ics-generator.test.ts` — deferred.
+- [ ] 17.3 `tests/lib/calendar-cache.test.ts` — deferred.
+- [ ] 17.4 Integration / a11y tree — deferred.
+- [ ] 17.5 Coverage threshold — re-run after tests land.
+
+## 18. Docs
+
+- [ ] 18.1 `CUSTOMIZING.md` / `docs/spec.md` section — deferred.
+- [ ] 18.2 `THEME.md` — verified no new keys; no doc update needed.
+- [x] 18.3 `CLAUDE.md` block-registry note — already consistent (`events_calendar` joins via `BLOCK_TYPES`).
+
+## 19. Demo + deploy
+
+- [ ] 19.1 Block placement on demo home pages — deferred to first deploy decision.
+- [ ] 19.2 `calendar-ics.js` deploy registration — deferred with the edge function.
+- [ ] 19.3 Verify demo deploy paths — pending first deploy.
+- [ ] 19.4 `bash deploy-all.sh` — pending first deploy.
+- [ ] 19.5 CI watch — pending first deploy.
+
+## 20. Follow-up tickets
+
+- [x] 20.1 Recurring events ([#79](https://github.com/kychee-com/kychon/issues/79)) — filed.
+- [ ] 20.2 File: "events: subscribable .ics feed via Run402 edge function" — covers tasks 12.3–12.8.
+- [ ] 20.3 File: "events: drag-to-reschedule (admin)" — covers phase 13.
+- [ ] 20.4 File: "events: ⌘K search across calendar" — covers 11.5.
+- [ ] 20.5 File: "events: AI-generated 'this month at a glance' summary" — premium feature.
+
+---
+
+**Verification (this slice):**
+
+- [x] `astro check` passes (zero errors, zero warnings introduced by the change).
+- [x] `astro build` succeeds across all 15 routes including new `/calendar.html`.
+- [x] Calendar renders Month, Week, and Agenda views with seeded events in the static preview.
+- [x] Filter chips (All/Members/Open/Past) toggle correctly; My RSVPs hidden when unauthenticated.
+- [x] Peek popover opens on day-cell "+N more" click and on hover.
+- [x] Density Glance reduces chips to colored dots; Light shows 1-line summary; Rich shows card style.
+- [x] Mobile (375px) auto-falls-through to Agenda view; Month/Week segmented control hidden.
+- [x] "Add to my calendar" downloads a valid `event-{id}.ics` file.
+- [x] "View as calendar →" link on `/events.html` navigates to `/calendar.html`.
+
+**What's next:**
+1. Wire `wl-events-changed` dispatch in `events.astro` / `event.astro` after CRUD (closes 1.5).
+2. ICS subscription edge function (separate change — file ticket per 20.2).
+3. Drag-to-reschedule + inline edit on chips (separate change — file ticket per 20.3).
+4. Tests + docs pass.

--- a/public/css/block-events-calendar.css
+++ b/public/css/block-events-calendar.css
@@ -1,0 +1,621 @@
+/* block-events-calendar.css — styles for the events_calendar block.
+   Theme integration via existing CSS variables (--color-*, --radius, --space-*).
+   Container queries drive the narrow → forced-agenda fall-through.
+   prefers-reduced-motion strips slide / pulse / fade animations. */
+
+.block-events-calendar {
+  container-type: inline-size;
+  container-name: events-calendar;
+  position: relative;
+}
+
+.block-events-calendar__heading {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+/* --- Controls --- */
+
+.block-events-calendar__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.block-events-calendar__nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.block-events-calendar__arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+  background: var(--color-surface, #fff);
+  color: var(--color-text, inherit);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.block-events-calendar__arrow:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+.block-events-calendar__month-label {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  min-width: 9rem;
+  text-align: center;
+}
+
+.block-events-calendar__today-btn {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+  background: var(--color-surface, #fff);
+  color: var(--color-text, inherit);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.block-events-calendar__today-btn:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+.block-events-calendar__seg {
+  display: inline-flex;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+  overflow: hidden;
+}
+.block-events-calendar__seg-btn {
+  padding: 0.375rem 0.75rem;
+  border: 0;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, inherit);
+  font-size: 0.875rem;
+  cursor: pointer;
+  border-right: 1px solid var(--color-border, #e5e7eb);
+}
+.block-events-calendar__seg-btn:last-child { border-right: 0; }
+.block-events-calendar__seg-btn.is-active {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+}
+.block-events-calendar__seg-btn:not(.is-active):hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+/* --- Filter chips --- */
+
+.block-events-calendar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+.block-events-calendar__filter-chip {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 999px;
+  background: var(--color-surface, #fff);
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.block-events-calendar__filter-chip:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+  color: var(--color-text, inherit);
+}
+.block-events-calendar__filter-chip.is-active {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  border-color: var(--color-primary, #2563eb);
+}
+
+/* --- Month grid --- */
+
+.block-events-calendar__grid {
+  display: grid;
+  grid-template-rows: auto repeat(6, minmax(6rem, 1fr));
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+  overflow: hidden;
+  background: var(--color-surface, #fff);
+}
+
+.block-events-calendar__weekdays,
+.block-events-calendar__row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.block-events-calendar__weekdays {
+  background: var(--color-surface-alt, #f9fafb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+.block-events-calendar__weekday {
+  padding: 0.5rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #6b7280);
+  text-align: center;
+}
+
+.block-events-calendar__cell {
+  position: relative;
+  min-height: 6rem;
+  padding: 0.375rem 0.375rem 0.5rem;
+  border-right: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  outline: none;
+  cursor: default;
+}
+.block-events-calendar__cell:nth-child(7n) { border-right: 0; }
+.block-events-calendar__row:last-child .block-events-calendar__cell { border-bottom: 0; }
+.block-events-calendar__cell.is-outside { background: var(--color-surface-alt, #f9fafb); }
+.block-events-calendar__cell.is-outside .block-events-calendar__cell-num { opacity: 0.4; }
+.block-events-calendar__cell.is-today .block-events-calendar__cell-num {
+  background: var(--color-accent, var(--color-primary, #2563eb));
+  color: #fff;
+  border-radius: 999px;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.block-events-calendar__cell.is-focused {
+  outline: 2px solid var(--color-primary, #2563eb);
+  outline-offset: -2px;
+}
+
+.block-events-calendar__cell-num {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #6b7280);
+  font-variant-numeric: tabular-nums;
+}
+
+.block-events-calendar__cell-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+/* --- Event chips (anchor links) --- */
+
+.block-events-calendar a.block-events-calendar__chip {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  text-decoration: none;
+  font-size: 0.75rem;
+  color: var(--color-text, inherit);
+  background: var(--color-primary-soft, rgba(37, 99, 235, 0.08));
+  border-left: 3px solid var(--color-primary, #2563eb);
+  padding: 0.1875rem 0.375rem;
+  border-radius: 0.25rem;
+  min-width: 0;
+  overflow: hidden;
+}
+.block-events-calendar a.block-events-calendar__chip:hover {
+  background: var(--color-primary-soft-hover, rgba(37, 99, 235, 0.15));
+}
+.block-events-calendar a.block-events-calendar__chip.is-live {
+  border-left-color: var(--color-danger, #ef4444);
+}
+
+.block-events-calendar__chip-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.6875rem;
+  flex-shrink: 0;
+}
+.block-events-calendar__chip-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+.block-events-calendar__chip-thumb {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.1875rem;
+  background-size: cover;
+  background-position: center;
+  flex-shrink: 0;
+}
+
+/* Density: glance — chip becomes a colored dot. */
+.block-events-calendar--density-glance a.block-events-calendar__chip {
+  width: 0.5rem;
+  height: 0.5rem;
+  min-width: 0.5rem;
+  padding: 0;
+  border-radius: 999px;
+  border-left: 0;
+  background: var(--color-primary, #2563eb);
+  display: inline-block;
+  flex: none;
+}
+.block-events-calendar--density-glance a.block-events-calendar__chip.is-live {
+  background: var(--color-danger, #ef4444);
+}
+.block-events-calendar--density-glance .block-events-calendar__chip-title,
+.block-events-calendar--density-glance .block-events-calendar__chip-time,
+.block-events-calendar--density-glance .block-events-calendar__chip-thumb,
+.block-events-calendar--density-glance .block-events-calendar__lock,
+.block-events-calendar--density-glance .block-events-calendar__avatars,
+.block-events-calendar--density-glance .block-events-calendar__badge {
+  display: none;
+}
+.block-events-calendar--density-glance .block-events-calendar__cell-events {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+}
+
+/* Density: rich — full card style. */
+.block-events-calendar--density-rich .block-events-calendar__chip {
+  flex-wrap: wrap;
+  padding: 0.375rem 0.5rem;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-left: 3px solid var(--color-primary, #2563eb);
+  border-radius: var(--radius, 0.375rem);
+}
+
+/* --- Live-now dot --- */
+
+.block-events-calendar__live-dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--color-danger, #ef4444);
+  flex-shrink: 0;
+  animation: bec-pulse 1.6s ease-in-out infinite;
+}
+@keyframes bec-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.7; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .block-events-calendar__live-dot { animation: none; }
+}
+
+/* --- Lock + capacity badges --- */
+
+.block-events-calendar__lock {
+  font-size: 0.6875rem;
+  flex-shrink: 0;
+}
+
+.block-events-calendar__badge {
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.block-events-calendar__badge--filling {
+  background: var(--color-warning-soft, rgba(245, 158, 11, 0.18));
+  color: var(--color-warning, #b45309);
+}
+.block-events-calendar__badge--sold {
+  background: var(--color-danger-soft, rgba(239, 68, 68, 0.15));
+  color: var(--color-danger, #b91c1c);
+}
+
+/* --- RSVP avatars --- */
+
+.block-events-calendar__avatars {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.block-events-calendar__avatar {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  border: 2px solid var(--color-surface, #fff);
+  margin-left: -0.375rem;
+  object-fit: cover;
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  font-size: 0.625rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.block-events-calendar__avatar:first-child { margin-left: 0; }
+.block-events-calendar__avatar-more {
+  margin-left: 0.25rem;
+  font-size: 0.6875rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* --- "+N more" overflow link --- */
+
+.block-events-calendar__more {
+  font-size: 0.6875rem;
+  background: transparent;
+  border: 0;
+  padding: 0.125rem 0.375rem;
+  color: var(--color-primary, #2563eb);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+}
+.block-events-calendar__more:hover { text-decoration: none; }
+
+/* --- Agenda view --- */
+
+.block-events-calendar__agenda {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.block-events-calendar__agenda-day { }
+.block-events-calendar__agenda-day.is-today .block-events-calendar__agenda-heading {
+  color: var(--color-accent, var(--color-primary, #2563eb));
+}
+.block-events-calendar__agenda-heading {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-surface, #fff);
+  margin: 0 0 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #6b7280);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+.block-events-calendar__agenda-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.block-events-calendar--view-agenda .block-events-calendar__chip,
+.block-events-calendar--view-agenda a.block-events-calendar__chip {
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+}
+
+/* --- Week view --- */
+
+.block-events-calendar__week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+}
+.block-events-calendar__week-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+  padding: 0.5rem;
+  min-height: 12rem;
+  background: var(--color-surface, #fff);
+}
+.block-events-calendar__week-col.is-today { border-color: var(--color-primary, #2563eb); }
+.block-events-calendar__week-head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  padding-bottom: 0.25rem;
+}
+.block-events-calendar__week-dow {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #6b7280);
+}
+.block-events-calendar__week-num {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+.block-events-calendar__week-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* --- Peek overlay (dialog) --- */
+
+.block-events-calendar__peek {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(28rem, 90vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius-lg, 0.5rem);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.12);
+  padding: 1rem 1.25rem;
+  z-index: 100;
+}
+.block-events-calendar__peek-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  background: transparent;
+  border: 0;
+  font-size: 1rem;
+  cursor: pointer;
+  color: var(--color-text-muted, #6b7280);
+  border-radius: 999px;
+}
+.block-events-calendar__peek-close:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+.block-events-calendar__peek-heading {
+  margin: 0 2rem 0.75rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.block-events-calendar__peek-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.block-events-calendar__peek-item {
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  padding-bottom: 0.75rem;
+}
+.block-events-calendar__peek-item:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+.block-events-calendar__peek-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--color-text, inherit);
+  font-weight: 500;
+}
+.block-events-calendar__peek-link:hover { text-decoration: underline; }
+.block-events-calendar__peek-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted, #6b7280);
+  flex-shrink: 0;
+}
+.block-events-calendar__peek-title { flex: 1; }
+.block-events-calendar__peek-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.block-events-calendar__peek-actions {
+  margin-top: 0.5rem;
+}
+.block-events-calendar__peek-ics {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  border: 0;
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius, 0.375rem);
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+.block-events-calendar__peek-ics:hover {
+  filter: brightness(0.95);
+}
+
+/* Mobile peek transforms into a bottom sheet. */
+@media (max-width: 600px) {
+  .block-events-calendar__peek {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform: none;
+    width: 100%;
+    max-width: 100%;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top-left-radius: var(--radius-lg, 0.75rem);
+    border-top-right-radius: var(--radius-lg, 0.75rem);
+    max-height: 80vh;
+    animation: bec-slide-up 220ms ease-out;
+  }
+}
+@keyframes bec-slide-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .block-events-calendar__peek { animation: none; }
+}
+
+/* --- Empty + skeleton --- */
+
+.block-events-calendar__empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+  border: 1px dashed var(--color-border, #e5e7eb);
+  border-radius: var(--radius, 0.375rem);
+}
+.block-events-calendar__skeleton {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  min-height: 8rem;
+}
+
+/* --- Container query: narrow → forced agenda --- */
+
+@container events-calendar (max-width: 600px) {
+  .block-events-calendar__seg-btn[data-view="month"],
+  .block-events-calendar__seg-btn[data-view="week"] {
+    /* still tappable but visually de-emphasized on narrow containers */
+    opacity: 0.55;
+  }
+  .block-events-calendar__week {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Visual hint when block is narrow: hide the segmented control entirely. */
+.block-events-calendar--narrow .block-events-calendar__seg {
+  display: none;
+}
+.block-events-calendar--narrow .block-events-calendar__chips {
+  overflow-x: auto;
+  flex-wrap: nowrap;
+  scrollbar-width: thin;
+}
+
+/* --- View transition + reduced motion --- */
+
+.block-events-calendar__viewport {
+  position: relative;
+  min-height: 8rem;
+}
+.block-events-calendar__viewport[data-view="month"] {
+  /* placeholder hook for future view-transition styling */
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -144,6 +144,28 @@ export async function getEventRSVPs(eventId: number): Promise<EventRSVP[]> {
   return z.array(EventRSVPSchema).parse(data);
 }
 
+export async function getEventWindow(startIso: string, endIso: string): Promise<Event[]> {
+  const data = await get(
+    `events?starts_at=gte.${encodeURIComponent(startIso)}&starts_at=lt.${encodeURIComponent(endIso)}&order=starts_at.asc`,
+  );
+  return z.array(EventSchema).parse(data);
+}
+
+export interface RsvpAvatar {
+  event_id: number;
+  member_id: number | null;
+  members: { id: number; display_name: string | null; avatar_url: string | null } | null;
+}
+
+export async function getRsvpsForEvents(eventIds: number[]): Promise<RsvpAvatar[]> {
+  if (!eventIds.length) return [];
+  const ids = eventIds.join(',');
+  const data = await get(
+    `event_rsvps?event_id=in.(${ids})&status=eq.going&select=event_id,member_id,members(id,display_name,avatar_url)&limit=300`,
+  );
+  return Array.isArray(data) ? (data as RsvpAvatar[]) : [];
+}
+
 export async function getMembers(query = ''): Promise<Member[]> {
   const data = await get(`members${query ? `?${query}` : ''}`);
   return z.array(MemberSchema).parse(data);

--- a/src/lib/block-hydrators.ts
+++ b/src/lib/block-hydrators.ts
@@ -311,6 +311,19 @@ export async function hydrateLinkListResources(
 
 const EVENTS_LIST_FILTER_DAYS = 7;
 
+export async function hydrateEventsCalendar(
+  el: HTMLElement,
+  section: Section,
+  ctx: BlockRenderContext,
+): Promise<void> {
+  const root = el.querySelector('[data-block-hydrate="events_calendar"]') as HTMLElement | null;
+  if (!root) return;
+  if (root.dataset.hydrated === 'true') return;
+  const { initCalendar } = await import('./blocks/events-calendar.js');
+  initCalendar(root, section, ctx);
+  root.dataset.hydrated = 'true';
+}
+
 export async function hydrateEventsList(
   el: HTMLElement,
   _section: Section,

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1345,6 +1345,46 @@ const EVENTS_LIST: BlockType = {
   },
 };
 
+const EVENTS_CALENDAR: BlockType = {
+  label: 'Events Calendar',
+  icon: '\u{1F5D3}', // 🗓 spiral calendar pad — distinct from events_list (📅)
+  dynamic: true,
+  zoneHints: ['main'],
+  // 1/3 column always falls through to agenda at runtime; the picker still
+  // allows '1' (full) and '2/3' as desktop layouts.
+  supportedSpans: ['1', '2/3', '1/2'],
+  defaultConfig: {
+    heading: 'Calendar',
+    view: 'month',
+    density: 'light',
+    filter: 'all',
+    first_day_of_week: 0,
+    show_filter_chips: true,
+    density_lock: false,
+    agenda_show_empty_days: false,
+  },
+  render(section, ctx) {
+    const cfg = section.config || {};
+    const heading = cfg.heading
+      ? `<h2 class="block-events-calendar__heading"${editableAttr(section, 'heading', ctx)}>${escHtml(cfg.heading)}</h2>`
+      : '';
+    const view = (cfg.view as string) || 'month';
+    const density = (cfg.density as string) || 'light';
+    const skeleton = `<div class="block-events-calendar__skeleton">${'<div class="event-skeleton-card skeleton"></div>'.repeat(4)}</div>`;
+    const inner = `<div class="container" data-block-hydrate="events_calendar" data-config="${jsonAttr(cfg)}">${heading}${skeleton}</div>`;
+    const cls = `section section-events-calendar block-events-calendar block-events-calendar--view-${escAttr(view)} block-events-calendar--density-${escAttr(density)}`;
+    return adminWrap(section, ctx, inner, cls);
+  },
+  async hydrate(el, section, ctx) {
+    if (!ctx.isFeatureEnabled?.('feature_events')) {
+      el.style.display = 'none';
+      return;
+    }
+    const { hydrateEventsCalendar } = await import('./block-hydrators.js');
+    await hydrateEventsCalendar(el, section, ctx);
+  },
+};
+
 const SLIDESHOW: BlockType = {
   label: 'Slideshow',
   icon: '\u{1F5BC}', // 🖼 (shared with banner; ok)
@@ -1444,6 +1484,7 @@ export const BLOCK_TYPES: Record<string, BlockType> = {
   link_list: LINK_LIST,
   promo_cards: PROMO_CARDS,
   events_list: EVENTS_LIST,
+  events_calendar: EVENTS_CALENDAR,
   slideshow: SLIDESHOW,
   nav: NAV,
   brand_header: BRAND_HEADER,

--- a/src/lib/blocks/events-calendar.ts
+++ b/src/lib/blocks/events-calendar.ts
@@ -1,0 +1,917 @@
+// events-calendar.ts — Lazy-loaded view controller for the events_calendar block.
+//
+// State machine drives Month / Week / Agenda views with three density modes.
+// Stale-while-revalidate cache via calendar-cache.ts. Container-query
+// observer auto-falls-through to Agenda below 600px regardless of admin's
+// configured view.
+
+import type { BlockRenderContext, Section } from '../blocks.js';
+import { escAttr, escHtml } from '../blocks.js';
+import { get, patch } from '../api.js';
+import {
+  cancelPendingPrefetches,
+  fetchAndUpdateWindow,
+  invalidateAllEventCaches,
+  readEventWindow,
+  readRsvpsForWindow,
+  schedulePrefetch,
+  windowKey,
+} from '../calendar-cache.js';
+import type { Event } from '../../schemas/event.js';
+import type { RsvpAvatar } from '../api.js';
+
+type ViewMode = 'month' | 'week' | 'agenda';
+type Density = 'glance' | 'light' | 'rich';
+type Filter = 'all' | 'members' | 'open' | 'my_rsvps' | 'past';
+
+interface Config {
+  heading?: string;
+  view?: ViewMode;
+  density?: Density;
+  filter?: Filter;
+  first_day_of_week?: number;
+  show_filter_chips?: boolean;
+  density_lock?: boolean;
+  agenda_show_empty_days?: boolean;
+}
+
+interface State {
+  currentMonth: Date;     // anchor: first of month, UTC-mid for stability
+  view: ViewMode;         // requested view
+  effectiveView: ViewMode; // post-container-query (may degrade to agenda)
+  density: Density;
+  filter: Filter;
+  focusDate: Date | null;
+  peekDayKey: string | null;
+  peekEventId: number | null;
+  myRsvpEventIds: Set<number> | null;
+  events: Event[];
+  rsvps: RsvpAvatar[];
+}
+
+const REDUCED_MOTION = typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+const HOVER_CAPABLE = typeof window !== 'undefined' &&
+  window.matchMedia?.('(hover: hover) and (pointer: fine)').matches;
+
+// CSS injection — one stylesheet per page session.
+const CSS_HREF = '/css/block-events-calendar.css';
+function ensureCss(): void {
+  if (typeof document === 'undefined') return;
+  if (document.querySelector(`link[data-events-calendar-css]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = CSS_HREF;
+  link.setAttribute('data-events-calendar-css', '');
+  document.head.appendChild(link);
+}
+
+// --- Date utilities (Intl-only, no external date lib) ---
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1, 0, 0, 0, 0);
+}
+
+function startOfWeek(d: Date, firstDow: number): Date {
+  const out = new Date(d);
+  const day = out.getDay();
+  const diff = (day - firstDow + 7) % 7;
+  out.setDate(out.getDate() - diff);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function addDays(d: Date, n: number): Date {
+  const out = new Date(d);
+  out.setDate(out.getDate() + n);
+  return out;
+}
+
+function addMonths(d: Date, n: number): Date {
+  const out = new Date(d);
+  out.setMonth(out.getMonth() + n);
+  return out;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
+function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+function dayKey(d: Date): string {
+  // Locally-keyed (not UTC) so an event on a date displays under that date.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+function fmtMonthYear(d: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(d);
+}
+
+function fmtWeekday(d: Date, locale: string, style: 'narrow' | 'short' = 'short'): string {
+  return new Intl.DateTimeFormat(locale, { weekday: style }).format(d);
+}
+
+function fmtDayOfMonth(d: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(d);
+}
+
+function fmtAgendaDayHeading(d: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long', month: 'short', day: 'numeric',
+  }).format(d);
+}
+
+function fmtTime(d: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }).format(d);
+}
+
+function fmtDateLong(d: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+  }).format(d);
+}
+
+// --- Visible window calculation (6 rows × 7 cols) ---
+
+function visibleWindow(currentMonth: Date, firstDow: number): { start: Date; end: Date } {
+  const start = startOfWeek(startOfMonth(currentMonth), firstDow);
+  const end = addDays(start, 42); // 6 weeks of 7 days = 42 cells
+  return { start, end };
+}
+
+// --- Filtering ---
+
+function filterEvents(events: Event[], state: State, now: Date): Event[] {
+  const myIds = state.myRsvpEventIds;
+  return events.filter((e) => {
+    if (state.filter === 'members' && !e.is_members_only) return false;
+    if (state.filter === 'open' && e.is_members_only) return false;
+    if (state.filter === 'my_rsvps' && (!myIds || !myIds.has(e.id))) return false;
+    if (state.filter === 'past' && new Date(e.starts_at) >= now) return false;
+    if (state.filter !== 'past' && new Date(e.starts_at) < startOfDay(now)) return false;
+    return true;
+  });
+}
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+// Group events by local-day key. Multi-day events appear on each day they span.
+function groupByDay(events: Event[]): Map<string, Event[]> {
+  const map = new Map<string, Event[]>();
+  for (const e of events) {
+    const start = new Date(e.starts_at);
+    const end = e.ends_at ? new Date(e.ends_at) : start;
+    const startDay = startOfDay(start);
+    const endDay = startOfDay(end);
+    let cursor = startDay;
+    while (cursor <= endDay) {
+      const k = dayKey(cursor);
+      const list = map.get(k) || [];
+      list.push(e);
+      map.set(k, list);
+      cursor = addDays(cursor, 1);
+      if (cursor.getTime() - startDay.getTime() > 365 * 86400000) break; // safety
+    }
+  }
+  return map;
+}
+
+// --- ICS (browser-side, single event one-tap) ---
+
+function escIcs(s: string): string {
+  return String(s ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n');
+}
+
+function fmtIcsDate(d: Date): string {
+  // Floating-form UTC: YYYYMMDDTHHMMSSZ
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const mi = String(d.getUTCMinutes()).padStart(2, '0');
+  const s = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${y}${m}${dd}T${h}${mi}${s}Z`;
+}
+
+function eventToIcs(evt: Event, host: string): string {
+  const start = new Date(evt.starts_at);
+  const end = evt.ends_at ? new Date(evt.ends_at) : new Date(start.getTime() + 60 * 60 * 1000);
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Kychon//Calendar//EN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:event-${evt.id}@${host}`,
+    `DTSTAMP:${fmtIcsDate(new Date())}`,
+    `DTSTART:${fmtIcsDate(start)}`,
+    `DTEND:${fmtIcsDate(end)}`,
+    `SUMMARY:${escIcs(evt.title || '')}`,
+    evt.location ? `LOCATION:${escIcs(evt.location)}` : null,
+    evt.description ? `DESCRIPTION:${escIcs(evt.description)}` : null,
+    `URL:https://${host}/event.html?id=${evt.id}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean) as string[];
+  return lines.join('\r\n');
+}
+
+function downloadIcs(evt: Event): void {
+  const host = window.location.host || 'kychon.run402.com';
+  const ics = eventToIcs(evt, host);
+  const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `event-${evt.id}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 0);
+}
+
+// --- HTML helpers ---
+
+function avatarChip(rsvp: RsvpAvatar): string {
+  const m = rsvp.members;
+  const name = m?.display_name || '?';
+  const initial = name.charAt(0).toUpperCase();
+  if (m?.avatar_url) {
+    return `<img class="block-events-calendar__avatar" src="${escAttr(m.avatar_url)}" alt="${escAttr(name)}" loading="lazy">`;
+  }
+  return `<span class="block-events-calendar__avatar block-events-calendar__avatar--initial" aria-label="${escAttr(name)}">${escHtml(initial)}</span>`;
+}
+
+function rsvpAvatarStack(eventId: number, rsvps: RsvpAvatar[]): string {
+  const list = rsvps.filter((r) => r.event_id === eventId).slice(0, 3);
+  if (!list.length) return '';
+  const total = rsvps.filter((r) => r.event_id === eventId).length;
+  const more = total > 3 ? `<span class="block-events-calendar__avatar-more">+${total - 3}</span>` : '';
+  return `<span class="block-events-calendar__avatars">${list.map(avatarChip).join('')}${more}</span>`;
+}
+
+function isLiveNow(evt: Event, now: Date): boolean {
+  const start = new Date(evt.starts_at);
+  if (start > now) return false;
+  if (evt.ends_at) return new Date(evt.ends_at) > now;
+  // No end → consider "live" for 2h after start.
+  return now.getTime() - start.getTime() < 2 * 60 * 60 * 1000;
+}
+
+function capacityBadge(evt: Event, rsvps: RsvpAvatar[], locale: string): string {
+  if (!evt.capacity) return '';
+  const going = rsvps.filter((r) => r.event_id === evt.id).length;
+  if (going >= evt.capacity) return `<span class="block-events-calendar__badge block-events-calendar__badge--sold">${escHtml(t('Sold out', locale))}</span>`;
+  if (going >= evt.capacity * 0.8) return `<span class="block-events-calendar__badge block-events-calendar__badge--filling">${escHtml(t('Filling fast', locale))}</span>`;
+  return '';
+}
+
+// Tiny in-file translations — full i18n table lives in public/custom/strings/{lang}.json.
+// For v1 we only translate strings the calendar surfaces; non-en falls back to en.
+const STRINGS_EN: Record<string, string> = {
+  'Calendar': 'Calendar',
+  'Today': 'Today',
+  'Month': 'Month',
+  'Week': 'Week',
+  'Agenda': 'Agenda',
+  'All': 'All',
+  'Members': 'Members',
+  'Open': 'Open',
+  'My RSVPs': 'My RSVPs',
+  'Past': 'Past',
+  'Live now': 'Live now',
+  'Live': 'Live',
+  'Filling fast': 'Filling fast',
+  'Sold out': 'Sold out',
+  'Members only': 'Members only',
+  'No events.': 'No events.',
+  'No events this month.': 'No events this month.',
+  'Add to my calendar': 'Add to my calendar',
+  'Subscribe in your calendar app': 'Subscribe in your calendar app',
+  'Open full event': 'Open full event',
+  'more': 'more',
+  'Previous month': 'Previous month',
+  'Next month': 'Next month',
+  'Previous week': 'Previous week',
+  'Next week': 'Next week',
+  'Loading…': 'Loading…',
+};
+function t(key: string, _locale: string): string {
+  // Future: lookup against active i18n strings. Today, en-only is fine — the
+  // public/custom/strings/{lang}.json files don't yet contain calendar keys.
+  return STRINGS_EN[key] ?? key;
+}
+
+// --- Renderers ---
+
+function renderControls(state: State, locale: string): string {
+  const monthLabel = fmtMonthYear(state.currentMonth, locale);
+  const segView = (key: ViewMode, label: string): string =>
+    `<button type="button" class="block-events-calendar__seg-btn${state.view === key ? ' is-active' : ''}" data-view="${key}" aria-pressed="${state.view === key}">${escHtml(t(label, locale))}</button>`;
+  return `
+    <div class="block-events-calendar__controls">
+      <div class="block-events-calendar__nav">
+        <button type="button" class="block-events-calendar__arrow" data-nav="prev" aria-label="${escAttr(t('Previous month', locale))}">‹</button>
+        <h3 class="block-events-calendar__month-label" aria-live="polite">${escHtml(monthLabel)}</h3>
+        <button type="button" class="block-events-calendar__arrow" data-nav="next" aria-label="${escAttr(t('Next month', locale))}">›</button>
+        <button type="button" class="block-events-calendar__today-btn" data-nav="today">${escHtml(t('Today', locale))}</button>
+      </div>
+      <div class="block-events-calendar__seg" role="tablist" aria-label="View mode">
+        ${segView('month', 'Month')}
+        ${segView('week', 'Week')}
+        ${segView('agenda', 'Agenda')}
+      </div>
+    </div>
+  `;
+}
+
+function renderFilterChips(state: State, locale: string, isAuthed: boolean): string {
+  const chip = (key: Filter, label: string, hidden = false): string => {
+    if (hidden) return '';
+    const active = state.filter === key ? ' is-active' : '';
+    return `<button type="button" class="block-events-calendar__filter-chip${active}" data-filter="${key}" aria-pressed="${state.filter === key}">${escHtml(t(label, locale))}</button>`;
+  };
+  return `
+    <div class="block-events-calendar__chips" role="group" aria-label="Filter">
+      ${chip('all', 'All')}
+      ${chip('members', 'Members')}
+      ${chip('open', 'Open')}
+      ${chip('my_rsvps', 'My RSVPs', !isAuthed)}
+      ${chip('past', 'Past')}
+    </div>
+  `;
+}
+
+function renderEventChip(
+  evt: Event,
+  state: State,
+  locale: string,
+  now: Date,
+  density: Density,
+): string {
+  const start = new Date(evt.starts_at);
+  const time = fmtTime(start, locale);
+  const live = isLiveNow(evt, now);
+  const liveDot = live
+    ? `<span class="block-events-calendar__live-dot" role="img" aria-label="${escAttr(t('Live now', locale))}"></span>`
+    : '';
+  const lock = evt.is_members_only ? `<span class="block-events-calendar__lock" aria-label="${escAttr(t('Members only', locale))}">🔒</span>` : '';
+  const cap = capacityBadge(evt, state.rsvps, locale);
+  const avatars = density === 'rich' ? rsvpAvatarStack(evt.id, state.rsvps) : '';
+  const thumb = density === 'rich' && evt.image_url
+    ? `<span class="block-events-calendar__chip-thumb" style="background-image:url(${escAttr(evt.image_url)})" aria-hidden="true"></span>`
+    : '';
+  const titleHtml = `<span class="block-events-calendar__chip-title">${escHtml(evt.title || '')}</span>`;
+  const timeHtml = density === 'glance' ? '' : `<span class="block-events-calendar__chip-time">${escHtml(time)}</span>`;
+  return `
+    <a class="block-events-calendar__chip block-events-calendar__chip--${density}${live ? ' is-live' : ''}"
+       href="/event.html?id=${evt.id}"
+       data-event-id="${evt.id}"
+       data-day="${escAttr(dayKey(start))}"
+       draggable="true">
+      ${thumb}${liveDot}${timeHtml}${titleHtml}${lock}${cap}${avatars}
+    </a>
+  `;
+}
+
+function renderMonthView(state: State, locale: string, _ctx: BlockRenderContext): string {
+  const firstDow = state.density === 'glance' ? 0 : (Number.isInteger((state as any).first_day_of_week) ? (state as any).first_day_of_week : 0);
+  const win = visibleWindow(state.currentMonth, firstDow);
+  const now = new Date();
+
+  // Weekday headers
+  const weekdayCells: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = addDays(win.start, i);
+    weekdayCells.push(`<div class="block-events-calendar__weekday" role="columnheader">${escHtml(fmtWeekday(d, locale, 'short'))}</div>`);
+  }
+
+  const filtered = filterEvents(state.events, state, now);
+  const grouped = groupByDay(filtered);
+
+  const rows: string[] = [];
+  for (let row = 0; row < 6; row++) {
+    const cells: string[] = [];
+    for (let col = 0; col < 7; col++) {
+      const cellDate = addDays(win.start, row * 7 + col);
+      const inMonth = isSameMonth(cellDate, state.currentMonth);
+      const today = isSameDay(cellDate, now);
+      const focused = state.focusDate && isSameDay(cellDate, state.focusDate);
+      const events = grouped.get(dayKey(cellDate)) || [];
+      const visible = events.slice(0, 3);
+      const overflow = events.length - visible.length;
+      const overflowHtml = overflow > 0
+        ? `<button type="button" class="block-events-calendar__more" data-day-peek="${escAttr(dayKey(cellDate))}">+${overflow} ${escHtml(t('more', locale))}</button>`
+        : '';
+      const chipsHtml = visible.map((e) => renderEventChip(e, state, locale, now, state.density)).join('');
+      const ariaLabel = `${fmtDateLong(cellDate, locale)}, ${events.length} ${events.length === 1 ? 'event' : 'events'}`;
+      cells.push(`
+        <div class="block-events-calendar__cell${inMonth ? '' : ' is-outside'}${today ? ' is-today' : ''}${focused ? ' is-focused' : ''}"
+             role="gridcell"
+             tabindex="${focused ? '0' : '-1'}"
+             data-day="${escAttr(dayKey(cellDate))}"
+             aria-label="${escAttr(ariaLabel)}">
+          <div class="block-events-calendar__cell-num">${escHtml(fmtDayOfMonth(cellDate, locale))}</div>
+          <div class="block-events-calendar__cell-events">${chipsHtml}${overflowHtml}</div>
+        </div>
+      `);
+    }
+    rows.push(`<div class="block-events-calendar__row" role="row">${cells.join('')}</div>`);
+  }
+
+  const liveRegion = `<div class="block-events-calendar__live-region sr-only" aria-live="polite"></div>`;
+  return `
+    <div class="block-events-calendar__grid" role="grid" aria-label="${escAttr(fmtMonthYear(state.currentMonth, locale))}" data-grid-cols="7">
+      <div class="block-events-calendar__weekdays" role="row">${weekdayCells.join('')}</div>
+      ${rows.join('')}
+    </div>
+    ${liveRegion}
+  `;
+}
+
+function renderAgendaView(state: State, locale: string): string {
+  const now = new Date();
+  const filtered = filterEvents(state.events, state, now).sort((a, b) => a.starts_at.localeCompare(b.starts_at));
+  if (!filtered.length) {
+    return `<div class="block-events-calendar__empty">${escHtml(t('No events this month.', locale))}</div>`;
+  }
+  // Group by day key, render header + chip list.
+  const grouped = groupByDay(filtered);
+  const dayKeys = Array.from(grouped.keys()).sort();
+  const sections = dayKeys.map((k) => {
+    const dayDate = new Date(k + 'T00:00:00');
+    const events = grouped.get(k)!;
+    const heading = fmtAgendaDayHeading(dayDate, locale);
+    const today = isSameDay(dayDate, now) ? ' is-today' : '';
+    const chips = events.map((e) => renderEventChip(e, state, locale, now, state.density === 'glance' ? 'light' : state.density)).join('');
+    return `
+      <section class="block-events-calendar__agenda-day${today}">
+        <h4 class="block-events-calendar__agenda-heading">${escHtml(heading)}</h4>
+        <div class="block-events-calendar__agenda-events">${chips}</div>
+      </section>
+    `;
+  });
+  return `<div class="block-events-calendar__agenda">${sections.join('')}</div>`;
+}
+
+function renderWeekView(state: State, locale: string): string {
+  // Week view = 7-column day strip, single row, taller cells.
+  const firstDow = 0;
+  const start = startOfWeek(state.focusDate || new Date(), firstDow);
+  const now = new Date();
+  const filtered = filterEvents(state.events, state, now);
+  const grouped = groupByDay(filtered);
+  const cols: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = addDays(start, i);
+    const events = grouped.get(dayKey(d)) || [];
+    const today = isSameDay(d, now) ? ' is-today' : '';
+    const chips = events.map((e) => renderEventChip(e, state, locale, now, state.density === 'glance' ? 'light' : state.density)).join('');
+    cols.push(`
+      <section class="block-events-calendar__week-col${today}" data-day="${escAttr(dayKey(d))}">
+        <header class="block-events-calendar__week-head">
+          <div class="block-events-calendar__week-dow">${escHtml(fmtWeekday(d, locale))}</div>
+          <div class="block-events-calendar__week-num">${escHtml(fmtDayOfMonth(d, locale))}</div>
+        </header>
+        <div class="block-events-calendar__week-events">${chips || `<div class="block-events-calendar__week-empty"></div>`}</div>
+      </section>
+    `);
+  }
+  return `<div class="block-events-calendar__week">${cols.join('')}</div>`;
+}
+
+// --- Main entry ---
+
+export function initCalendar(root: HTMLElement, _section: Section, ctx: BlockRenderContext): void {
+  ensureCss();
+
+  let cfg: Config = {};
+  try {
+    cfg = JSON.parse(root.getAttribute('data-config') || '{}');
+  } catch {}
+
+  const isAuthed = !!ctx.session;
+  const memberId = ctx.session?.user?.member?.id ?? null;
+
+  const state: State = {
+    currentMonth: startOfMonth(new Date()),
+    view: (cfg.view as ViewMode) || 'month',
+    effectiveView: (cfg.view as ViewMode) || 'month',
+    density: (cfg.density as Density) || 'light',
+    filter: (cfg.filter as Filter) || 'all',
+    focusDate: new Date(),
+    peekDayKey: null,
+    peekEventId: null,
+    myRsvpEventIds: null,
+    events: [],
+    rsvps: [],
+  };
+
+  // Container-query observer — drop to agenda below 600px unless density_lock.
+  let containerNarrow = false;
+  const ro = new ResizeObserver((entries) => {
+    const w = entries[0]?.contentRect.width || root.clientWidth;
+    const wasNarrow = containerNarrow;
+    containerNarrow = w < 600;
+    if (containerNarrow !== wasNarrow && !cfg.density_lock) {
+      const newEffective: ViewMode = containerNarrow ? 'agenda' : state.view;
+      if (newEffective !== state.effectiveView) {
+        state.effectiveView = newEffective;
+        repaint();
+      }
+    }
+  });
+  ro.observe(root);
+
+  // Strip the skeleton class+content; build the shell.
+  function shell(): string {
+    return `
+      ${state.peekDayKey ? '' /* peek rendered as overlay below */ : ''}
+      ${renderControls(state, ctx.locale)}
+      ${cfg.show_filter_chips !== false ? renderFilterChips(state, ctx.locale, isAuthed) : ''}
+      <div class="block-events-calendar__viewport" data-view="${state.effectiveView}"></div>
+    `;
+  }
+
+  function renderViewport(): string {
+    if (state.effectiveView === 'agenda') return renderAgendaView(state, ctx.locale);
+    if (state.effectiveView === 'week') return renderWeekView(state, ctx.locale);
+    return renderMonthView(state, ctx.locale, ctx);
+  }
+
+  function repaint(): void {
+    // Preserve scroll, focus where reasonable.
+    root.classList.toggle('block-events-calendar--narrow', containerNarrow);
+    root.classList.remove('block-events-calendar--view-month', 'block-events-calendar--view-week', 'block-events-calendar--view-agenda');
+    root.classList.add(`block-events-calendar--view-${state.effectiveView}`);
+    root.classList.remove('block-events-calendar--density-glance', 'block-events-calendar--density-light', 'block-events-calendar--density-rich');
+    root.classList.add(`block-events-calendar--density-${state.density}`);
+    root.innerHTML = shell();
+    const viewport = root.querySelector<HTMLElement>('.block-events-calendar__viewport');
+    if (viewport) viewport.innerHTML = renderViewport();
+    bindControls();
+    bindCells();
+    if (state.peekDayKey) renderPeekOverlay();
+    announceMonth();
+  }
+
+  function announceMonth(): void {
+    const live = root.querySelector('.block-events-calendar__live-region');
+    if (!live) return;
+    const count = filterEvents(state.events, state, new Date()).length;
+    live.textContent = `${fmtMonthYear(state.currentMonth, ctx.locale)}, ${count} ${count === 1 ? 'event' : 'events'}`;
+  }
+
+  // --- Data fetch ---
+
+  async function loadWindow(target = state.currentMonth): Promise<void> {
+    const firstDow = cfg.first_day_of_week ?? 0;
+    const win = visibleWindow(target, firstDow);
+    const key = windowKey(win.start);
+
+    // Synchronous cache-first paint.
+    const cachedEvents = readEventWindow(key);
+    const cachedRsvps = readRsvpsForWindow(key);
+    if (cachedEvents) {
+      state.events = cachedEvents;
+      state.rsvps = cachedRsvps || [];
+      repaint();
+    }
+
+    // Prep filter-specific extra fetch (My RSVPs).
+    if (state.filter === 'my_rsvps' && memberId) {
+      try {
+        const rows = await get(`event_rsvps?member_id=eq.${memberId}&select=event_id`);
+        state.myRsvpEventIds = new Set((rows as { event_id: number }[]).map((r) => r.event_id));
+      } catch (_e) {
+        state.myRsvpEventIds = new Set();
+      }
+    }
+
+    const result = await fetchAndUpdateWindow({
+      startIso: win.start.toISOString(),
+      endIso: win.end.toISOString(),
+      key,
+      withRsvps: state.density === 'rich',
+      onEvents: (evs) => {
+        state.events = evs;
+        repaint();
+      },
+      onRsvps: (rs) => {
+        state.rsvps = rs;
+        repaint();
+      },
+    });
+    state.events = result.events;
+    state.rsvps = result.rsvps;
+    repaint();
+
+    // Idle-prefetch ±1 month.
+    const prevMonth = addMonths(target, -1);
+    const nextMonth = addMonths(target, 1);
+    const prevWin = visibleWindow(prevMonth, firstDow);
+    const nextWin = visibleWindow(nextMonth, firstDow);
+    schedulePrefetch({
+      prevStart: prevWin.start,
+      prevEnd: prevWin.end,
+      nextStart: nextWin.start,
+      nextEnd: nextWin.end,
+      withRsvps: state.density === 'rich',
+    });
+  }
+
+  // --- Listeners ---
+
+  function bindControls(): void {
+    root.querySelectorAll<HTMLElement>('[data-nav]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const dir = btn.dataset.nav;
+        if (dir === 'today') {
+          state.currentMonth = startOfMonth(new Date());
+          state.focusDate = new Date();
+        } else if (dir === 'prev') {
+          state.currentMonth = addMonths(state.currentMonth, -1);
+        } else if (dir === 'next') {
+          state.currentMonth = addMonths(state.currentMonth, 1);
+        }
+        void loadWindow();
+      });
+    });
+    root.querySelectorAll<HTMLElement>('[data-view]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const v = btn.dataset.view as ViewMode;
+        if (v && v !== state.view) {
+          state.view = v;
+          state.effectiveView = containerNarrow && !cfg.density_lock ? 'agenda' : v;
+          repaint();
+        }
+      });
+    });
+    root.querySelectorAll<HTMLElement>('[data-filter]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const f = btn.dataset.filter as Filter;
+        if (f && f !== state.filter) {
+          state.filter = f;
+          // Persist per block instance.
+          try {
+            const sid = root.closest('[data-sortable-id]')?.getAttribute('data-sortable-id') || 'global';
+            localStorage.setItem(`wl_calendar_filter_${sid}`, f);
+          } catch {}
+          void loadWindow();
+        }
+      });
+    });
+  }
+
+  function bindCells(): void {
+    // Click chip → no special handling (anchor href to /event.html); drag handlers TODO.
+    // Click overflow "+N more" → open day peek.
+    root.querySelectorAll<HTMLElement>('[data-day-peek]').forEach((btn) => {
+      btn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        state.peekDayKey = btn.dataset.dayPeek || null;
+        renderPeekOverlay();
+      });
+    });
+
+    // Tap a day cell on touch → also opens peek (mobile-friendly).
+    root.querySelectorAll<HTMLElement>('.block-events-calendar__cell').forEach((cell) => {
+      cell.addEventListener('click', (ev) => {
+        if (HOVER_CAPABLE) return;
+        const target = ev.target as HTMLElement;
+        if (target.closest('a, button')) return;
+        const k = cell.dataset.day;
+        if (!k) return;
+        state.peekDayKey = k;
+        renderPeekOverlay();
+      });
+    });
+
+    // Hover peek (desktop only).
+    if (HOVER_CAPABLE) {
+      let hoverTimer: number | undefined;
+      root.querySelectorAll<HTMLElement>('.block-events-calendar__cell').forEach((cell) => {
+        cell.addEventListener('mouseenter', () => {
+          const events = (state.events && state.events.length)
+            ? filterEvents(state.events, state, new Date()).filter((e) => dayKey(new Date(e.starts_at)) === cell.dataset.day)
+            : [];
+          if (!events.length) return;
+          window.clearTimeout(hoverTimer);
+          hoverTimer = window.setTimeout(() => {
+            state.peekDayKey = cell.dataset.day || null;
+            renderPeekOverlay();
+          }, 200);
+        });
+        cell.addEventListener('mouseleave', () => {
+          window.clearTimeout(hoverTimer);
+        });
+      });
+    }
+  }
+
+  function renderPeekOverlay(): void {
+    // Remove any existing peek.
+    root.querySelector('.block-events-calendar__peek')?.remove();
+    if (!state.peekDayKey) return;
+
+    const dayDate = new Date(state.peekDayKey + 'T00:00:00');
+    const events = filterEvents(state.events, state, new Date()).filter((e) => {
+      const k = dayKey(new Date(e.starts_at));
+      return k === state.peekDayKey;
+    });
+    if (!events.length) {
+      state.peekDayKey = null;
+      return;
+    }
+    const heading = fmtDateLong(dayDate, ctx.locale);
+    const items = events.map((e) => {
+      const start = new Date(e.starts_at);
+      const time = fmtTime(start, ctx.locale);
+      const lock = e.is_members_only ? `<span class="block-events-calendar__lock" aria-label="${escAttr(t('Members only', ctx.locale))}">🔒</span>` : '';
+      const live = isLiveNow(e, new Date()) ? `<span class="block-events-calendar__live-dot" aria-label="${escAttr(t('Live now', ctx.locale))}"></span>` : '';
+      const cap = capacityBadge(e, state.rsvps, ctx.locale);
+      const avatars = rsvpAvatarStack(e.id, state.rsvps);
+      return `
+        <li class="block-events-calendar__peek-item">
+          <a class="block-events-calendar__peek-link" href="/event.html?id=${e.id}">
+            ${live}
+            <span class="block-events-calendar__peek-time">${escHtml(time)}</span>
+            <span class="block-events-calendar__peek-title">${escHtml(e.title || '')}</span>
+            ${lock}${cap}
+          </a>
+          <div class="block-events-calendar__peek-meta">${e.location ? `<span>${escHtml(e.location)}</span>` : ''}${avatars}</div>
+          <div class="block-events-calendar__peek-actions">
+            <button type="button" class="block-events-calendar__peek-ics" data-event-id="${e.id}">${escHtml(t('Add to my calendar', ctx.locale))}</button>
+          </div>
+        </li>
+      `;
+    }).join('');
+
+    const overlay = document.createElement('div');
+    overlay.className = 'block-events-calendar__peek';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'false');
+    overlay.setAttribute('aria-label', heading);
+    overlay.innerHTML = `
+      <button type="button" class="block-events-calendar__peek-close" aria-label="Close">✕</button>
+      <h4 class="block-events-calendar__peek-heading">${escHtml(heading)}</h4>
+      <ul class="block-events-calendar__peek-list">${items}</ul>
+    `;
+    root.appendChild(overlay);
+
+    overlay.querySelector('.block-events-calendar__peek-close')?.addEventListener('click', () => {
+      state.peekDayKey = null;
+      overlay.remove();
+    });
+    // Click outside closes
+    overlay.addEventListener('click', (ev) => {
+      if (ev.target === overlay) {
+        state.peekDayKey = null;
+        overlay.remove();
+      }
+    });
+    overlay.querySelectorAll<HTMLElement>('[data-event-id]').forEach((btn) => {
+      btn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const id = Number(btn.dataset.eventId);
+        const evt = state.events.find((e) => e.id === id);
+        if (evt) downloadIcs(evt);
+      });
+    });
+  }
+
+  // --- Keyboard nav (top-level on root) ---
+
+  function onKeyDown(ev: KeyboardEvent): void {
+    if (!root.contains(document.activeElement) && document.activeElement !== document.body) return;
+    const k = ev.key;
+    if (k === 'Escape' && state.peekDayKey) {
+      ev.preventDefault();
+      state.peekDayKey = null;
+      root.querySelector('.block-events-calendar__peek')?.remove();
+      return;
+    }
+    if (k === 't' || k === 'T') {
+      state.currentMonth = startOfMonth(new Date());
+      state.focusDate = new Date();
+      ev.preventDefault();
+      void loadWindow();
+      return;
+    }
+    if (k === 'm' || k === 'M') {
+      state.view = 'month';
+      state.effectiveView = containerNarrow && !cfg.density_lock ? 'agenda' : 'month';
+      ev.preventDefault();
+      repaint();
+      return;
+    }
+    if (k === 'w' || k === 'W') {
+      state.view = 'week';
+      state.effectiveView = containerNarrow && !cfg.density_lock ? 'agenda' : 'week';
+      ev.preventDefault();
+      repaint();
+      return;
+    }
+    if (k === 'a' || k === 'A') {
+      state.view = 'agenda';
+      state.effectiveView = 'agenda';
+      ev.preventDefault();
+      repaint();
+      return;
+    }
+    if (state.effectiveView === 'month' && (k === 'ArrowLeft' || k === 'ArrowRight' || k === 'ArrowUp' || k === 'ArrowDown' || k === 'Enter')) {
+      handleGridKeyNav(k);
+      ev.preventDefault();
+    }
+  }
+
+  function handleGridKeyNav(k: string): void {
+    if (!state.focusDate) state.focusDate = new Date();
+    let next = state.focusDate;
+    if (k === 'ArrowLeft') next = addDays(state.focusDate, -1);
+    else if (k === 'ArrowRight') next = addDays(state.focusDate, 1);
+    else if (k === 'ArrowUp') next = addDays(state.focusDate, -7);
+    else if (k === 'ArrowDown') next = addDays(state.focusDate, 7);
+    else if (k === 'Enter') {
+      // Open peek for the focused day.
+      state.peekDayKey = dayKey(state.focusDate);
+      renderPeekOverlay();
+      return;
+    }
+    state.focusDate = next;
+    if (!isSameMonth(next, state.currentMonth)) {
+      state.currentMonth = startOfMonth(next);
+      void loadWindow();
+    } else {
+      repaint();
+      // Move focus to new cell.
+      const cell = root.querySelector<HTMLElement>(`[data-day="${dayKey(next)}"]`);
+      cell?.focus();
+    }
+  }
+
+  document.addEventListener('keydown', onKeyDown);
+
+  // --- External event hooks ---
+  const onAuthChanged = () => {
+    void loadWindow();
+  };
+  const onLocaleChanged = () => repaint();
+  const onEventsChanged = () => {
+    invalidateAllEventCaches();
+    void loadWindow();
+  };
+  const onBeforeSwap = () => cleanup();
+
+  document.addEventListener('wl-auth-changed', onAuthChanged);
+  document.addEventListener('wl-locale-changed', onLocaleChanged);
+  document.addEventListener('wl-events-changed', onEventsChanged);
+  document.addEventListener('astro:before-swap', onBeforeSwap, { once: true });
+
+  function cleanup(): void {
+    ro.disconnect();
+    cancelPendingPrefetches();
+    document.removeEventListener('keydown', onKeyDown);
+    document.removeEventListener('wl-auth-changed', onAuthChanged);
+    document.removeEventListener('wl-locale-changed', onLocaleChanged);
+    document.removeEventListener('wl-events-changed', onEventsChanged);
+  }
+
+  // Restore persisted filter, if any.
+  try {
+    const sid = root.closest('[data-sortable-id]')?.getAttribute('data-sortable-id') || 'global';
+    const stored = localStorage.getItem(`wl_calendar_filter_${sid}`);
+    if (stored && ['all', 'members', 'open', 'my_rsvps', 'past'].includes(stored)) {
+      state.filter = stored as Filter;
+    }
+  } catch {}
+
+  // Initial paint and load.
+  repaint();
+  void loadWindow();
+
+  // Suppress unused vars warning for reduced-motion + patch (drag-resched TODO).
+  void REDUCED_MOTION;
+  void patch;
+}

--- a/src/lib/calendar-cache.ts
+++ b/src/lib/calendar-cache.ts
@@ -1,0 +1,172 @@
+// calendar-cache.ts — Stale-while-revalidate cache for calendar event windows.
+//
+// Each visible 6-week window keys against `wl_cache_events_{yyyy-mm}_window`.
+// Idle prefetch warms ±1 month so navigation feels instant.
+
+import type { Event } from '../schemas/event.js';
+import { getEventWindow, getRsvpsForEvents, type RsvpAvatar } from './api.js';
+
+const EVENTS_PREFIX = 'wl_cache_events_';
+const RSVPS_PREFIX = 'wl_cache_rsvps_';
+const TTL_MS = 5 * 60 * 1000;
+
+interface CachedWindow<T> {
+  data: T;
+  ts: number;
+}
+
+function readCache<T>(prefix: string, key: string): T | null {
+  try {
+    const raw = localStorage.getItem(prefix + key);
+    if (!raw) return null;
+    const parsed: CachedWindow<T> = JSON.parse(raw);
+    return parsed?.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache<T>(prefix: string, key: string, data: T): void {
+  try {
+    localStorage.setItem(prefix + key, JSON.stringify({ data, ts: Date.now() } satisfies CachedWindow<T>));
+  } catch {}
+}
+
+function isFresh(prefix: string, key: string): boolean {
+  try {
+    const raw = localStorage.getItem(prefix + key);
+    if (!raw) return false;
+    const { ts } = JSON.parse(raw);
+    return typeof ts === 'number' && ts + TTL_MS > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+export function windowKey(start: Date): string {
+  // Anchor on the first day of the visible window so adjacent months key cleanly.
+  const y = start.getUTCFullYear();
+  const m = String(start.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(start.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function readEventWindow(key: string): Event[] | null {
+  return readCache<Event[]>(EVENTS_PREFIX, key);
+}
+
+export function readRsvpsForWindow(key: string): RsvpAvatar[] | null {
+  return readCache<RsvpAvatar[]>(RSVPS_PREFIX, key);
+}
+
+export interface FetchWindowOpts {
+  startIso: string;
+  endIso: string;
+  key: string;
+  withRsvps: boolean;
+  onEvents?: (events: Event[]) => void;
+  onRsvps?: (rsvps: RsvpAvatar[]) => void;
+}
+
+export async function fetchAndUpdateWindow(opts: FetchWindowOpts): Promise<{
+  events: Event[];
+  rsvps: RsvpAvatar[];
+}> {
+  const cachedEvents = readEventWindow(opts.key);
+  let events: Event[] = [];
+  try {
+    events = await getEventWindow(opts.startIso, opts.endIso);
+  } catch (e) {
+    console.warn('events window fetch failed:', e);
+    return { events: cachedEvents ?? [], rsvps: readRsvpsForWindow(opts.key) ?? [] };
+  }
+  writeCache(EVENTS_PREFIX, opts.key, events);
+  if (
+    opts.onEvents &&
+    (!cachedEvents || JSON.stringify(cachedEvents) !== JSON.stringify(events))
+  ) {
+    opts.onEvents(events);
+  }
+
+  let rsvps: RsvpAvatar[] = readRsvpsForWindow(opts.key) ?? [];
+  if (opts.withRsvps && events.length) {
+    try {
+      rsvps = await getRsvpsForEvents(events.map((e) => e.id));
+      writeCache(RSVPS_PREFIX, opts.key, rsvps);
+      opts.onRsvps?.(rsvps);
+    } catch (e) {
+      console.warn('rsvp window fetch failed:', e);
+    }
+  }
+  return { events, rsvps };
+}
+
+export interface IdlePrefetchOpts {
+  prevStart: Date;
+  prevEnd: Date;
+  nextStart: Date;
+  nextEnd: Date;
+  withRsvps: boolean;
+}
+
+const idleHandles = new Set<number>();
+
+export function schedulePrefetch(opts: IdlePrefetchOpts): void {
+  const cb = () => {
+    const ranges = [
+      { start: opts.prevStart, end: opts.prevEnd },
+      { start: opts.nextStart, end: opts.nextEnd },
+    ];
+    for (const r of ranges) {
+      const key = windowKey(r.start);
+      if (isFresh(EVENTS_PREFIX, key)) continue;
+      void fetchAndUpdateWindow({
+        startIso: r.start.toISOString(),
+        endIso: r.end.toISOString(),
+        key,
+        withRsvps: opts.withRsvps,
+      });
+    }
+  };
+  const w: any = typeof window !== 'undefined' ? window : null;
+  if (!w) return;
+  if (typeof w.requestIdleCallback === 'function') {
+    const id = w.requestIdleCallback(cb, { timeout: 2500 }) as number;
+    idleHandles.add(id);
+  } else {
+    const id = w.setTimeout(cb, 800) as number;
+    idleHandles.add(id);
+  }
+}
+
+export function cancelPendingPrefetches(): void {
+  for (const id of idleHandles) {
+    if (typeof window !== 'undefined' && 'cancelIdleCallback' in window) {
+      try {
+        (window as any).cancelIdleCallback(id);
+      } catch {}
+    }
+    try {
+      window.clearTimeout(id);
+    } catch {}
+  }
+  idleHandles.clear();
+}
+
+export function invalidateAllEventCaches(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && (k.startsWith(EVENTS_PREFIX) || k.startsWith(RSVPS_PREFIX))) keys.push(k);
+    }
+    for (const k of keys) localStorage.removeItem(k);
+  } catch {}
+}
+
+export function invalidateWindow(key: string): void {
+  try {
+    localStorage.removeItem(EVENTS_PREFIX + key);
+    localStorage.removeItem(RSVPS_PREFIX + key);
+  } catch {}
+}

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -1,0 +1,71 @@
+---
+import Portal from '../layouts/Portal.astro';
+---
+<Portal title="Calendar">
+  <div class="container" style="max-width:72rem">
+    <section
+      class="section section-events-calendar block-events-calendar block-events-calendar--view-month block-events-calendar--density-rich"
+      data-section-zone="main"
+      data-section-scope="page"
+    >
+      <div
+        class="container"
+        data-block-hydrate="events_calendar"
+        data-config='{"heading":"Calendar","view":"month","density":"rich","filter":"all","first_day_of_week":0,"show_filter_chips":true}'
+      >
+        <h2 class="block-events-calendar__heading">Calendar</h2>
+        <div class="block-events-calendar__skeleton">
+          <div class="event-skeleton-card skeleton"></div>
+          <div class="event-skeleton-card skeleton"></div>
+          <div class="event-skeleton-card skeleton"></div>
+          <div class="event-skeleton-card skeleton"></div>
+        </div>
+      </div>
+    </section>
+  </div>
+</Portal>
+
+<script>
+  import { BLOCK_TYPES, type BlockRenderContext, type Section } from '../lib/blocks';
+  import { getSession, getRole } from '../lib/auth';
+  import { isFeatureEnabled, ready } from '../lib/config';
+  import { getLocale } from '../lib/i18n';
+
+  async function init() {
+    await ready;
+    const host = document.querySelector<HTMLElement>('[data-block-hydrate="events_calendar"]');
+    if (!host) return;
+    if (host.dataset.hydrated === 'true') return;
+
+    const block = BLOCK_TYPES['events_calendar'];
+    if (!block?.hydrate) return;
+
+    const section: Section = {
+      page_slug: 'calendar',
+      zone: 'main',
+      scope: 'page',
+      section_type: 'events_calendar',
+      config: JSON.parse(host.getAttribute('data-config') || '{}'),
+      position: 1,
+    };
+
+    const session = getSession();
+    const role = getRole();
+    const ctx: BlockRenderContext = {
+      admin: role === 'admin',
+      locale: getLocale(),
+      authenticated: !!session,
+      role: (role as BlockRenderContext['role']) ?? null,
+      isFeatureEnabled,
+      session,
+      currentPath: window.location.pathname,
+    };
+
+    const wrapper = host.closest('section') as HTMLElement;
+    await block.hydrate(wrapper, section, ctx);
+  }
+
+  init();
+  document.addEventListener('astro:after-swap', init);
+  document.addEventListener('wl-locale-changed', init);
+</script>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -5,7 +5,10 @@ import Portal from '../layouts/Portal.astro';
   <div class="container">
     <div class="flex justify-between items-center mb-2">
       <h2>Events</h2>
-      <button class="btn btn-primary hidden" id="event-create-btn">Create Event</button>
+      <div class="flex gap-1 items-center">
+        <a href="/calendar.html" class="btn btn-secondary btn-sm" aria-label="View as calendar">View as calendar &rarr;</a>
+        <button class="btn btn-primary hidden" id="event-create-btn">Create Event</button>
+      </div>
     </div>
     <div id="events-list">
       <div class="card-grid"><div class="card"><div class="skeleton skeleton-card"></div></div><div class="card"><div class="skeleton skeleton-card"></div></div><div class="card"><div class="skeleton skeleton-card"></div></div></div>


### PR DESCRIPTION
## Summary

V1 spine of the modern community calendar (closes #78). Replaces the Wild Apricot month-grid with a multi-lens, social, frictionless surface — placeable as a block anywhere or via the new dedicated [`/calendar.html`](src/pages/calendar.astro) page.

- **New `events_calendar` block** — lazy-loaded, ~12 KB, no schema changes. Registered alongside `events_list` and `event_countdown`.
- **Three views**: Month grid · Week strip · Agenda (vertical day list). `ResizeObserver` auto-falls-through to Agenda below 600px container width.
- **Three densities**: Glance (colored dots, sidebar-friendly) · Light (1-line summaries) · Rich (cards with thumbnails + RSVP avatars + capacity badges).
- **Filter chips**: All / Members / Open / My RSVPs / Past — `localStorage` persistence per block instance.
- **Hover peek + bottom sheet** — same component, CSS `@media` transform on mobile. Includes one-tap browser-side ICS export per event (RFC 5545).
- **Live-now pulsing dot**, **"Filling fast"** at ≥80% capacity, **"Sold out"** at cap, **🔒 lock** on members-only.
- **Keyboard nav**: ↑↓←→, Enter, Esc, T (today), M/W/A (view modes).
- **A11y**: ARIA grid pattern with roving tabindex, live region announces month, `prefers-reduced-motion` strips animations.
- **SWR cache** per visible 6-week window in `localStorage`, idle prefetch of ±1 month via `requestIdleCallback`.

OpenSpec change: [`openspec/changes/events-calendar-view/`](openspec/changes/events-calendar-view/proposal.md) — proposal, design, tasks, spec delta.

### What's deferred (filed as separate issues)

- #79 recurring events (rrule expansion + edit-this/series fork)
- #80 subscribable `.ics` feed via Run402 edge function
- #81 drag-to-reschedule + inline chip editing (admin)
- #82 ⌘K fuzzy search across calendar events

These were intentionally scoped out to keep V1 focused on the reading experience. The architecture leaves clean seams for each.

## Test plan

- [x] `astro check` — 0 errors, 0 warnings introduced
- [x] `astro build` — 15 routes including new `/calendar.html`
- [x] `openspec validate events-calendar-view --strict` — valid
- [x] Static preview verified: month / week / agenda views all render with seeded events
- [x] Filter chips toggle correctly; My RSVPs hidden when unauthenticated
- [x] Hover peek and "+N more" overflow open the day popover with "Add to my calendar"
- [x] Density Glance reduces chips to colored dots; Live indicator preserved as red dot
- [x] Mobile (375px) auto-falls-through to Agenda; segmented control hidden
- [x] "View as calendar →" link on `/events.html` navigates to `/calendar.html`
- [x] Browser-side ICS download generates valid `event-{id}.ics`
- [ ] Once deployed: verify against real Run402 backend with live event data
- [ ] Once deployed: smoke-test on iOS Safari and Android Chrome at native viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)