### PR TITLE
fix(events): use and=() filter for two-sided starts_at queries

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -145,8 +145,11 @@ export async function getEventRSVPs(eventId: number): Promise<EventRSVP[]> {
 }
 
 export async function getEventWindow(startIso: string, endIso: string): Promise<Event[]> {
+  // PostgREST concatenates repeated column filters in the query string instead
+  // of AND-ing them, which produces a 400 ("time zone not recognized") on a
+  // pair of starts_at filters. Use the explicit and=(...) form.
   const data = await get(
-    `events?starts_at=gte.${encodeURIComponent(startIso)}&starts_at=lt.${encodeURIComponent(endIso)}&order=starts_at.asc`,
+    `events?and=(starts_at.gte.${encodeURIComponent(startIso)},starts_at.lt.${encodeURIComponent(endIso)})&order=starts_at.asc`,
   );
   return z.array(EventSchema).parse(data);
 }

--- a/src/lib/block-hydrators.ts
+++ b/src/lib/block-hydrators.ts
@@ -351,7 +351,9 @@ export async function hydrateEventsList(
     query = `events?starts_at=lt.${nowIso}&order=starts_at.desc&limit=${count}`;
   } else if (filter === 'this_week') {
     const inAWeek = new Date(Date.now() + EVENTS_LIST_FILTER_DAYS * 86400 * 1000).toISOString();
-    query = `events?starts_at=gte.${nowIso}&starts_at=lt.${inAWeek}&order=starts_at.asc&limit=${count}`;
+    // PostgREST concatenates duplicate column filters; use and=(...) so both
+    // bounds AND-combine instead of overwriting.
+    query = `events?and=(starts_at.gte.${nowIso},starts_at.lt.${inAWeek})&order=starts_at.asc&limit=${count}`;
   } else {
     query = `events?starts_at=gte.${nowIso}&order=starts_at.asc&limit=${count}`;
   }

--- a/tests/integration/blocks-events-list.test.ts
+++ b/tests/integration/blocks-events-list.test.ts
@@ -89,8 +89,10 @@ describe('hydrateEventsList', () => {
     );
 
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain('starts_at=gte.');
-    expect(url).toContain('starts_at=lt.');
+    // Use and=(...) instead of repeated ?starts_at=… params — PostgREST
+    // concatenates duplicate column filters and 400s on the second value.
+    expect(url).toContain('and=(starts_at.gte.');
+    expect(url).toContain(',starts_at.lt.');
   });
 
   it('empty result shows placeholder', async () => {


### PR DESCRIPTION
## Summary

Live-demo verification of #78 surfaced a real PostgREST query bug. When two filters target the same column via repeated query params (e.g. `?starts_at=gte.X&starts_at=lt.Y`), PostgREST concatenates the values rather than AND-ing them and returns 400:

\`\`\`
{"code":"22023","message":"time zone \"lt.2026-06-06T00:00:00.000Z\" not recognized"}
\`\`\`

The result: Eagles' `/calendar.html` rendered an empty page because every window fetch 400'd. Switching to the explicit `and=(starts_at.gte.X,starts_at.lt.Y)` form fixes it.

Affects:
- `src/lib/api.ts` `getEventWindow` — primary bug for the calendar block introduced in #78
- `src/lib/block-hydrators.ts` `events_list` `this_week` filter — same latent pattern; not previously exercised on demos but worth fixing while we're here

Verified against the live Eagles PostgREST backend before submitting (the `and=()` form returned 5 rows; the repeated-param form returned the 400 above).

## Test plan

- [x] `astro check` clean
- [x] Live PostgREST query test confirms `and=(...)` returns rows
- [ ] Redeploy demos and confirm calendars populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)