### PR TITLE
Fix security bugs #23-#27 (private repo): XSS, mass-assignment, uploads, undefined db, hardening

### DIFF
--- a/functions/ai-content.js
+++ b/functions/ai-content.js
@@ -61,19 +61,19 @@ async function handleNewsletter() {
 async function gatherWeeklyActivity(since) {
   const [newMembers, upcomingEvents, announcements, topForumPosts, newResources] = await Promise.all([
     adminDb().from('members').select('display_name').gte('joined_at', since).eq('status', 'active'),
-    db
+    adminDb()
       .from('events')
       .select('title,starts_at,location')
       .gte('starts_at', new Date().toISOString())
       .order('starts_at', { ascending: true })
       .limit(5),
-    db
+    adminDb()
       .from('announcements')
       .select('title,body')
       .gte('created_at', since)
       .order('created_at', { ascending: false })
       .limit(5),
-    db
+    adminDb()
       .from('forum_topics')
       .select('title,reply_count')
       .gte('created_at', since)

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -223,13 +223,13 @@ const TABLE_QUERIES = {
   'members.get': { table: 'members', mode: 'one', map: memberRow },
   'tiers.list': { table: 'membership_tiers', mode: 'list' },
   'memberFields.list': { table: 'member_custom_fields', mode: 'list', visible: visibleMemberField },
-  'events.list': { table: 'events', mode: 'list', visible: visibleMembersOnly },
-  'events.get': { table: 'events', mode: 'one', visible: visibleMembersOnly },
+  'events.list': { table: 'events', mode: 'list', visible: visibleMembersOnly, map: eventRow },
+  'events.get': { table: 'events', mode: 'one', visible: visibleMembersOnly, map: eventRow },
   'registrationOptions.list': { table: 'event_registration_options', mode: 'list' },
   'rsvps.listForEvent': { table: 'event_rsvps', mode: 'list' },
   'rsvps.listMine': { table: 'event_rsvps', mode: 'listMine' },
-  'announcements.list': { table: 'announcements', mode: 'list' },
-  'announcements.get': { table: 'announcements', mode: 'one' },
+  'announcements.list': { table: 'announcements', mode: 'list', map: announcementRow },
+  'announcements.get': { table: 'announcements', mode: 'one', map: announcementRow },
   'resources.list': { table: 'resources', mode: 'list', visible: visibleMembersOnly },
   'resources.get': { table: 'resources', mode: 'one', visible: visibleMembersOnly },
   'forum.categories.list': { table: 'forum_categories', mode: 'list' },
@@ -256,6 +256,11 @@ const TABLE_QUERIES = {
 };
 
 const SQL_WRITE_TABLES = new Set(['events', 'resources']);
+
+// Site-config categories that are intentionally readable by anonymous
+// callers. Anything else (future webhook URLs, integration tokens, etc.)
+// requires admin. (#27 item 4)
+const PUBLIC_CONFIG_CATEGORIES = new Set(['branding', 'features', 'theme', 'demo', 'general']);
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -308,7 +313,12 @@ export default async (req) => {
 
   const actor = await resolveActor(req);
   const permission = checkPermission(actor, operation);
-  if (!permission.allowed && envelope.phase !== 'validate') {
+  if (!permission.allowed) {
+    // Validate-phase used to run even when the actor lacked permission so
+    // the SDK could echo back required-state hints. That makes the whole
+    // mutation surface a free enumeration oracle for anonymous callers
+    // (and reflects their input back unmodified, which is its own probe).
+    // Gate validate on the same minimum actor state as execute. (#27 item 3)
     return errorResponse(correlationId, 403, {
       code: 'permission.denied',
       message: `Permission denied for ${operation.name}.`,
@@ -370,14 +380,21 @@ async function parseEnvelope(req) {
     return invalidEnvelope('Request envelope requires apiVersion, operation, phase, and input.');
   }
 
+  // Reject non-object input up front rather than silently coercing
+  // null/arrays into `{ value: ... }` — the schema documents `input` as a
+  // plain object and silent coercion lets callers smuggle filter-bypass
+  // shapes through. (#27 item 1)
+  if (!body.input || typeof body.input !== 'object' || Array.isArray(body.input)) {
+    return invalidEnvelope('Request envelope `input` must be a plain object.');
+  }
+
   return {
     ok: true,
     envelope: {
       apiVersion: body.apiVersion,
       operation: body.operation,
       phase: body.phase,
-      input:
-        body.input && typeof body.input === 'object' && !Array.isArray(body.input) ? body.input : { value: body.input },
+      input: body.input,
       idempotencyKey: typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined,
       confirmed: typeof body.confirmed === 'boolean' ? body.confirmed : undefined,
     },
@@ -480,11 +497,15 @@ async function handleTableQuery(correlationId, input, actor, spec) {
     const map = spec.map || ((row) => row);
 
     if (spec.mode === 'config') {
+      // Non-admin callers see only the categories that are explicitly safe to
+      // publish — branding, features, theme, demo. Any other category (a
+      // future webhook URL, integration token, etc.) requires admin. (#27 item 4)
+      const visibleConfig = (row) => isAdminLike(actor) || PUBLIC_CONFIG_CATEGORIES.has(row.category);
       if (typeof input.key === 'string') {
-        const row = rows.find((item) => item.key === input.key);
+        const row = rows.find((item) => item.key === input.key && visibleConfig(item));
         return successResponse(correlationId, row ? configRow(row) : null);
       }
-      const mapped = rows.map(configRow);
+      const mapped = rows.filter(visibleConfig).map(configRow);
       return successResponse(correlationId, { rows: mapped, count: mapped.length });
     }
 
@@ -592,13 +613,16 @@ async function handleExecute(correlationId, envelope, operation, actor) {
     const execution = await beginExecution(envelope, operation, actor, correlationId);
     if (execution.kind === 'replay') return successResponse(correlationId, execution.record.result_payload);
     if (execution.kind === 'conflict') {
+      // Don't echo the prior operation name back to the caller — it's an
+      // info leak about other clients' traffic and a free oracle for
+      // idempotency-key enumeration. The internal correlation log still
+      // captures the conflict for ops debugging. (#27 item 2)
       return errorResponse(correlationId, 409, {
         code: 'conflict.idempotencyKey',
         message: execution.reason,
         detail: {
           operation: operation.name,
           idempotencyKey: envelope.idempotencyKey,
-          existingOperation: execution.record.operation,
         },
         retryable: false,
       });
@@ -801,11 +825,14 @@ async function genericMutation(operation, input, actor) {
 }
 
 async function publishAnnouncement(input, actor) {
+  // author_id is bound to the acting admin — never honored from input. The
+  // dedicated `announcements.update` operation is the path for any later
+  // attribution change. (#24)
   const announcement = await insertRow('announcements', {
     title: input.title || 'Untitled',
     body: input.body || '',
     is_pinned: input.pin === true || input.is_pinned === true,
-    author_id: input.author_id ?? memberId(actor),
+    author_id: memberId(actor),
   });
   const changed = [changedObject('announcement', announcement.id)];
   if (isPlainObject(input.poll)) {
@@ -825,13 +852,16 @@ async function publishAnnouncement(input, actor) {
 }
 
 async function createForumTopic(input, actor) {
+  // author_id / author_name come from the actor only — caller-supplied values
+  // would let any active member impersonate another member or admin. Pinning a
+  // topic at create time is reserved for moderators via `forum.topics.pin`. (#24)
   const topic = await insertRow('forum_topics', {
     category_id: input.categoryId ?? input.category_id ?? null,
     title: input.title || 'Untitled',
     body: input.body || '',
-    author_id: input.author_id ?? memberId(actor),
-    author_name: input.author_name ?? actor.member?.displayName ?? null,
-    is_pinned: input.is_pinned === true,
+    author_id: memberId(actor),
+    author_name: actor.member?.displayName ?? null,
+    is_pinned: false,
     reply_count: 0,
     last_reply_at: null,
   });
@@ -861,11 +891,12 @@ async function createForumReply(input, actor) {
       object: { type: 'forum.topic', id: String(topicId) },
     });
 
+  // author_id / author_name come from the actor only. (#24)
   const reply = await insertRow('forum_replies', {
     topic_id: topicId,
     body: input.body || '',
-    author_id: input.author_id ?? memberId(actor),
-    author_name: input.author_name ?? actor.member?.displayName ?? null,
+    author_id: memberId(actor),
+    author_name: actor.member?.displayName ?? null,
   });
   await updateRow('forum_topics', topicId, {
     reply_count: Number(topic.reply_count || 0) + 1,
@@ -888,6 +919,7 @@ async function createPollAction(input, actor) {
 }
 
 async function createPoll(input, actor) {
+  // created_by is bound to the actor — never honored from input. (#24)
   const poll = await insertRow('polls', {
     question: input.question || 'Poll',
     description: input.description || null,
@@ -898,7 +930,7 @@ async function createPoll(input, actor) {
     closes_at: input.closesAt || input.closes_at || null,
     attached_to: input.attached_to || input.attachedTo || null,
     attached_id: input.attached_id || input.attachedId || null,
-    created_by: input.created_by ?? memberId(actor),
+    created_by: memberId(actor),
   });
   const options = Array.isArray(input.options) ? input.options : [];
   let position = 0;
@@ -920,6 +952,23 @@ async function castPollVote(input, actor) {
     throw capabilityError('notFound.object', 'Poll not found.', { object: { type: 'poll', id: String(pollId) } });
   if (poll.is_open === false)
     throw capabilityError('conflict.state', 'Poll is closed.', { object: { type: 'poll', id: String(pollId) } });
+
+  // Each option must belong to this poll. Without this check a member can
+  // vote on poll N with an option from poll M and corrupt totals. (#24)
+  const validOptionIds = new Set(
+    (await selectRows('poll_options'))
+      .filter((option) => String(option.poll_id) === String(pollId))
+      .map((option) => String(option.id)),
+  );
+  for (const optionId of optionIds) {
+    if (!validOptionIds.has(String(optionId))) {
+      throw capabilityError(
+        'validation.failed',
+        `pollVotes.cast optionId ${optionId} does not belong to poll ${pollId}.`,
+        { object: { type: 'poll.option', id: String(optionId) } },
+      );
+    }
+  }
 
   const member = memberId(actor);
   const existing = (await selectRows('poll_votes')).filter(
@@ -964,11 +1013,23 @@ async function clearMinePollVotes(input, actor) {
 }
 
 async function setRsvpStatus(input, actor) {
+  // member_id is bound to the actor (admins act-as via dedicated admin paths,
+  // not this capability) and an `id` from input must belong to that member —
+  // otherwise an active member could update arbitrary RSVP rows. (#24)
+  const member = memberId(actor);
   const id = input.id;
   const eventId = input.eventId ?? input.event_id;
-  const member = input.memberId ?? input.member_id ?? memberId(actor);
+
   if (id != null) {
-    const row = await updateRow('event_rsvps', id, { status: input.status || 'going', member_id: member });
+    const target = (await selectRows('event_rsvps')).find((row) => String(row.id) === String(id));
+    if (!target)
+      throw capabilityError('notFound.object', 'RSVP not found.', { object: { type: 'event.rsvp', id: String(id) } });
+    if (String(target.member_id) !== String(member) && !isAdminLike(actor) && !isModeratorLike(actor)) {
+      throw capabilityError('permission.denied', 'rsvps.setStatus can only update the active member RSVP.', {
+        object: { type: 'event.rsvp', id: String(id) },
+      });
+    }
+    const row = await updateRow('event_rsvps', id, { status: input.status || 'going', member_id: target.member_id });
     const object = changedObject('event.rsvp', row.id ?? id);
     return actionResult(
       row,
@@ -989,9 +1050,10 @@ async function setRsvpStatus(input, actor) {
 }
 
 async function cancelRsvp(input, actor) {
+  // Same ownership rule as setRsvpStatus. (#24)
+  const member = memberId(actor);
   const id = input.id;
   const eventId = input.eventId ?? input.event_id;
-  const member = input.memberId ?? input.member_id ?? memberId(actor);
   const existing =
     id != null
       ? (await selectRows('event_rsvps')).find((row) => String(row.id) === String(id))
@@ -999,12 +1061,18 @@ async function cancelRsvp(input, actor) {
           (row) => String(row.event_id) === String(eventId) && String(row.member_id) === String(member),
         );
   if (!existing) return actionResult({ cancelled: false }, [], null);
+  if (String(existing.member_id) !== String(member) && !isAdminLike(actor) && !isModeratorLike(actor)) {
+    throw capabilityError('permission.denied', 'rsvps.cancel can only cancel the active member RSVP.', {
+      object: { type: 'event.rsvp', id: String(existing.id) },
+    });
+  }
   const row = await updateRow('event_rsvps', existing.id, { status: 'cancelled' });
   const object = changedObject('event.rsvp', row.id);
   return actionResult(row, [object], verification('rsvps.listForEvent', { eventId: row.event_id ?? eventId }, object));
 }
 
 async function uploadResource(input, actor) {
+  // uploaded_by is bound to the actor — never honored from input. (#24)
   const metadata = isPlainObject(input.metadata) ? input.metadata : input;
   const resource = await insertRow('resources', {
     title: metadata.title || input.title || input.name || 'Resource',
@@ -1013,7 +1081,7 @@ async function uploadResource(input, actor) {
     file_url: input.fileUrl || input.file_url || metadata.file_url || null,
     file_type: metadata.file_type || metadata.fileType || input.file_type || 'file',
     is_members_only: metadata.is_members_only !== false,
-    uploaded_by: metadata.uploaded_by ?? memberId(actor),
+    uploaded_by: memberId(actor),
   });
   const activity = await writeActivity(actor, 'resource_upload', { title: resource.title, resource_id: resource.id });
   const object = changedObject('resource', resource.id);
@@ -1091,12 +1159,13 @@ async function upsertConfig(input) {
 }
 
 function rowForCreate(operation, input, actor) {
-  if (operation.startsWith('polls.'))
-    return { ...stripControlFields(input), created_by: input.created_by ?? memberId(actor) };
-  if (operation.startsWith('events.'))
-    return { ...stripControlFields(input), created_by: input.created_by ?? memberId(actor) };
-  if (operation.startsWith('activity.'))
-    return { ...stripControlFields(input), member_id: input.member_id ?? memberId(actor) };
+  // Author/owner fields are always bound to the actor — never accepted from
+  // input. Letting input override them lets an active member spoof identity
+  // on every generic create handler. (#24)
+  if (operation.startsWith('polls.')) return { ...stripControlFields(input), created_by: memberId(actor) };
+  if (operation.startsWith('events.')) return { ...stripControlFields(input), created_by: memberId(actor) };
+  if (operation.startsWith('activity.')) return { ...stripControlFields(input), member_id: memberId(actor) };
+  if (operation.startsWith('reactions.')) return { ...stripControlFields(input), member_id: memberId(actor) };
   return stripControlFields(input);
 }
 
@@ -1333,13 +1402,53 @@ function memberProfilePatch(input) {
 }
 
 function requiredAny(value, message) {
-  if (typeof value === 'string' || typeof value === 'number') return value;
+  // Reject "" / "   " / 0 / NaN — they parse as a "value" but never match a
+  // real row, producing a silent no-op instead of a clear validation error.
+  // (#27 item 6)
+  if (typeof value === 'string') {
+    if (value.trim() === '') throw capabilityError('validation.failed', message);
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value === 0) throw capabilityError('validation.failed', message);
+    return value;
+  }
   throw capabilityError('validation.failed', message);
 }
 
+// Privileged fields the active actor must never override on a create/update
+// path — any change to these flows through dedicated capability operations
+// (members.changeRole, *.pin, *.lock, etc.) that have their own role gate. (#24)
+const PRIVILEGED_INPUT_FIELDS = new Set([
+  'id',
+  'operation',
+  'author_id',
+  'member_id',
+  'memberId',
+  'created_by',
+  'createdBy',
+  'reviewed_by',
+  'uploaded_by',
+  'user_id',
+  'userId',
+  'role',
+  'is_pinned',
+  'isPinned',
+  'pin',
+  'locked',
+  'hidden',
+  'tier_id',
+  'tierId',
+]);
+
 function stripControlFields(input) {
-  const { id: _id, operation: _operation, ...rest } = input || {};
-  return rest;
+  if (!input) return {};
+  const out = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (PRIVILEGED_INPUT_FIELDS.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
 }
 
 function isPlainObject(value) {
@@ -1417,6 +1526,21 @@ function memberRow(row, actor) {
     tier_id: row.tier_id,
     role: row.role,
   };
+}
+
+// Strip server-attribution columns from anonymous projections of events and
+// announcements — anon clients have no business knowing which member created
+// what, and those ids are useful pivots for the IDOR shapes in #24. (#27 item 5)
+function eventRow(row, actor) {
+  if (isAdminLike(actor) || isModeratorLike(actor)) return row;
+  const { created_by: _createdBy, ...rest } = row;
+  return rest;
+}
+
+function announcementRow(row, actor) {
+  if (isAdminLike(actor) || isModeratorLike(actor)) return row;
+  const { author_id: _authorId, ...rest } = row;
+  return rest;
 }
 
 function visiblePage(row, actor) {

--- a/functions/on-signup.js
+++ b/functions/on-signup.js
@@ -72,25 +72,23 @@ export default async (req) => {
   const defaultTier = await adminDb().from('membership_tiers').select('id').eq('is_default', true).limit(1);
   const tierId = defaultTier.length > 0 ? defaultTier[0].id : null;
 
-  // Create member record
-  const created = await db
-    .from('members')
-    .insert({
-      user_id: userId,
-      email: memberEmail,
-      display_name: displayName,
-      avatar_url: avatarUrl,
-      tier_id: tierId,
-      role,
-      status: memberStatus,
-    })
-    .select('id,role,status');
+  // Create member record. adminDb().from(t).insert(row) returns the inserted
+  // row(s); the platform doesn't support a `.select(...)` chain on insert, so
+  // we read the first element directly.
+  const created = await adminDb().from('members').insert({
+    user_id: userId,
+    email: memberEmail,
+    display_name: displayName,
+    avatar_url: avatarUrl,
+    tier_id: tierId,
+    role,
+    status: memberStatus,
+  });
 
-  if (created.length === 0) {
+  const member = Array.isArray(created) ? created[0] : created;
+  if (!member?.id) {
     return new Response(JSON.stringify({ error: 'Failed to create member' }), { status: 500 });
   }
-
-  const member = created[0];
 
   // Log activity
   await adminDb()

--- a/functions/upload-asset.js
+++ b/functions/upload-asset.js
@@ -60,14 +60,31 @@ function readImageDimensions(bytes, mime) {
 // so the admin UI can offer a one-click reroute to brand_wordmark_url.
 const WORDMARK_ASPECT_THRESHOLD = 1.5;
 
+// Asset paths are passed by the admin UI; the storage call runs with the
+// project service key, so an unvalidated `body.path` is a privileged delete
+// primitive across the entire storage API. Constrain the shape strictly:
+// safe ASCII characters only, no traversal, no leading slash, no double
+// slashes, no NUL. (#25)
+const SAFE_ASSET_PATH = /^[A-Za-z0-9_.\-/]+$/;
+function isSafeAssetPath(value) {
+  if (typeof value !== 'string' || !value) return false;
+  if (!SAFE_ASSET_PATH.test(value)) return false;
+  if (value.startsWith('/')) return false;
+  if (value.includes('//')) return false;
+  if (value.split('/').some((seg) => seg === '..' || seg === '.')) return false;
+  return true;
+}
+
 export default async (req) => {
   const user = await getUser(req);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
   }
 
-  // Check admin role
-  const memberResult = await adminDb().sql(`SELECT role FROM members WHERE user_id = '${user.id}' LIMIT 1`);
+  // Check admin role using a parameterized query — concatenating user.id is
+  // safe today because Run402 issues UUIDs, but a future auth path that
+  // produces a different `sub` shape could turn this into SQL injection. (#25)
+  const memberResult = await adminDb().sql('SELECT role FROM members WHERE user_id = $1 LIMIT 1', [user.id]);
   if (!memberResult.rows?.length || memberResult.rows[0].role !== 'admin') {
     return new Response(JSON.stringify({ error: 'Admin access required' }), { status: 403 });
   }
@@ -77,6 +94,12 @@ export default async (req) => {
 
     // Delete action
     if (body.action === 'delete' && body.path) {
+      if (!isSafeAssetPath(body.path)) {
+        return new Response(
+          JSON.stringify({ error: 'Invalid path', detail: 'Asset path must be a relative ASCII segment chain.' }),
+          { status: 400 },
+        );
+      }
       const delRes = await fetch(`https://api.run402.com/storage/v1/delete/assets/${body.path}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}` },

--- a/functions/upload-resource.js
+++ b/functions/upload-resource.js
@@ -1,10 +1,25 @@
 // schedule: none (triggered by client on resource upload)
 import { adminDb, getUser } from '@run402/functions';
 
+// File names that flow into the storage path must be limited to safe ASCII
+// segments — `..`, `/`, NUL, and other surprises would let a caller place
+// files outside `resources/`. (#25)
+const SAFE_FILE_NAME = /^[A-Za-z0-9._-]+$/;
+const MAX_BASE64_LEN = 50 * 1024 * 1024; // ~37 MB raw — Run402's per-blob upload limit.
+
 export default async (req) => {
   const user = await getUser(req);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  // Admin-only — mirror the role check in upload-asset.js. The legacy "any
+  // authenticated user can upload" surface let arbitrary signed-in Run402
+  // users write to the project's resources bucket. (#25)
+  const memberResult = await adminDb().sql('SELECT role FROM members WHERE user_id = $1 LIMIT 1', [user.id]);
+  const role = memberResult?.rows?.[0]?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Admin access required' }), { status: 403 });
   }
 
   try {
@@ -13,6 +28,16 @@ export default async (req) => {
 
     if (!file?.data || !file.name) {
       return new Response(JSON.stringify({ error: 'No file provided' }), { status: 400 });
+    }
+
+    if (!SAFE_FILE_NAME.test(file.name)) {
+      return new Response(JSON.stringify({ error: 'Invalid file name', detail: 'expected [A-Za-z0-9._-]+' }), {
+        status: 400,
+      });
+    }
+
+    if (typeof file.data !== 'string' || file.data.length > MAX_BASE64_LEN) {
+      return new Response(JSON.stringify({ error: 'File too large' }), { status: 413 });
     }
 
     // Decode base64 file data
@@ -39,7 +64,10 @@ export default async (req) => {
     const uploadResult = await uploadRes.json();
     const fileUrl = uploadResult.url || `/storage/${path}`;
 
-    // Insert resource row
+    // Insert resource row. uploaded_by is bound to the authenticated admin —
+    // never honored from input. (#24/#25)
+    const memberRow = await adminDb().sql('SELECT id FROM members WHERE user_id = $1 LIMIT 1', [user.id]);
+    const uploadedBy = memberRow?.rows?.[0]?.id ?? null;
     const created = await adminDb()
       .from('resources')
       .insert({
@@ -49,10 +77,11 @@ export default async (req) => {
         file_url: fileUrl,
         file_type: metadata.file_type || 'pdf',
         is_members_only: metadata.is_members_only !== false,
-        uploaded_by: metadata.uploaded_by || null,
+        uploaded_by: uploadedBy,
       });
 
-    return new Response(JSON.stringify({ status: 'ok', resource: created[0] }));
+    const row = Array.isArray(created) ? created[0] : created;
+    return new Response(JSON.stringify({ status: 'ok', resource: row }));
   } catch (e) {
     return new Response(JSON.stringify({ error: e.message }), { status: 500 });
   }

--- a/src/lib/block-hydrators.ts
+++ b/src/lib/block-hydrators.ts
@@ -3,14 +3,17 @@
 // (Astro frontmatter runs in Node and shouldn't pull in localStorage/auth).
 
 import type { Section, BlockRenderContext } from './blocks.js';
+import { escAttr, escHtml } from './blocks.js';
 import { siteConfig } from './config.js';
 import { formatEventDateTime } from './event-display.js';
+import { sanitizeRichHtml } from './sanitize-html.js';
 
-function esc(s: any): string {
-  const d = document.createElement('div');
-  d.textContent = String(s ?? '');
-  return d.innerHTML;
-}
+// `esc()` is intentionally an alias for escAttr — every call site in this
+// module interpolates into a double-quoted attribute or HTML text, both of
+// which require the quote-escaping that escAttr provides. The previous
+// `textContent → innerHTML` helper left " and ' alone, which let attacker
+// content break out of attribute context (#23).
+const esc = escAttr;
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
@@ -93,8 +96,8 @@ export async function hydrateAnnouncementsFeed(
             : '';
           return `
         <div class="announcement card mb-1 ${a.is_pinned ? 'pinned' : ''}" data-id="${a.id}">
-          <div class="announcement-title" data-editable="announcements.${a.id}.title">${esc(a.title)}</div>
-          <div class="announcement-body" data-editable-rich="announcements.${a.id}.body">${a.body}</div>
+          <div class="announcement-title" data-editable="announcements.${a.id}.title">${escHtml(a.title)}</div>
+          <div class="announcement-body" data-editable-rich="announcements.${a.id}.body">${sanitizeRichHtml(a.body)}</div>
           ${pollHtml}
           <div class="announcement-meta">${a.is_pinned ? '<span class="badge badge-primary">Pinned</span> ' : ''}<span>${formatDate(a.created_at)}</span></div>
           ${ctx.role === 'admin' ? `<div class="mt-1 flex gap-1"><button class="btn btn-sm btn-secondary ann-pin" data-id="${a.id}" data-pinned="${a.is_pinned}">${a.is_pinned ? 'Unpin' : 'Pin'}</button><button class="btn btn-sm btn-danger ann-delete" data-id="${a.id}">Delete</button></div>` : ''}

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -1,0 +1,158 @@
+// Tiny dependency-free HTML sanitizer for rich-text fields stored by admins
+// (announcement bodies, etc.) and re-rendered into innerHTML on every member's
+// page. Strips on*= event handlers, <script>, javascript: hrefs, and any tag
+// not on the Tiptap-compatible allowlist.
+//
+// Two execution contexts:
+//   - Browser: uses native DOMParser.
+//   - Node tests: relies on happy-dom (or jsdom) to provide DOMParser globally.
+// Both are tested in tests/unit/security-bug-23-esc-xss.test.ts.
+
+const ALLOWED_TAGS = new Set([
+  'p',
+  'br',
+  'hr',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  's',
+  'strike',
+  'del',
+  'ins',
+  'sub',
+  'sup',
+  'mark',
+  'small',
+  'span',
+  'div',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'pre',
+  'code',
+  'img',
+  'figure',
+  'figcaption',
+  'table',
+  'thead',
+  'tbody',
+  'tfoot',
+  'tr',
+  'th',
+  'td',
+]);
+
+const ALLOWED_ATTRS_BY_TAG: Record<string, Set<string>> = {
+  a: new Set(['href', 'title', 'target', 'rel']),
+  img: new Set(['src', 'alt', 'title', 'width', 'height']),
+  '*': new Set(['class', 'id', 'lang', 'dir']),
+};
+
+const SAFE_URL_PROTOCOLS = ['http:', 'https:', 'mailto:'];
+
+function isSafeUrl(value: string, allowDataImage = false): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  // Allow protocol-relative or absolute paths.
+  if (trimmed.startsWith('/') || trimmed.startsWith('#')) return true;
+  // URLs with no colon are relative and safe.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return true;
+  const colon = trimmed.indexOf(':');
+  const protocol = trimmed.slice(0, colon + 1).toLowerCase();
+  if (SAFE_URL_PROTOCOLS.includes(protocol)) return true;
+  if (allowDataImage && protocol === 'data:' && /^data:image\/(png|jpe?g|gif|webp|svg\+xml)/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+function sanitizeAttributes(el: Element): void {
+  const tag = el.tagName.toLowerCase();
+  const allowed = ALLOWED_ATTRS_BY_TAG[tag] ?? new Set<string>();
+  const allowedGlobal = ALLOWED_ATTRS_BY_TAG['*'];
+  const toRemove: string[] = [];
+  for (const attr of Array.from(el.attributes)) {
+    const name = attr.name.toLowerCase();
+    if (name.startsWith('on')) {
+      toRemove.push(attr.name);
+      continue;
+    }
+    if (!allowed.has(name) && !allowedGlobal.has(name)) {
+      toRemove.push(attr.name);
+      continue;
+    }
+    if (name === 'href' && !isSafeUrl(attr.value)) {
+      toRemove.push(attr.name);
+      continue;
+    }
+    if (name === 'src' && !isSafeUrl(attr.value, true)) {
+      toRemove.push(attr.name);
+      continue;
+    }
+    if (name === 'target' && attr.value && attr.value.toLowerCase() === '_blank') {
+      // _blank without rel=noopener leaks window.opener — force a safe rel.
+      const existingRel = el.getAttribute('rel') || '';
+      if (!/noopener/i.test(existingRel)) {
+        el.setAttribute('rel', `${existingRel} noopener noreferrer`.trim());
+      }
+    }
+  }
+  for (const name of toRemove) el.removeAttribute(name);
+}
+
+function walk(node: Node): void {
+  // Iterate over a snapshot since we mutate as we go.
+  const children = Array.from(node.childNodes);
+  for (const child of children) {
+    if (child.nodeType === 1 /* ELEMENT_NODE */) {
+      const el = child as Element;
+      const tag = el.tagName.toLowerCase();
+      if (!ALLOWED_TAGS.has(tag)) {
+        // Drop the element but keep its (recursively sanitized) children.
+        const parent = el.parentNode!;
+        for (const grand of Array.from(el.childNodes)) parent.insertBefore(grand, el);
+        parent.removeChild(el);
+        continue;
+      }
+      sanitizeAttributes(el);
+      walk(el);
+    } else if (child.nodeType !== 3 /* TEXT_NODE */ && child.nodeType !== 4 /* CDATA */) {
+      // Strip comments, processing instructions, etc.
+      child.parentNode?.removeChild(child);
+    }
+  }
+}
+
+export function sanitizeRichHtml(input: string | null | undefined): string {
+  const raw = String(input ?? '');
+  if (!raw) return '';
+  // DOMParser is provided by the browser at runtime and by happy-dom in tests.
+  const parserCtor: typeof DOMParser | undefined =
+    typeof DOMParser !== 'undefined'
+      ? DOMParser
+      : (globalThis as unknown as { DOMParser?: typeof DOMParser }).DOMParser;
+  if (!parserCtor) {
+    // Server-side build context with no DOM — fail closed by escaping.
+    return raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+  const doc = new parserCtor().parseFromString(`<body>${raw}</body>`, 'text/html');
+  const body = doc.body;
+  if (!body) return '';
+  walk(body);
+  return body.innerHTML;
+}

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -76,10 +76,12 @@ function isSafeUrl(value: string, allowDataImage = false): boolean {
   return false;
 }
 
+const EMPTY_ATTR_SET: ReadonlySet<string> = new Set();
+
 function sanitizeAttributes(el: Element): void {
   const tag = el.tagName.toLowerCase();
-  const allowed = ALLOWED_ATTRS_BY_TAG[tag] ?? new Set<string>();
-  const allowedGlobal = ALLOWED_ATTRS_BY_TAG['*'];
+  const allowed = ALLOWED_ATTRS_BY_TAG[tag] ?? EMPTY_ATTR_SET;
+  const allowedGlobal = ALLOWED_ATTRS_BY_TAG['*'] ?? EMPTY_ATTR_SET;
   const toRemove: string[] = [];
   for (const attr of Array.from(el.attributes)) {
     const name = attr.name.toLowerCase();

--- a/src/pages/forum.astro
+++ b/src/pages/forum.astro
@@ -172,14 +172,14 @@ import Portal from '../layouts/Portal.astro';
 <script>
   import { del, get, patch, post } from '../lib/api';
   import { getSession, isAdmin, isAuthenticated } from '../lib/auth';
+  import { escAttr } from '../lib/blocks';
   import { addTranslateButton, translateItems, isFeatureEnabled, getConfig } from '../lib/config';
   import { renderPoll, bindPollVoteListeners, createPollForm, submitPoll, fetchAttachedPoll } from '../lib/poll-ui';
 
-  function esc(s: string): string {
-    const d = document.createElement('div');
-    d.textContent = String(s || '');
-    return d.innerHTML;
-  }
+  // Every esc(...) call below interpolates into a double-quoted attribute or
+  // HTML text. escAttr escapes both <>&" and ', closing the quote-breakout
+  // XSS in the previous textContent → innerHTML helper (#23).
+  const esc = escAttr;
 
   function timeAgo(dateStr: string): string {
     if (!dateStr) return '';

--- a/tests/unit/security-bug-23-esc-xss.test.ts
+++ b/tests/unit/security-bug-23-esc-xss.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+//
+// Regression coverage for #23: stored XSS via the local esc() helpers.
+//
+// Two distinct sinks:
+//   1. `esc()` in src/pages/forum.astro and src/lib/block-hydrators.ts uses
+//      `textContent → innerHTML`, which escapes <, >, & but NOT " or '. When
+//      the result is interpolated into a double-quoted attribute, an attacker
+//      can break out of the attribute and inject event handlers (onmouseover,
+//      onerror, ...).
+//   2. `announcement.body` is interpolated raw into innerHTML, so any HTML
+//      payload an admin (or AI feature) writes runs in every reader's browser.
+//
+// The fix is to (a) use the shared escAttr/escHtml from src/lib/blocks.ts in
+// every attribute/text context (they escape quotes correctly), and (b)
+// sanitize announcement bodies before assigning them to innerHTML.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { escAttr, escHtml } from '../../src/lib/blocks.ts';
+import { sanitizeRichHtml } from '../../src/lib/sanitize-html.ts';
+
+// happy-dom rebinds import.meta.url to a non-file scheme; resolve test paths
+// against the repo root via process.cwd() instead.
+const repoRoot = process.cwd();
+const FORUM_PAGE = resolve(repoRoot, 'src/pages/forum.astro');
+const BLOCK_HYDRATORS = resolve(repoRoot, 'src/lib/block-hydrators.ts');
+
+// Reproduce the local `esc()` helper as defined in the affected files so the
+// test pins the legacy (broken) behavior we are removing.
+function legacyEsc(s: unknown): string {
+  const d = document.createElement('div');
+  d.textContent = String(s ?? '');
+  return d.innerHTML;
+}
+
+const QUOTE_BREAKOUT = '" onmouseover="alert(1)" x="';
+const IMG_PAYLOAD = '<img src=x onerror="alert(1)">';
+
+function attributesOf(html: string, selector: string): string[] {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  const node = host.querySelector(selector);
+  if (!node) throw new Error(`No node matched ${selector} in ${html}`);
+  return Array.from(node.attributes).map((a) => a.name);
+}
+
+describe('bug #23 — esc() quote-escape XSS in attribute contexts', () => {
+  it('escAttr/escHtml escape both " and \' so attribute interpolation is safe', () => {
+    const escaped = escAttr(QUOTE_BREAKOUT);
+    expect(escaped).not.toContain('"');
+    expect(escaped).not.toContain("'");
+    expect(escaped).toContain('&quot;');
+
+    // The actual sink shape — data-translate-text="${escAttr(body)}".
+    const html = `<div data-translate-text="${escaped}" data-ct="forum_topic">body</div>`;
+    const attrs = attributesOf(html, 'div');
+    expect(attrs).toEqual(['data-translate-text', 'data-ct']);
+    expect(attrs).not.toContain('onmouseover');
+  });
+
+  it('forum.astro must NOT redefine its own esc() that leaves quotes unescaped', async () => {
+    const source = await readFile(FORUM_PAGE, 'utf8');
+    // The local esc() helper at line ~178 uses textContent → innerHTML, which
+    // is unsafe in attribute contexts. The fix replaces every esc(...) call
+    // with escAttr/escHtml from blocks.ts and removes the local definition.
+    expect(source).not.toMatch(/function esc\s*\(/);
+    expect(source).toMatch(/escAttr|escHtml/);
+  });
+
+  it('block-hydrators.ts must NOT redefine its own esc() helper', async () => {
+    const source = await readFile(BLOCK_HYDRATORS, 'utf8');
+    expect(source).not.toMatch(/function esc\s*\(/);
+    expect(source).toMatch(/escAttr|escHtml/);
+  });
+
+  it('reproduces the unsafe behavior of the legacy esc() to lock in the regression', () => {
+    // Sanity check that the original bug truly existed: legacyEsc leaves
+    // quotes alone and so attribute breakout works.
+    const escaped = legacyEsc(QUOTE_BREAKOUT);
+    expect(escaped).toContain('"');
+    const html = `<div data-translate-text="${escaped}" data-ct="forum_topic">body</div>`;
+    const attrs = attributesOf(html, 'div');
+    // The legacy helper would have caused onmouseover to land as a real
+    // attribute. We don't want this to ever be re-introduced.
+    expect(attrs).toContain('onmouseover');
+  });
+});
+
+describe('bug #23 — announcement body raw innerHTML sink', () => {
+  it('sanitizeRichHtml strips <script> and on*= event handlers from rich text', () => {
+    const cleaned = sanitizeRichHtml(IMG_PAYLOAD);
+    expect(cleaned.toLowerCase()).not.toContain('onerror');
+    expect(cleaned.toLowerCase()).not.toContain('<script');
+
+    const host = document.createElement('div');
+    host.innerHTML = cleaned;
+    const img = host.querySelector('img');
+    if (img) {
+      // <img> is allowed (Tiptap-style rich content), but never with on* attrs.
+      const attrs = Array.from(img.attributes).map((a) => a.name.toLowerCase());
+      for (const attr of attrs) expect(attr).not.toMatch(/^on/);
+    }
+  });
+
+  it('sanitizeRichHtml allows safe Tiptap output (<p>, <strong>, links with safe href)', () => {
+    const cleaned = sanitizeRichHtml('<p>Hello <strong>world</strong> <a href="https://example.com">link</a></p>');
+    expect(cleaned).toContain('<p>');
+    expect(cleaned).toContain('<strong>');
+    expect(cleaned).toContain('href="https://example.com"');
+  });
+
+  it('sanitizeRichHtml strips javascript: hrefs', () => {
+    const cleaned = sanitizeRichHtml('<a href="javascript:alert(1)">click</a>');
+    expect(cleaned.toLowerCase()).not.toContain('javascript:');
+  });
+
+  it('block-hydrators.ts must sanitize announcement bodies before innerHTML', async () => {
+    const source = await readFile(BLOCK_HYDRATORS, 'utf8');
+    // The announcement-body div must not interpolate `${a.body}` raw — it
+    // must pass through sanitizeRichHtml.
+    expect(source).not.toMatch(/data-editable-rich="announcements\.\$\{a\.id\}\.body">\$\{a\.body\}/);
+    expect(source).toMatch(/sanitizeRichHtml/);
+  });
+});
+
+// escHtml is the helper used elsewhere — keep it referenced so the import is
+// not pruned by linters and so the test file documents the intended boundary.
+escHtml(undefined);

--- a/tests/unit/security-bug-24-mass-assignment.test.ts
+++ b/tests/unit/security-bug-24-mass-assignment.test.ts
@@ -1,0 +1,344 @@
+// Regression coverage for #24: capability-API mass-assignment.
+//
+// Several mutation handlers thread caller-supplied actor fields straight into
+// the row insert via `input.X ?? memberId(actor)`. The capability gate confirms
+// "you may post a forum reply" but does not constrain that you may only post
+// **as yourself** — so an active member can spoof author_id / member_id /
+// created_by, pin their own forum topic without the moderator-only `.pin`
+// operation, RSVP another member to an event, attribute activity to others,
+// etc. pollVotes.cast also fails to validate that optionId belongs to pollId.
+//
+// These tests pin the safe behavior: writes must use the actor's identity,
+// privileged fields are stripped from create-path inputs, and pollVotes.cast
+// rejects cross-poll option ids.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type JsonObject, KYCHON_API_VERSION } from '../../src/lib/capability-api/index.ts';
+
+type MockDbChain = Promise<JsonObject[]> & {
+  eq(column: string, value: unknown): MockDbChain;
+  limit(count: number): Promise<JsonObject[]>;
+};
+
+const mockState = vi.hoisted(() => ({
+  user: null as null | { id: string; email?: string },
+  tables: {} as Record<string, JsonObject[]>,
+  counters: {} as Record<string, number>,
+  postgrestWriteRlsTables: new Set<string>(),
+  chain(rows: JsonObject[]): MockDbChain {
+    const query = Promise.resolve(rows) as MockDbChain;
+    query.eq = (column: string, value: unknown) =>
+      mockState.chain(rows.filter((row) => String(row[column]) === String(value)));
+    query.limit = (count: number) => Promise.resolve(rows.slice(0, count));
+    return query;
+  },
+  insert(table: string, row: JsonObject) {
+    if (mockState.postgrestWriteRlsTables.has(table)) {
+      throw new Error(`PostgREST RLS blocked insert on ${table}`);
+    }
+    const nextId = (mockState.counters[table] || maxId(mockState.tables[table] || [])) + 1;
+    mockState.counters[table] = nextId;
+    const created = { id: nextId, ...row };
+    mockState.tables[table] = [...(mockState.tables[table] || []), created];
+    return Promise.resolve(created);
+  },
+  update(table: string, column: string, value: unknown, patch: JsonObject) {
+    const rows = mockState.tables[table] || [];
+    const updated: JsonObject[] = [];
+    mockState.tables[table] = rows.map((row) => {
+      if (String(row[column]) !== String(value)) return row;
+      const next = { ...row, ...patch };
+      updated.push(next);
+      return next;
+    });
+    return Promise.resolve(updated);
+  },
+  delete(table: string, column: string, value: unknown) {
+    const rows = mockState.tables[table] || [];
+    const kept: JsonObject[] = [];
+    const deleted: JsonObject[] = [];
+    for (const row of rows) {
+      if (String(row[column]) === String(value)) deleted.push(row);
+      else kept.push(row);
+    }
+    mockState.tables[table] = kept;
+    return Promise.resolve(deleted);
+  },
+}));
+
+vi.mock(
+  '@run402/functions',
+  () => ({
+    getUser: vi.fn(async () => mockState.user),
+    adminDb: () => ({
+      sql(query: string, params: unknown[] = []) {
+        return mockSql(query, params);
+      },
+      from(table: string) {
+        return {
+          select() {
+            return mockState.chain(mockState.tables[table] || []);
+          },
+          insert(row: JsonObject) {
+            return mockState.insert(table, row);
+          },
+          update(patch: JsonObject) {
+            return {
+              eq(column: string, value: unknown) {
+                return mockState.update(table, column, value, patch);
+              },
+            };
+          },
+          delete() {
+            return {
+              eq(column: string, value: unknown) {
+                return mockState.delete(table, column, value);
+              },
+            };
+          },
+        };
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+function maxId(rows: JsonObject[]) {
+  return Math.max(0, ...rows.map((row) => Number(row.id || 0)));
+}
+
+function mockSql(query: string, params: unknown[]) {
+  const normalized = query.replace(/\s+/g, ' ').trim();
+  const insert = normalized.match(/^INSERT INTO "([^"]+)" \(([^)]+)\) VALUES \(([^)]+)\) RETURNING \*$/);
+  if (insert) {
+    const [, table, columns] = insert;
+    const row = Object.fromEntries(columns.split(', ').map((column, index) => [column.slice(1, -1), params[index]]));
+    const nextId = (mockState.counters[table] || maxId(mockState.tables[table] || [])) + 1;
+    mockState.counters[table] = nextId;
+    const created = { id: nextId, ...row };
+    mockState.tables[table] = [...(mockState.tables[table] || []), created];
+    return Promise.resolve([created]);
+  }
+  const update = normalized.match(/^UPDATE "([^"]+)" SET (.+) WHERE "([^"]+)" = \$([0-9]+) RETURNING \*$/);
+  if (update) {
+    const [, table, assignments, column, idParam] = update;
+    const patch = Object.fromEntries(
+      assignments.split(', ').map((assignment) => {
+        const [, rawColumn, rawParam] = assignment.match(/^"([^"]+)" = \$([0-9]+)$/) || [];
+        return [rawColumn, params[Number(rawParam) - 1]];
+      }),
+    );
+    const rows = mockState.tables[table] || [];
+    const updated: JsonObject[] = [];
+    mockState.tables[table] = rows.map((row) => {
+      if (String(row[column]) !== String(params[Number(idParam) - 1])) return row;
+      const next = { ...row, ...patch };
+      updated.push(next);
+      return next;
+    });
+    return Promise.resolve(updated);
+  }
+  const select = normalized.match(/^SELECT \* FROM "([^"]+)" WHERE "([^"]+)" = \$1 LIMIT 1$/);
+  if (select) {
+    const [, table, column] = select;
+    return Promise.resolve(
+      (mockState.tables[table] || []).filter((row) => String(row[column]) === String(params[0])).slice(0, 1),
+    );
+  }
+  const del = normalized.match(/^DELETE FROM "([^"]+)" WHERE "([^"]+)" = \$1 RETURNING \*$/);
+  if (del) {
+    const [, table, column] = del;
+    const rows = mockState.tables[table] || [];
+    const kept: JsonObject[] = [];
+    const deleted: JsonObject[] = [];
+    for (const row of rows) {
+      if (String(row[column]) === String(params[0])) deleted.push(row);
+      else kept.push(row);
+    }
+    mockState.tables[table] = kept;
+    return Promise.resolve(deleted);
+  }
+  throw new Error(`Unexpected SQL: ${normalized}`);
+}
+
+const ATTACKER = {
+  user_id: 'attacker-user',
+  email: 'attacker@example.com',
+  display_name: 'Attacker',
+  role: 'member' as const,
+  status: 'active' as const,
+};
+
+const VICTIM_MEMBER_ID = 999;
+
+async function apiRequest(body: JsonObject) {
+  const kychonApi = (await import('../../functions/kychon-api.js')).default;
+  return kychonApi(
+    new Request('https://portal.test/functions/v1/kychon-api', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+async function callJson(body: JsonObject) {
+  const res = await apiRequest(body);
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => {
+  mockState.user = { id: ATTACKER.user_id, email: ATTACKER.email };
+  mockState.counters = {};
+  mockState.postgrestWriteRlsTables = new Set<string>();
+  mockState.tables = {
+    members: [
+      { id: 1, ...ATTACKER },
+      {
+        id: VICTIM_MEMBER_ID,
+        user_id: 'victim-user',
+        email: 'victim@example.com',
+        role: 'admin',
+        status: 'active',
+        display_name: 'Admin',
+      },
+    ],
+    forum_categories: [{ id: 1, name: 'General', position: 1 }],
+    forum_topics: [],
+    forum_replies: [],
+    events: [{ id: 1, title: 'Meetup', starts_at: '2099-01-01T10:00:00Z' }],
+    event_rsvps: [{ id: 1, event_id: 1, member_id: VICTIM_MEMBER_ID, status: 'going' }],
+    polls: [
+      { id: 1, question: 'Poll A', poll_type: 'single', is_open: true },
+      { id: 2, question: 'Poll B', poll_type: 'single', is_open: true },
+    ],
+    poll_options: [
+      { id: 10, poll_id: 1, label: 'A1', position: 0 },
+      { id: 11, poll_id: 1, label: 'A2', position: 1 },
+      { id: 20, poll_id: 2, label: 'B1', position: 0 },
+    ],
+    poll_votes: [],
+    activity_log: [],
+    capability_executions: [],
+    reactions: [],
+    announcements: [],
+  };
+});
+
+describe('bug #24 — capability API mass-assignment', () => {
+  it('forum.topics.create ignores caller-supplied author_id', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'forum.topics.create',
+      phase: 'execute',
+      idempotencyKey: 'topic-author-spoof',
+      input: {
+        categoryId: 1,
+        title: 'Spoofed',
+        body: 'body',
+        author_id: VICTIM_MEMBER_ID,
+        author_name: 'Admin',
+      },
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    const topic = mockState.tables.forum_topics[0];
+    expect(String(topic.author_id)).toBe('1'); // attacker member id, not VICTIM
+    expect(topic.author_name).toBe(ATTACKER.display_name);
+  });
+
+  it('forum.topics.create ignores caller-supplied is_pinned (moderator-only via .pin)', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'forum.topics.create',
+      phase: 'execute',
+      idempotencyKey: 'topic-self-pin',
+      input: { categoryId: 1, title: 'Self-pin attempt', body: 'body', is_pinned: true },
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    const topic = mockState.tables.forum_topics[0];
+    expect(topic.is_pinned).toBe(false);
+  });
+
+  it('forum.replies.create ignores caller-supplied author_id', async () => {
+    mockState.tables.forum_topics = [{ id: 5, category_id: 1, title: 'Topic', locked: false, reply_count: 0 }];
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'forum.replies.create',
+      phase: 'execute',
+      idempotencyKey: 'reply-author-spoof',
+      input: {
+        topicId: 5,
+        body: 'reply body',
+        author_id: VICTIM_MEMBER_ID,
+        author_name: 'Admin',
+      },
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    const reply = mockState.tables.forum_replies[0];
+    expect(String(reply.author_id)).toBe('1');
+    expect(reply.author_name).toBe(ATTACKER.display_name);
+  });
+
+  it('rsvps.setStatus ignores caller-supplied member_id (cannot RSVP another member)', async () => {
+    mockState.tables.event_rsvps = []; // no existing RSVP for attacker
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'rsvps.setStatus',
+      phase: 'execute',
+      idempotencyKey: 'rsvp-member-spoof',
+      input: { eventId: 1, status: 'going', memberId: VICTIM_MEMBER_ID },
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    expect(mockState.tables.event_rsvps).toHaveLength(1);
+    expect(String(mockState.tables.event_rsvps[0].member_id)).toBe('1');
+  });
+
+  it("rsvps.setStatus ignores caller-supplied id targeting another member's RSVP", async () => {
+    // Pre-existing RSVP belongs to VICTIM_MEMBER_ID. Attacker tries to flip
+    // it via id=1.
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'rsvps.setStatus',
+      phase: 'execute',
+      idempotencyKey: 'rsvp-id-spoof',
+      input: { id: 1, status: 'cancelled' },
+    });
+    // Attacker has no RSVP of their own, so this should NOT mutate someone
+    // else's row. Either reject with permission.denied or create a new
+    // attacker-owned RSVP.
+    if (r.status === 200) {
+      expect(String(mockState.tables.event_rsvps[0].member_id)).toBe(String(VICTIM_MEMBER_ID));
+      expect(mockState.tables.event_rsvps[0].status).toBe('going');
+    } else {
+      expect(r.body.error?.code).toBe('permission.denied');
+    }
+  });
+
+  it('pollVotes.cast rejects optionId from a different poll', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'pollVotes.cast',
+      phase: 'execute',
+      idempotencyKey: 'poll-vote-cross',
+      input: { pollId: 1, optionId: 20 }, // option 20 belongs to poll 2, not 1
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(400);
+    expect(r.body.error.code).toBe('validation.failed');
+    expect(mockState.tables.poll_votes).toHaveLength(0);
+  });
+
+  it('pollVotes.cast accepts optionId that belongs to the poll', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'pollVotes.cast',
+      phase: 'execute',
+      idempotencyKey: 'poll-vote-ok',
+      input: { pollId: 1, optionId: 10 },
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    expect(mockState.tables.poll_votes).toHaveLength(1);
+    expect(String(mockState.tables.poll_votes[0].member_id)).toBe('1');
+    expect(String(mockState.tables.poll_votes[0].option_id)).toBe('10');
+  });
+});

--- a/tests/unit/security-bug-25-uploads.test.ts
+++ b/tests/unit/security-bug-25-uploads.test.ts
@@ -1,0 +1,207 @@
+// Regression coverage for #25: upload edge-function vulnerabilities.
+//
+// 1. functions/upload-resource.js requires only "any signed-in Run402 user" —
+//    not a Kychon admin and not even a Kychon member. uploaded_by is taken
+//    from caller-supplied metadata. Result: anyone who can authenticate to
+//    Run402 can write a file and a row into the project.
+// 2. functions/upload-asset.js interpolates `body.path` straight into the
+//    Run402 storage delete URL with the service key, allowing path traversal
+//    out of the assets/ bucket.
+// 3. functions/upload-asset.js builds a SQL query via string concatenation on
+//    `user.id`. Safe today because user.id is a UUID, but this is a
+//    defense-in-depth issue — should use parameterized SQL.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { JsonObject } from '../../src/lib/capability-api/index.ts';
+
+const mockState = vi.hoisted(() => ({
+  user: null as null | { id: string; email?: string },
+  members: [] as JsonObject[],
+  resources: [] as JsonObject[],
+  fetchCalls: [] as Array<{ url: string; method: string }>,
+  uploadResponse: { ok: true, url: '/storage/test', status: 200 },
+  deleteResponse: { ok: true, status: 200 },
+  sqlCalls: [] as Array<{ query: string; params: unknown[] }>,
+}));
+
+vi.mock(
+  '@run402/functions',
+  () => ({
+    getUser: vi.fn(async () => mockState.user),
+    adminDb: () => ({
+      sql(query: string, params: unknown[] = []) {
+        mockState.sqlCalls.push({ query, params });
+        const lc = query.replace(/\s+/g, ' ').trim().toLowerCase();
+        if (lc.startsWith('select role from members')) {
+          const want = String(params[0] ?? '');
+          const found = mockState.members.find((m) => String(m.user_id) === want);
+          return Promise.resolve(found ? { rows: [{ role: found.role }] } : { rows: [] });
+        }
+        if (lc.startsWith('select id from members')) {
+          const want = String(params[0] ?? '');
+          const found = mockState.members.find((m) => String(m.user_id) === want);
+          return Promise.resolve(found ? { rows: [{ id: found.id }] } : { rows: [] });
+        }
+        return Promise.resolve({ rows: [] });
+      },
+      from(table: string) {
+        return {
+          insert(row: JsonObject) {
+            if (table === 'resources') {
+              const created = { id: mockState.resources.length + 1, ...row };
+              mockState.resources.push(created);
+              return Promise.resolve([created]);
+            }
+            return Promise.resolve([row]);
+          },
+        };
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+beforeEach(() => {
+  mockState.user = null;
+  mockState.members = [];
+  mockState.resources = [];
+  mockState.fetchCalls = [];
+  mockState.sqlCalls = [];
+  mockState.uploadResponse = { ok: true, url: '/storage/test', status: 200 };
+  mockState.deleteResponse = { ok: true, status: 200 };
+  process.env.RUN402_SERVICE_KEY = 'service-key-test';
+
+  globalThis.fetch = vi.fn(async (url: string, init?: { method?: string }) => {
+    const method = init?.method || 'GET';
+    mockState.fetchCalls.push({ url: String(url), method });
+    if (method === 'DELETE') {
+      return new Response(JSON.stringify({ deleted: true }), {
+        status: mockState.deleteResponse.status,
+      });
+    }
+    return new Response(JSON.stringify({ url: mockState.uploadResponse.url }), {
+      status: mockState.uploadResponse.status,
+    });
+  }) as unknown as typeof fetch;
+});
+
+function jsonReq(path: string, body: unknown) {
+  return new Request(`https://portal.test/functions/v1/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('bug #25 — upload-resource.js role check + uploaded_by spoof', () => {
+  it('rejects non-admin Kychon members with 403', async () => {
+    mockState.user = { id: 'plain-user', email: 'plain@example.com' };
+    mockState.members = [
+      { id: 1, user_id: 'plain-user', email: 'plain@example.com', role: 'member', status: 'active' },
+    ];
+    const handler = (await import('../../functions/upload-resource.js')).default;
+    const res = await handler(
+      jsonReq('upload-resource', {
+        file: { name: 'guide.pdf', type: 'application/pdf', data: btoa('hello') },
+        metadata: { title: 'Guide' },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockState.resources).toHaveLength(0);
+  });
+
+  it('rejects unauthenticated callers with 401', async () => {
+    mockState.user = null;
+    const handler = (await import('../../functions/upload-resource.js')).default;
+    const res = await handler(
+      jsonReq('upload-resource', {
+        file: { name: 'guide.pdf', type: 'application/pdf', data: btoa('hello') },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('overwrites caller-supplied uploaded_by with the actor member id', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-resource.js')).default;
+    const res = await handler(
+      jsonReq('upload-resource', {
+        file: { name: 'guide.pdf', type: 'application/pdf', data: btoa('hi') },
+        metadata: { title: 'Guide', uploaded_by: 999 },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockState.resources).toHaveLength(1);
+    expect(String(mockState.resources[0].uploaded_by)).toBe('7');
+  });
+
+  it('rejects unsafe file names (path traversal in storage path)', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-resource.js')).default;
+    const res = await handler(
+      jsonReq('upload-resource', {
+        file: { name: '../../etc/passwd', type: 'text/plain', data: btoa('pwn') },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockState.resources).toHaveLength(0);
+  });
+});
+
+describe('bug #25 — upload-asset.js path traversal in delete', () => {
+  it('rejects body.path containing ".." path traversal', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-asset.js')).default;
+    const res = await handler(jsonReq('upload-asset', { action: 'delete', path: '../resources/secret.pdf' }));
+    expect(res.status).toBe(400);
+    // Crucially — no DELETE request should have been issued upstream.
+    expect(mockState.fetchCalls.filter((c) => c.method === 'DELETE')).toHaveLength(0);
+  });
+
+  it('rejects body.path with leading slash (escapes bucket prefix)', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-asset.js')).default;
+    const res = await handler(jsonReq('upload-asset', { action: 'delete', path: '/etc/secret' }));
+    expect(res.status).toBe(400);
+    expect(mockState.fetchCalls.filter((c) => c.method === 'DELETE')).toHaveLength(0);
+  });
+
+  it('rejects body.path with double slash', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-asset.js')).default;
+    const res = await handler(jsonReq('upload-asset', { action: 'delete', path: 'foo//bar' }));
+    expect(res.status).toBe(400);
+    expect(mockState.fetchCalls.filter((c) => c.method === 'DELETE')).toHaveLength(0);
+  });
+
+  it('accepts a clean asset path', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-asset.js')).default;
+    const res = await handler(jsonReq('upload-asset', { action: 'delete', path: 'logo.png' }));
+    expect(res.status).toBe(200);
+    const deleteCall = mockState.fetchCalls.find((c) => c.method === 'DELETE');
+    expect(deleteCall?.url).toBe('https://api.run402.com/storage/v1/delete/assets/logo.png');
+  });
+});
+
+describe('bug #25 — upload-asset.js parameterized SQL', () => {
+  it('uses parameterized $1 binding for user_id (not string interpolation)', async () => {
+    mockState.user = { id: 'admin-user' };
+    mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
+    const handler = (await import('../../functions/upload-asset.js')).default;
+    await handler(jsonReq('upload-asset', { action: 'delete', path: 'logo.png' }));
+
+    const roleQuery = mockState.sqlCalls.find((c) => /role from members/i.test(c.query));
+    expect(roleQuery, 'expected a SELECT role FROM members SQL call').toBeDefined();
+    expect(roleQuery!.query).toMatch(/\$1/);
+    expect(roleQuery!.query).not.toMatch(/'admin-user'/);
+    expect(roleQuery!.params).toEqual(['admin-user']);
+  });
+});

--- a/tests/unit/security-bug-26-undefined-db.test.ts
+++ b/tests/unit/security-bug-26-undefined-db.test.ts
@@ -1,0 +1,170 @@
+// Regression coverage for #26: on-signup.js and ai-content.js dereference a
+// bare `db` identifier even though only `adminDb` is imported. Both throw a
+// `ReferenceError` at runtime — on-signup loses every brand-new member, and
+// the AI newsletter never produces a draft. These tests load the deployed
+// modules, mock @run402/functions, and exercise the failing code paths.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Row = Record<string, unknown>;
+
+const state = vi.hoisted(() => ({
+  tables: {} as Record<string, Row[]>,
+  counters: {} as Record<string, number>,
+  authUserResponses: [] as Array<{ ok: boolean; status?: number; json: unknown }>,
+  fetchCalls: [] as string[],
+  insertedRows: [] as Array<{ table: string; row: Row }>,
+}));
+
+type DbChain = Promise<Row[]> & {
+  eq(column: string, value: unknown): DbChain;
+  gte(column: string, value: unknown): DbChain;
+  order(): DbChain;
+  limit(count: number): Promise<Row[]>;
+};
+
+function chain(rows: Row[]): DbChain {
+  const promise = Promise.resolve(rows) as DbChain;
+  promise.eq = (column: string, value: unknown) => chain(rows.filter((row) => String(row[column]) === String(value)));
+  promise.gte = (column: string, value: unknown) =>
+    chain(rows.filter((row) => String(row[column] ?? '') >= String(value)));
+  promise.order = () => chain(rows);
+  promise.limit = (count: number) => Promise.resolve(rows.slice(0, count));
+  return promise;
+}
+
+function table(name: string) {
+  state.tables[name] ||= [];
+  return {
+    select() {
+      return chain(state.tables[name]);
+    },
+    insert(row: Row) {
+      const nextId = (state.counters[name] || 0) + 1;
+      state.counters[name] = nextId;
+      const created = { id: nextId, ...row };
+      state.tables[name] = [...state.tables[name], created];
+      state.insertedRows.push({ table: name, row: created });
+      return Promise.resolve([created]);
+    },
+  };
+}
+
+vi.mock(
+  '@run402/functions',
+  () => ({
+    getUser: vi.fn(async () => ({ id: 'auth-user-1', email: 'new@example.com' })),
+    adminDb: () => ({
+      from: table,
+      sql(query: string) {
+        if (/count\(\*\)/i.test(query)) {
+          return Promise.resolve({ rows: [{ count: 0 }] });
+        }
+        throw new Error(`Unexpected SQL: ${query}`);
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+beforeEach(() => {
+  state.tables = {};
+  state.counters = {};
+  state.authUserResponses = [];
+  state.fetchCalls = [];
+  state.insertedRows = [];
+
+  // The on-signup handler may fetch the auth user details for display_name/avatar.
+  globalThis.fetch = vi.fn(async (url: string) => {
+    state.fetchCalls.push(url);
+    const next = state.authUserResponses.shift();
+    if (next) {
+      return new Response(JSON.stringify(next.json), {
+        status: next.status ?? (next.ok ? 200 : 500),
+      });
+    }
+    return new Response('{}', { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+describe('on-signup.js — bug #26 (undefined db)', () => {
+  it('creates a member when invoked via the lifecycle hook (no ReferenceError)', async () => {
+    const onSignup = (await import('../../functions/on-signup.js')).default;
+    const req = new Request('https://portal.test/functions/v1/on-signup', {
+      method: 'POST',
+      headers: { 'x-run402-trigger': 'signup', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user: { id: 'auth-user-1', email: 'new@example.com' } }),
+    });
+    const res = await onSignup(req);
+    const body = await res.json();
+    expect(res.status, body?.error || 'on-signup unexpectedly failed').toBe(200);
+    expect(body.status).toBe('created');
+    expect(state.tables.members).toHaveLength(1);
+    expect(state.tables.members[0]).toMatchObject({
+      user_id: 'auth-user-1',
+      email: 'new@example.com',
+      role: 'admin', // first member becomes admin
+      status: 'active',
+    });
+    expect(state.tables.activity_log).toHaveLength(1);
+  });
+});
+
+describe('ai-content.js — bug #26 (undefined db)', () => {
+  it('runs gatherWeeklyActivity without ReferenceError when newsletter feature is enabled', async () => {
+    process.env.AI_API_KEY = 'sk-test';
+    process.env.AI_PROVIDER = 'openai';
+    state.tables.site_config = [
+      { id: 1, key: 'feature_ai_newsletter', value: true },
+      { id: 2, key: 'site_name', value: '"Test Community"' },
+    ];
+    state.tables.events = [];
+    state.tables.announcements = [];
+    state.tables.forum_topics = [];
+    state.tables.resources = [];
+    state.tables.members = [];
+    state.tables.newsletter_drafts = [];
+
+    // Mock OpenAI response — fetch is already mocked in beforeEach; override
+    // for this test to return a valid newsletter JSON envelope.
+    let openaiCalls = 0;
+    globalThis.fetch = vi.fn(async (url: string) => {
+      state.fetchCalls.push(url);
+      if (url.includes('openai.com')) {
+        openaiCalls += 1;
+        return new Response(
+          JSON.stringify({
+            choices: [{ message: { content: '{"subject":"Hi","body":"<p>Hi</p>"}' } }],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const aiContent = (await import('../../functions/ai-content.js')).default;
+    const buildReq = () =>
+      new Request('https://portal.test/functions/v1/ai-content', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+    const res = await aiContent(buildReq());
+    const body = await res.json();
+    // Handler may "skip" when activity is empty — but it must NOT 500 with
+    // ReferenceError. status === 'skipped' is acceptable; status >= 500 is not.
+    expect(res.status, body?.error || 'ai-content unexpectedly failed').toBeLessThan(500);
+    expect(body?.error ?? '').not.toMatch(/db is not defined|ReferenceError/);
+
+    // Sanity: with content present we expect a draft. Add some activity and
+    // exercise the path again.
+    state.tables.announcements.push({ id: 1, title: 'News', body: 'Body', created_at: new Date().toISOString() });
+    const res2 = await aiContent(buildReq());
+    const body2 = await res2.json();
+    expect(res2.status, body2?.error || 'ai-content gather failed with content').toBe(200);
+    expect(body2.status).toBe('ok');
+    expect(state.tables.newsletter_drafts).toHaveLength(1);
+    expect(openaiCalls).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/security-bug-27-hardening.test.ts
+++ b/tests/unit/security-bug-27-hardening.test.ts
@@ -1,0 +1,309 @@
+// Regression coverage for #27: capability API hardening bag.
+// None of these are individually exploitable, but each is a friction-reducer
+// for an attacker or makes the API contract a little less honest.
+//
+//   1. Envelope coercion silently allows non-object `input` (null, arrays).
+//   2. idempotencyKey conflict response discloses the prior operation name.
+//   3. Anon `validate` phase enumerates the whole mutation surface.
+//   4. `config.get` returns the full site_config to anonymous callers.
+//   5. `events.list` / `announcements.list` expose `created_by` / `author_id`
+//      to anonymous callers — usable as IDOR pivots for #24.
+//   6. `requiredAny` accepts the empty string "" as a valid id.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type JsonObject, KYCHON_API_VERSION } from '../../src/lib/capability-api/index.ts';
+
+type MockDbChain = Promise<JsonObject[]> & {
+  eq(column: string, value: unknown): MockDbChain;
+  limit(count: number): Promise<JsonObject[]>;
+};
+
+const mockState = vi.hoisted(() => ({
+  user: null as null | { id: string; email?: string },
+  tables: {} as Record<string, JsonObject[]>,
+  counters: {} as Record<string, number>,
+  chain(rows: JsonObject[]): MockDbChain {
+    const query = Promise.resolve(rows) as MockDbChain;
+    query.eq = (column: string, value: unknown) =>
+      mockState.chain(rows.filter((row) => String(row[column]) === String(value)));
+    query.limit = (count: number) => Promise.resolve(rows.slice(0, count));
+    return query;
+  },
+  insert(table: string, row: JsonObject) {
+    const nextId = (mockState.counters[table] || 0) + 1;
+    mockState.counters[table] = nextId;
+    const created = { id: nextId, ...row };
+    mockState.tables[table] = [...(mockState.tables[table] || []), created];
+    return Promise.resolve(created);
+  },
+  update(table: string, column: string, value: unknown, patch: JsonObject) {
+    const rows = mockState.tables[table] || [];
+    const updated: JsonObject[] = [];
+    mockState.tables[table] = rows.map((row) => {
+      if (String(row[column]) !== String(value)) return row;
+      const next = { ...row, ...patch };
+      updated.push(next);
+      return next;
+    });
+    return Promise.resolve(updated);
+  },
+  delete(table: string, column: string, value: unknown) {
+    const rows = mockState.tables[table] || [];
+    const kept: JsonObject[] = [];
+    const deleted: JsonObject[] = [];
+    for (const row of rows) {
+      if (String(row[column]) === String(value)) deleted.push(row);
+      else kept.push(row);
+    }
+    mockState.tables[table] = kept;
+    return Promise.resolve(deleted);
+  },
+}));
+
+vi.mock(
+  '@run402/functions',
+  () => ({
+    getUser: vi.fn(async () => mockState.user),
+    adminDb: () => ({
+      sql() {
+        return Promise.resolve({ rows: [] });
+      },
+      from(table: string) {
+        return {
+          select() {
+            return mockState.chain(mockState.tables[table] || []);
+          },
+          insert(row: JsonObject) {
+            return mockState.insert(table, row);
+          },
+          update(patch: JsonObject) {
+            return {
+              eq(column: string, value: unknown) {
+                return mockState.update(table, column, value, patch);
+              },
+            };
+          },
+          delete() {
+            return {
+              eq(column: string, value: unknown) {
+                return mockState.delete(table, column, value);
+              },
+            };
+          },
+        };
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+async function callJson(body: unknown) {
+  const kychonApi = (await import('../../functions/kychon-api.js')).default;
+  const res = await kychonApi(
+    new Request('https://portal.test/functions/v1/kychon-api', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => {
+  mockState.user = null;
+  mockState.counters = {};
+  mockState.tables = {
+    members: [],
+    capability_executions: [],
+    activity_log: [],
+    site_config: [
+      { id: 1, key: 'site_name', value: '"Public"', category: 'branding' },
+      { id: 2, key: 'feature_polls', value: true, category: 'features' },
+      { id: 3, key: 'webhook_url', value: 'https://hooks.example/secret', category: 'private' },
+      { id: 4, key: 'integration_token', value: 'shh', category: 'secrets' },
+    ],
+    events: [
+      {
+        id: 1,
+        title: 'Public Meetup',
+        starts_at: '2099-01-01T10:00:00Z',
+        is_members_only: false,
+        created_by: 42,
+      },
+    ],
+    announcements: [{ id: 1, title: 'Hello', body: 'World', author_id: 42, is_pinned: false }],
+    pages: [],
+    sections: [],
+  };
+});
+
+describe('bug #27 — envelope coercion (item 1)', () => {
+  it('rejects null input with request.invalidEnvelope', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'events.list',
+      phase: 'query',
+      input: null,
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(400);
+    expect(r.body.error.code).toBe('request.invalidEnvelope');
+  });
+
+  it('rejects array input with request.invalidEnvelope', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'events.list',
+      phase: 'query',
+      input: [1, 2, 3],
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(400);
+    expect(r.body.error.code).toBe('request.invalidEnvelope');
+  });
+});
+
+describe('bug #27 — idempotencyKey conflict info disclosure (item 2)', () => {
+  it('does not disclose the prior operation name in conflict response', async () => {
+    mockState.user = { id: 'admin-user', email: 'admin@example.com' };
+    mockState.tables.members = [
+      { id: 1, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' },
+    ];
+
+    // First call seeds an idempotency key under operation A.
+    const first = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'pages.create',
+      phase: 'execute',
+      idempotencyKey: 'shared-key',
+      input: { title: 'A', slug: 'a' },
+    });
+    expect(first.status, JSON.stringify(first.body)).toBe(200);
+
+    // Second call reuses the key but with operation B — should conflict but
+    // not leak the existing op name.
+    const conflict = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'sections.create',
+      phase: 'execute',
+      idempotencyKey: 'shared-key',
+      input: { section_type: 'hero', config: {}, position: 1 },
+    });
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error.code).toBe('conflict.idempotencyKey');
+    const detailJson = JSON.stringify(conflict.body.error.detail || {});
+    expect(detailJson).not.toMatch(/pages\.create/);
+    expect(detailJson).not.toContain('existingOperation');
+  });
+});
+
+describe('bug #27 — anon validate-phase enumeration (item 3)', () => {
+  it('does not expose required-state hints to anonymous callers', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'members.changeRole',
+      phase: 'validate',
+      input: { id: 1, role: 'admin' },
+    });
+    // Either deny outright (recommended) or strip requiredState from the
+    // permission detail. Both close the enumeration oracle.
+    if (r.status === 200) {
+      expect(r.body.data.permission?.requiredState).toBeUndefined();
+    } else {
+      expect(r.status).toBe(403);
+    }
+  });
+});
+
+describe('bug #27 — config.get visibility (item 4)', () => {
+  it('only exposes public categories (branding/features/theme/demo) to anonymous', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'config.get',
+      phase: 'query',
+      input: {},
+    });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    const keys = (r.body.data.rows || []).map((row: JsonObject) => row.key);
+    expect(keys).toContain('site_name');
+    expect(keys).toContain('feature_polls');
+    expect(keys).not.toContain('webhook_url');
+    expect(keys).not.toContain('integration_token');
+  });
+
+  it('exposes a private key to admins', async () => {
+    mockState.user = { id: 'admin-user', email: 'admin@example.com' };
+    mockState.tables.members = [
+      { id: 1, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' },
+    ];
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'config.get',
+      phase: 'query',
+      input: {},
+    });
+    expect(r.status).toBe(200);
+    const keys = (r.body.data.rows || []).map((row: JsonObject) => row.key);
+    expect(keys).toContain('webhook_url');
+  });
+});
+
+describe('bug #27 — created_by / author_id leak in anonymous list (item 5)', () => {
+  it('events.list strips created_by from anonymous projections', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'events.list',
+      phase: 'query',
+      input: {},
+    });
+    expect(r.status).toBe(200);
+    for (const row of r.body.data.rows as JsonObject[]) {
+      expect(row.created_by, JSON.stringify(row)).toBeUndefined();
+    }
+  });
+
+  it('announcements.list strips author_id from anonymous projections', async () => {
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'announcements.list',
+      phase: 'query',
+      input: {},
+    });
+    expect(r.status).toBe(200);
+    for (const row of r.body.data.rows as JsonObject[]) {
+      expect(row.author_id, JSON.stringify(row)).toBeUndefined();
+    }
+  });
+
+  it('events.list keeps created_by visible to admins', async () => {
+    mockState.user = { id: 'admin-user', email: 'admin@example.com' };
+    mockState.tables.members = [
+      { id: 1, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' },
+    ];
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'events.list',
+      phase: 'query',
+      input: {},
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.data.rows[0].created_by).toBe(42);
+  });
+});
+
+describe('bug #27 — requiredAny accepts empty string (item 6)', () => {
+  it('rejects empty-string id with validation.failed', async () => {
+    mockState.user = { id: 'admin-user', email: 'admin@example.com' };
+    mockState.tables.members = [
+      { id: 1, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' },
+    ];
+    const r = await callJson({
+      apiVersion: KYCHON_API_VERSION,
+      operation: 'pages.update',
+      phase: 'execute',
+      idempotencyKey: 'pages-update-empty-id',
+      input: { id: '', title: 'X' },
+    });
+    expect(r.status).toBe(400);
+    expect(r.body.error.code).toBe('validation.failed');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the five security/correctness bugs filed in [kychee-com/kychon-private](https://github.com/kychee-com/kychon-private) issues #23-#27. Each was reproduced with a TDD test before the fix; 28 new tests pin the safe behavior, the entire 789-test suite passes.

| Issue | Severity | Fix |
| --- | --- | --- |
| kychon-private#23 | Critical | Quote-safe `escAttr` for forum / block-hydrator interpolation; new `sanitizeRichHtml` for announcement bodies |
| kychon-private#24 | High | Owner fields bound to actor (never input); broader `stripControlFields` allowlist; pollVotes validates option/poll; RSVP ownership gate |
| kychon-private#25 | High | Admin role gate + filename validation on upload-resource; path-traversal validator + parameterized SQL on upload-asset |
| kychon-private#26 | High | `s/db/adminDb()/` in on-signup.js & ai-content.js (broke every brand-new signup + AI newsletter) |
| kychon-private#27 | Low | Envelope rejects null/array input; idempotency conflict no longer leaks prior op; validate-phase gates on minimum role; config.get filters by category for non-admins; events/announcements lists strip created_by/author_id for anon; requiredAny rejects empty string |

## Test plan
- [x] `npm test` — 789/789 passing including 28 new regression tests under `tests/unit/security-bug-2{3,4,5,6,7}-*.test.ts`
- [x] `npm run lint` — no new warnings in changed files
- [x] `npx tsc --noEmit` — clean
- [ ] Deploy to demo, smoke check member signup (kychon-private#26), forum stored-XSS payload (kychon-private#23), and admin asset delete (kychon-private#25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)