### PR TITLE
Fix bugs #28-#29: storage endpoint regression + hardening

### DIFF
--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -802,7 +802,62 @@ async function executeMutation(name, input, actor) {
     return actionResult({ status: 'queued', job: name.replace(/^jobs\./, '') }, [changedObject('job', name)], null);
   if (name === 'rsvps.setStatus') return setRsvpStatus(input, actor);
   if (name === 'rsvps.cancel') return cancelRsvp(input, actor);
+  if (name === 'members.changeRole') return changeMemberRole(input, actor);
   return genericMutation(name, input, actor);
+}
+
+const VALID_MEMBER_ROLES = new Set(['member', 'moderator', 'admin']);
+
+async function changeMemberRole(input, actor) {
+  // Reject anything that isn't a known role. The old fall-through path
+  // (`input.role || 'member'`) silently demoted on typos and let `'admin'`,
+  // `'moderator'`, or arbitrary strings reach the DB unfiltered. (#29)
+  const role = typeof input.role === 'string' ? input.role.toLowerCase() : '';
+  if (!VALID_MEMBER_ROLES.has(role)) {
+    throw capabilityError('validation.failed', 'members.changeRole requires role in member|moderator|admin.', {
+      role: String(input.role ?? ''),
+    });
+  }
+
+  const targetId = requiredId(input, 'members.changeRole');
+  const members = await selectRows('members');
+  const target = members.find((row) => String(row.id) === String(targetId));
+  if (!target) {
+    throw capabilityError('notFound.object', 'Member not found.', {
+      object: { type: 'member', id: String(targetId) },
+    });
+  }
+
+  // Last-admin guard: refuse to demote the actor's own admin role if doing
+  // so leaves zero remaining admins. Otherwise the portal locks itself out
+  // of admin features until someone goes around the API. (#29)
+  const actorMemberId = actor.member?.id ?? null;
+  if (
+    role !== 'admin' &&
+    actorMemberId != null &&
+    String(actorMemberId) === String(targetId) &&
+    String(target.role).toLowerCase() === 'admin'
+  ) {
+    const otherAdmins = members.filter(
+      (row) =>
+        String(row.id) !== String(targetId) &&
+        String(row.role).toLowerCase() === 'admin' &&
+        String(row.status).toLowerCase() === 'active',
+    );
+    if (otherAdmins.length === 0) {
+      throw capabilityError('conflict.state', 'Cannot demote the last active admin.', {
+        object: { type: 'member', id: String(targetId) },
+      });
+    }
+  }
+
+  const row = await updateRow('members', targetId, { role });
+  const object = changedObject('member', row?.id ?? targetId);
+  return actionResult(
+    row || { ...target, role },
+    [object],
+    verification('members.get', { id: row?.id ?? targetId }, object),
+  );
 }
 
 async function genericMutation(operation, input, actor) {
@@ -828,9 +883,13 @@ async function publishAnnouncement(input, actor) {
   // author_id is bound to the acting admin — never honored from input. The
   // dedicated `announcements.update` operation is the path for any later
   // attribution change. (#24)
+  //
+  // Body is sanitized on write so every downstream reader (newsletter
+  // generator, translation cache, CSV/RSS export) inherits the safety
+  // guarantee the read-side hydrator already provides. (#29)
   const announcement = await insertRow('announcements', {
     title: input.title || 'Untitled',
-    body: input.body || '',
+    body: sanitizeRichHtmlServer(input.body || ''),
     is_pinned: input.pin === true || input.is_pinned === true,
     author_id: memberId(actor),
   });
@@ -1039,6 +1098,15 @@ async function setRsvpStatus(input, actor) {
   }
 
   const event = requiredAny(eventId, 'rsvps.setStatus requires eventId.');
+  // Pre-validate the event so a missing FK surfaces as `notFound.object`,
+  // not the generic `internal.error` we'd get when the DB-side FK rejects
+  // the insert. (#29)
+  const eventRow = (await selectRows('events')).find((row) => String(row.id) === String(event));
+  if (!eventRow) {
+    throw capabilityError('notFound.object', 'Event not found.', {
+      object: { type: 'event', id: String(event) },
+    });
+  }
   const existing = (await selectRows('event_rsvps')).find(
     (row) => String(row.event_id) === String(event) && String(row.member_id) === String(member),
   );
@@ -1054,6 +1122,17 @@ async function cancelRsvp(input, actor) {
   const member = memberId(actor);
   const id = input.id;
   const eventId = input.eventId ?? input.event_id;
+  // When the caller addresses by eventId, validate it points at a real event
+  // before scanning rsvps — otherwise a typo collapses to a silent no-op
+  // with `cancelled: false` and the client can't tell why. (#29)
+  if (id == null && eventId != null) {
+    const eventRow = (await selectRows('events')).find((row) => String(row.id) === String(eventId));
+    if (!eventRow) {
+      throw capabilityError('notFound.object', 'Event not found.', {
+        object: { type: 'event', id: String(eventId) },
+      });
+    }
+  }
   const existing =
     id != null
       ? (await selectRows('event_rsvps')).find((row) => String(row.id) === String(id))
@@ -1200,6 +1279,11 @@ function rowForUpdate(operation, input, actor) {
     return { action: input.action || 'reviewed', reviewed_by: input.reviewed_by ?? memberId(actor) };
   if (operation === 'insights.updateStatus') return { status: input.status || 'reviewed' };
   if (operation === 'insights.dismiss') return { status: 'dismissed' };
+  if (operation === 'announcements.update') {
+    const patch = stripControlFields(input);
+    if (patch.body != null) patch.body = sanitizeRichHtmlServer(patch.body);
+    return patch;
+  }
   return stripControlFields(input);
 }
 
@@ -1440,6 +1524,25 @@ const PRIVILEGED_INPUT_FIELDS = new Set([
   'tier_id',
   'tierId',
 ]);
+
+// Server-side rich-HTML sanitizer mirroring the read-side allowlist in
+// `src/lib/sanitize-html.ts`. Run402 functions run in a Node-like runtime
+// without DOMParser, so we strip the obvious attack vectors with regex as
+// belt-and-braces for the read-side sanitizer. (#29)
+function sanitizeRichHtmlServer(input) {
+  if (input == null) return '';
+  let html = String(input);
+  // Strip executable / sandbox-escape tags and their content.
+  html = html.replace(/<(script|style|iframe|object|embed)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  // Strip the same set as void / unclosed forms.
+  html = html.replace(/<(script|style|iframe|object|embed|link|meta)\b[^>]*\/?>/gi, '');
+  // Strip on*= event handlers (quoted and unquoted).
+  html = html.replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  // Neutralize javascript:/vbscript: URLs anywhere they appear in attributes.
+  html = html.replace(/(\s\w+\s*=\s*["'])\s*(?:javascript|vbscript)\s*:/gi, '$1about:blank#blocked-');
+  html = html.replace(/(\s\w+\s*=\s*)(?:javascript|vbscript)\s*:/gi, '$1about:blank#blocked-');
+  return html;
+}
 
 function stripControlFields(input) {
   if (!input) return {};

--- a/functions/upload-asset.js
+++ b/functions/upload-asset.js
@@ -1,6 +1,62 @@
 // schedule: none (triggered by admin for asset upload/delete)
 import { adminDb, getUser } from '@run402/functions';
 
+const RUN402_API = 'https://api.run402.com';
+
+async function sha256Hex(bytes) {
+  const hash = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// Run402 went content-addressed post-v1.32. Three-step flow:
+//   1. POST /storage/v1/uploads        — init with sha256 + size + key
+//   2. PUT  <part.url>                 — upload each part
+//   3. POST /storage/v1/uploads/{id}/complete — finalize, returns cdn url
+// (#28)
+async function uploadBytesContentAddressed(bytes, { key, contentType, visibility = 'public', immutable = true }) {
+  const initRes = await fetch(`${RUN402_API}/storage/v1/uploads`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
+    },
+    body: JSON.stringify({
+      key,
+      size_bytes: bytes.byteLength,
+      content_type: contentType,
+      visibility,
+      immutable,
+      sha256: await sha256Hex(bytes),
+    }),
+  });
+  if (!initRes.ok) throw new Error(`init: ${await initRes.text()}`);
+  const init = await initRes.json();
+
+  const parts = [];
+  for (const part of init.parts || []) {
+    const slice = bytes.slice(part.byte_start, part.byte_end + 1);
+    const putRes = await fetch(part.url, { method: 'PUT', body: slice });
+    if (!putRes.ok) throw new Error(`part ${part.part_number}: ${putRes.status}`);
+    parts.push({ part_number: part.part_number, etag: putRes.headers.get('etag') || '' });
+  }
+
+  const completeRes = await fetch(`${RUN402_API}/storage/v1/uploads/${encodeURIComponent(init.upload_id)}/complete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
+    },
+    body: JSON.stringify(init.mode === 'multipart' ? { parts } : {}),
+  });
+  if (!completeRes.ok) throw new Error(`complete: ${await completeRes.text()}`);
+  const completed = await completeRes.json();
+  return (
+    completed.cdn_immutable_url || completed.immutable_url || completed.cdn_url || completed.url || `/storage/${key}`
+  );
+}
+
 // Read intrinsic dimensions from raw image bytes for the formats we expect
 // (PNG, JPEG, SVG). Returns null when the format is unknown — callers
 // downgrade to "no warning" rather than rejecting the upload.
@@ -92,7 +148,7 @@ export default async (req) => {
   try {
     const body = await req.json();
 
-    // Delete action
+    // Delete action — Run402 now exposes DELETE /storage/v1/blob/{key}. (#28)
     if (body.action === 'delete' && body.path) {
       if (!isSafeAssetPath(body.path)) {
         return new Response(
@@ -100,11 +156,12 @@ export default async (req) => {
           { status: 400 },
         );
       }
-      const delRes = await fetch(`https://api.run402.com/storage/v1/delete/assets/${body.path}`, {
+      const storageKey = `assets/${body.path}`;
+      const delRes = await fetch(`${RUN402_API}/storage/v1/blob/${storageKey}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}` },
       });
-      if (!delRes.ok) {
+      if (!delRes.ok && delRes.status !== 404) {
         const err = await delRes.text();
         return new Response(JSON.stringify({ error: 'Delete failed', detail: err }), { status: 500 });
       }
@@ -116,30 +173,30 @@ export default async (req) => {
     if (!file?.data || !file.name || !path) {
       return new Response(JSON.stringify({ error: 'Missing file or path' }), { status: 400 });
     }
+    if (!isSafeAssetPath(path)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid path', detail: 'Asset path must be a relative ASCII segment chain.' }),
+        { status: 400 },
+      );
+    }
 
     // Decode base64
     const bin = atob(file.data);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
 
-    // Upload to Run402 storage assets bucket
     const storagePath = `assets/${path}`;
-    const uploadRes = await fetch(`https://api.run402.com/storage/v1/upload/${storagePath}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
-        'Content-Type': file.type || 'application/octet-stream',
-      },
-      body: bytes,
-    });
-
-    if (!uploadRes.ok) {
-      const err = await uploadRes.text();
-      return new Response(JSON.stringify({ error: 'Upload failed', detail: err }), { status: 500 });
+    let url;
+    try {
+      url = await uploadBytesContentAddressed(bytes, {
+        key: storagePath,
+        contentType: file.type || 'application/octet-stream',
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: 'Upload failed', detail: String(err?.message || err) }), {
+        status: 500,
+      });
     }
-
-    const result = await uploadRes.json();
-    const url = result.url || `/storage/${storagePath}`;
 
     // brand_icon_url aspect-ratio hint. The caller passes `target` to opt in;
     // when the target slot is the square icon and the image is much wider

--- a/functions/upload-resource.js
+++ b/functions/upload-resource.js
@@ -7,6 +7,62 @@ import { adminDb, getUser } from '@run402/functions';
 const SAFE_FILE_NAME = /^[A-Za-z0-9._-]+$/;
 const MAX_BASE64_LEN = 50 * 1024 * 1024; // ~37 MB raw — Run402's per-blob upload limit.
 
+const RUN402_API = 'https://api.run402.com';
+
+async function sha256Hex(bytes) {
+  const hash = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// Run402 went content-addressed post-v1.32. Three-step flow:
+//   1. POST /storage/v1/uploads        — init with sha256 + size + key
+//   2. PUT  <part.url>                 — upload each part
+//   3. POST /storage/v1/uploads/{id}/complete — finalize, returns cdn url
+// (#28)
+async function uploadBytesContentAddressed(bytes, { key, contentType, visibility = 'public', immutable = true }) {
+  const initRes = await fetch(`${RUN402_API}/storage/v1/uploads`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
+    },
+    body: JSON.stringify({
+      key,
+      size_bytes: bytes.byteLength,
+      content_type: contentType,
+      visibility,
+      immutable,
+      sha256: await sha256Hex(bytes),
+    }),
+  });
+  if (!initRes.ok) throw new Error(`init: ${await initRes.text()}`);
+  const init = await initRes.json();
+
+  const parts = [];
+  for (const part of init.parts || []) {
+    const slice = bytes.slice(part.byte_start, part.byte_end + 1);
+    const putRes = await fetch(part.url, { method: 'PUT', body: slice });
+    if (!putRes.ok) throw new Error(`part ${part.part_number}: ${putRes.status}`);
+    parts.push({ part_number: part.part_number, etag: putRes.headers.get('etag') || '' });
+  }
+
+  const completeRes = await fetch(`${RUN402_API}/storage/v1/uploads/${encodeURIComponent(init.upload_id)}/complete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
+    },
+    body: JSON.stringify(init.mode === 'multipart' ? { parts } : {}),
+  });
+  if (!completeRes.ok) throw new Error(`complete: ${await completeRes.text()}`);
+  const completed = await completeRes.json();
+  return (
+    completed.cdn_immutable_url || completed.immutable_url || completed.cdn_url || completed.url || `/storage/${key}`
+  );
+}
+
 export default async (req) => {
   const user = await getUser(req);
   if (!user) {
@@ -45,24 +101,18 @@ export default async (req) => {
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
 
-    // Upload file to Run402 storage
-    const path = `resources/${Date.now()}_${file.name}`;
-    const uploadRes = await fetch(`https://api.run402.com/storage/v1/upload/${path}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.RUN402_SERVICE_KEY}`,
-        'Content-Type': file.type || 'application/octet-stream',
-      },
-      body: bytes,
-    });
-
-    if (!uploadRes.ok) {
-      const err = await uploadRes.text();
-      return new Response(JSON.stringify({ error: 'Upload failed', detail: err }), { status: 500 });
+    const key = `resources/${Date.now()}_${file.name}`;
+    let fileUrl;
+    try {
+      fileUrl = await uploadBytesContentAddressed(bytes, {
+        key,
+        contentType: file.type || 'application/octet-stream',
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: 'Upload failed', detail: String(err?.message || err) }), {
+        status: 500,
+      });
     }
-
-    const uploadResult = await uploadRes.json();
-    const fileUrl = uploadResult.url || `/storage/${path}`;
 
     // Insert resource row. uploaded_by is bound to the authenticated admin —
     // never honored from input. (#24/#25)

--- a/src/components/AdminEditor.astro
+++ b/src/components/AdminEditor.astro
@@ -10,6 +10,7 @@
   import { patch, get } from '../lib/api';
   import { COPIED_THEME_EDITOR_TYPES, openCopiedThemeEditor } from '../lib/admin/copied-theme-editor';
   import { clearCache, ready, refreshMemberRecord } from '../lib/config';
+  import { uploadFileContentAddressed } from '../lib/storage-upload';
   import { showToast as showKychonToast } from '../lib/toast-events';
 
   type AdminEditorControlsModule = typeof import('./kychon/AdminEditorControlsIsland');
@@ -20,12 +21,6 @@
     return d.innerHTML;
   }
 
-  function getAPI(): string {
-    return window.__KYCHON_API || 'https://api.run402.com';
-  }
-  function getAnonKey(): string {
-    return window.__KYCHON_ANON_KEY || '';
-  }
   function getToken(): string {
     const session = JSON.parse(localStorage.getItem('wl_session') || '{}');
     return session.access_token || '';
@@ -386,7 +381,6 @@
           try {
             const attr = htmlEl.dataset.editableImage!;
             const target = parseEditTarget(attr);
-            const storageName = `assets/${Date.now()}_${file.name}`;
 
             // Read dimensions in parallel with the upload — it's a hint, so we
             // don't block the upload on it. (Failures are silent.)
@@ -394,47 +388,33 @@
               ? readImageDimensions(file).catch(() => null)
               : Promise.resolve(null);
 
-            // Upload directly to Run402 storage (avoids function body size limit)
-            const res = await fetch(`${getAPI()}/storage/v1/upload/${storageName}`, {
-              method: 'POST',
-              headers: {
-                apikey: getAnonKey(),
-                Authorization: `Bearer ${getToken()}`,
-                'Content-Type': file.type || 'application/octet-stream',
-              },
-              body: file,
+            // Upload via Run402's content-addressed flow.
+            const { url } = await uploadFileContentAddressed(file, {
+              keyPrefix: 'assets',
+              authToken: getToken(),
             });
 
-            if (res.ok) {
-              const data = await res.json();
-              const url = data.url || `/storage/${storageName}`;
+            // Update the image element
+            const img = htmlEl.tagName === 'IMG' ? htmlEl as HTMLImageElement : htmlEl.querySelector('img');
+            if (img) img.src = url;
 
-              // Update the image element
-              const img = htmlEl.tagName === 'IMG' ? htmlEl as HTMLImageElement : htmlEl.querySelector('img');
-              if (img) img.src = url;
+            // Save URL to database
+            if (target) {
+              await saveField(htmlEl, target, url);
+            }
+            showToast('Image uploaded');
 
-              // Save URL to database
-              if (target) {
-                await saveField(htmlEl, target, url);
-              }
-              showToast('Image uploaded');
-
-              // brand_icon_url aspect-ratio hint (client-side mirror of the
-              // server-side check in functions/upload-asset.js). Surfaces only
-              // when uploading to the icon slot AND the image is much wider
-              // than tall.
-              const dims = await dimsPromise;
-              if (
-                isBrandIconTarget(target) &&
-                dims &&
-                dims.width > WORDMARK_ASPECT_THRESHOLD * dims.height
-              ) {
-                showWordmarkHint(htmlEl, url, dims);
-              }
-            } else {
-              const err = await res.text();
-              console.error('Upload failed:', err);
-              showToast('Upload failed', 'error');
+            // brand_icon_url aspect-ratio hint (client-side mirror of the
+            // server-side check in functions/upload-asset.js). Surfaces only
+            // when uploading to the icon slot AND the image is much wider
+            // than tall.
+            const dims = await dimsPromise;
+            if (
+              isBrandIconTarget(target) &&
+              dims &&
+              dims.width > WORDMARK_ASPECT_THRESHOLD * dims.height
+            ) {
+              showWordmarkHint(htmlEl, url, dims);
             }
           } catch (e) {
             console.error('Image upload error:', e);

--- a/src/lib/block-hydrators.ts
+++ b/src/lib/block-hydrators.ts
@@ -3,7 +3,7 @@
 // (Astro frontmatter runs in Node and shouldn't pull in localStorage/auth).
 
 import type { Section, BlockRenderContext } from './blocks.js';
-import { escAttr, escHtml } from './blocks.js';
+import { escAttr, escHtml, safeCssUrl } from './blocks.js';
 import { siteConfig } from './config.js';
 import { formatEventDateTime } from './event-display.js';
 import { sanitizeRichHtml } from './sanitize-html.js';
@@ -554,9 +554,10 @@ function renderEventCard(
   const location = opts.showLocation && evt.location ? esc(evt.location) : '';
   const href = evt.id ? `/event.html?id=${encodeURIComponent(evt.id)}` : '/events.html';
   const imageUrl = evt.image_url || evt.cover_image_url || '';
+  const safeImageUrl = imageUrl ? safeCssUrl(imageUrl) : '';
   const imageHtml =
-    opts.showImage && imageUrl
-      ? `<div class="event-card__image" style="background-image:url(${esc(imageUrl)})"></div>`
+    opts.showImage && safeImageUrl
+      ? `<div class="event-card__image" style="background-image:url('${safeImageUrl}')"></div>`
       : '';
   const dateBlock = dateLabel
     ? `<div class="event-card__date"><span class="event-card__date-day">${esc(dateLabel)}</span>${timeLabel ? `<span class="event-card__date-time">${esc(timeLabel)}</span>` : ''}</div>`

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -212,6 +212,22 @@ export function safeCssValue(value: any, maxLength = 180): string {
   return SAFE_CSS_VALUE_RE.test(s) ? s : '';
 }
 
+// Safe interpolation for `background-image:url(...)` and similar CSS url()
+// sinks. `escAttr` is HTML-quote-safe but does not escape `(`, `)`, `;`, or
+// `'`, so an attacker-controlled URL like `x);background:red url(y` survives
+// it and parses as two CSS declarations. (#29)
+//
+// We accept http(s) URLs and same-origin relative paths only, reject control
+// characters, then percent-encode the CSS-dangerous characters so the value
+// is safe inside single-quoted `url('…')`.
+export function safeCssUrl(value: any, maxLength = 2048): string {
+  const s = String(value ?? '').trim();
+  if (!s || s.length > maxLength) return '';
+  if (/[\r\n\t\x00-\x1f]/.test(s)) return '';
+  if (!/^(https?:\/\/[^\s]+|\/[^\s]*|\.[./][^\s]*)$/i.test(s)) return '';
+  return s.replace(/[()'"\\;*<>]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`);
+}
+
 function cssVar(name: string, value: any): string {
   const safe = safeCssValue(value);
   return safe ? `${name}:${safe};` : '';
@@ -509,7 +525,8 @@ function renderBackgroundHero(section: Section, ctx: BlockRenderContext): string
   const sortable = sid != null ? ` data-sortable-id="sections.${sid}" data-sortable-field="position"` : '';
   const cfgAttr = sid != null && ctx.admin ? ` data-editable-config="${jsonAttr(cfg)}"` : '';
   const imgAttr = sid != null && ctx.admin ? ` data-editable-image="sections.${sid}.config.bg_image"` : '';
-  const styleAttr = cfg.bg_image ? ` style="background-image:url(${escAttr(cfg.bg_image)})"` : '';
+  const safeBgImage = cfg.bg_image ? safeCssUrl(cfg.bg_image) : '';
+  const styleAttr = safeBgImage ? ` style="background-image:url('${safeBgImage}')"` : '';
   const adminCtrls = sid != null && ctx.admin
     ? `<div class="admin-section-actions">${adminEditButton(section, ctx)}<button class="admin-section-btn danger" data-section-remove="${sid}" title="Remove section">&times;</button></div>`
     : '';
@@ -1424,11 +1441,13 @@ const PAGE_BANNER: BlockType = {
     const cfg = section.config || {};
     const height = cfg.height || 'medium';
     const heightCls = `block-page-banner--height-${escAttr(height)}`;
-    const overlay = cfg.overlay_color
-      ? `<div class="block-page-banner__overlay" style="background-color:${escAttr(cfg.overlay_color)}"></div>`
+    const safeOverlay = cfg.overlay_color ? safeCssValue(cfg.overlay_color) : '';
+    const overlay = safeOverlay
+      ? `<div class="block-page-banner__overlay" style="background-color:${safeOverlay}"></div>`
       : '';
-    const bg = cfg.image_url
-      ? ` style="background-image:url(${escAttr(cfg.image_url)})"`
+    const safeImageUrl = cfg.image_url ? safeCssUrl(cfg.image_url) : '';
+    const bg = safeImageUrl
+      ? ` style="background-image:url('${safeImageUrl}')"`
       : '';
     const safeCaption = sanitizeCaptionHtml(String(cfg.caption_html || ''));
     const captionHtml = safeCaption
@@ -1540,11 +1559,13 @@ const PROMO_CARDS: BlockType = {
         const href = item.cta_href || '#';
         const titlePos = item.title_position === 'bottom' ? 'bottom' : 'top';
         const ariaLabel = `${item.title || ''}${item.cta_text ? `, ${item.cta_text}` : ''}`.trim();
-        const overlay = item.overlay_color
-          ? `<span class="promo-card__overlay" style="background-color:${escAttr(item.overlay_color)}"></span>`
+        const safeOverlay = item.overlay_color ? safeCssValue(item.overlay_color) : '';
+        const overlay = safeOverlay
+          ? `<span class="promo-card__overlay" style="background-color:${safeOverlay}"></span>`
           : '';
-        const imgStyle = item.image_url
-          ? ` style="background-image:url(${escAttr(item.image_url)})"`
+        const safeItemImage = item.image_url ? safeCssUrl(item.image_url) : '';
+        const imgStyle = safeItemImage
+          ? ` style="background-image:url('${safeItemImage}')"`
           : '';
         const imgEdit = ctx.admin && section.id != null
           ? ` data-editable-image="sections.${section.id}.config.items.${i}.image_url"`

--- a/src/lib/blocks/events-calendar.ts
+++ b/src/lib/blocks/events-calendar.ts
@@ -6,7 +6,7 @@
 // configured view.
 
 import type { BlockRenderContext, Section } from '../blocks.js';
-import { escAttr, escHtml } from '../blocks.js';
+import { escAttr, escHtml, safeCssUrl } from '../blocks.js';
 import { get, patch } from '../api.js';
 import {
   cancelPendingPrefetches,
@@ -384,8 +384,9 @@ function renderEventChip(
   const lock = evt.is_members_only ? `<span class="block-events-calendar__lock" aria-label="${escAttr(t('Members only', locale))}">🔒</span>` : '';
   const cap = capacityBadge(evt, state.rsvps, locale);
   const avatars = density === 'rich' ? rsvpAvatarStack(evt.id, state.rsvps) : '';
-  const thumb = density === 'rich' && evt.image_url
-    ? `<span class="block-events-calendar__chip-thumb" style="background-image:url(${escAttr(evt.image_url)})" aria-hidden="true"></span>`
+  const safeThumbUrl = density === 'rich' && evt.image_url ? safeCssUrl(evt.image_url) : '';
+  const thumb = safeThumbUrl
+    ? `<span class="block-events-calendar__chip-thumb" style="background-image:url('${safeThumbUrl}')" aria-hidden="true"></span>`
     : '';
   const titleHtml = `<span class="block-events-calendar__chip-title">${escHtml(evt.title || '')}</span>`;
   const timeHtml = density === 'glance' ? '' : `<span class="block-events-calendar__chip-time">${escHtml(time)}</span>`;

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -113,6 +113,9 @@ export async function executeCapabilityMutation(
   if (name === 'translations.translateContent') return translateContent(input, ctx);
   if (name === 'newsletters.drafts.generate') return generateNewsletterDraft(input, ctx);
   if (name.startsWith('jobs.')) return runJob(name, input, ctx);
+  if (name === 'rsvps.setStatus') return setRsvpStatus(input, ctx);
+  if (name === 'rsvps.cancel') return cancelRsvp(input, ctx);
+  if (name === 'members.changeRole') return changeMemberRole(input, ctx);
 
   return genericMutation(name, input, ctx);
 }
@@ -147,9 +150,12 @@ async function genericMutation(operation: string, input: JsonObject, ctx: Capabi
 }
 
 async function publishAnnouncement(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
+  // Body is sanitized on write so every downstream reader (newsletter
+  // generator, translation cache, CSV/RSS export) inherits the safety
+  // guarantee the read-side hydrator already provides. (#29)
   const announcement = await ctx.db.insert('announcements', {
     title: input.title || 'Untitled',
-    body: input.body || '',
+    body: sanitizeRichHtmlServer(input.body || ''),
     is_pinned: input.pin === true || input.is_pinned === true,
     author_id: memberId(ctx),
   });
@@ -291,6 +297,175 @@ async function uploadAsset(input: JsonObject, ctx: CapabilityMutationContext): P
   return actionResult(upload || { status: 'uploaded', path: input.path || null }, [object], null);
 }
 
+const VALID_MEMBER_ROLES: ReadonlySet<string> = new Set(['member', 'moderator', 'admin']);
+
+async function setRsvpStatus(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
+  // member_id is bound to the actor (admins act-as via dedicated admin paths,
+  // not this capability) and an `id` from input must belong to that member —
+  // otherwise an active member could update arbitrary RSVP rows. (#24)
+  const member = memberId(ctx);
+  const id = input.id;
+  const eventId = input.eventId ?? input.event_id;
+
+  if (id != null) {
+    const target = (await ctx.db.select('event_rsvps')).find((row) => String(row.id) === String(id));
+    if (!target) {
+      throw new CapabilityMutationError('notFound.object', 'RSVP not found.', {
+        object: { type: 'event.rsvp', id: String(id) },
+      });
+    }
+    if (String(target.member_id) !== String(member) && !isAdminLike(ctx) && !isModeratorLike(ctx)) {
+      throw new CapabilityMutationError('permission.denied', 'rsvps.setStatus can only update the active member RSVP.', {
+        object: { type: 'event.rsvp', id: String(id) },
+      });
+    }
+    const row =
+      (await ctx.db.update('event_rsvps', String(id), {
+        status: input.status || 'going',
+        member_id: target.member_id,
+      })) || target;
+    const object = changedObject('event.rsvp', String(row.id ?? id));
+    return actionResult(
+      row,
+      [object],
+      verificationQuery(getOperation('rsvps.listForEvent')!.name, { eventId: row.event_id ?? eventId }, object),
+    );
+  }
+
+  const event = requiredAny(eventId, 'rsvps.setStatus requires eventId.');
+  // Pre-validate the event so a missing FK surfaces as `notFound.object`,
+  // not a generic insert failure when the DB-side FK rejects the row. (#29)
+  const eventRow = (await ctx.db.select('events')).find((row) => String(row.id) === String(event));
+  if (!eventRow) {
+    throw new CapabilityMutationError('notFound.object', 'Event not found.', {
+      object: { type: 'event', id: String(event) },
+    });
+  }
+  const existing = (await ctx.db.select('event_rsvps')).find(
+    (row) => String(row.event_id) === String(event) && String(row.member_id) === String(member),
+  );
+  const row = existing
+    ? (await ctx.db.update('event_rsvps', String(existing.id), {
+        status: input.status || 'going',
+        member_id: member,
+      })) || existing
+    : await ctx.db.insert('event_rsvps', {
+        event_id: event,
+        member_id: member,
+        status: input.status || 'going',
+      });
+  const object = changedObject('event.rsvp', String(row.id));
+  return actionResult(
+    row,
+    [object],
+    verificationQuery(getOperation('rsvps.listForEvent')!.name, { eventId: event }, object),
+  );
+}
+
+async function cancelRsvp(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
+  const member = memberId(ctx);
+  const id = input.id;
+  const eventId = input.eventId ?? input.event_id;
+  // When the caller addresses by eventId, validate the event before scanning
+  // rsvps — otherwise a typo collapses to a silent `cancelled: false`. (#29)
+  if (id == null && eventId != null) {
+    const eventRow = (await ctx.db.select('events')).find((row) => String(row.id) === String(eventId));
+    if (!eventRow) {
+      throw new CapabilityMutationError('notFound.object', 'Event not found.', {
+        object: { type: 'event', id: String(eventId) },
+      });
+    }
+  }
+  const existing =
+    id != null
+      ? (await ctx.db.select('event_rsvps')).find((row) => String(row.id) === String(id))
+      : (await ctx.db.select('event_rsvps')).find(
+          (row) => String(row.event_id) === String(eventId) && String(row.member_id) === String(member),
+        );
+  if (!existing) return actionResult({ cancelled: false }, [], null);
+  if (String(existing.member_id) !== String(member) && !isAdminLike(ctx) && !isModeratorLike(ctx)) {
+    throw new CapabilityMutationError('permission.denied', 'rsvps.cancel can only cancel the active member RSVP.', {
+      object: { type: 'event.rsvp', id: String(existing.id) },
+    });
+  }
+  const row = (await ctx.db.update('event_rsvps', String(existing.id), { status: 'cancelled' })) || existing;
+  const object = changedObject('event.rsvp', String(row.id));
+  return actionResult(
+    row,
+    [object],
+    verificationQuery(getOperation('rsvps.listForEvent')!.name, { eventId: row.event_id ?? eventId }, object),
+  );
+}
+
+async function changeMemberRole(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
+  // Reject anything that isn't a known role. The old fall-through path
+  // (`input.role || 'member'`) silently demoted on typos and let `'admin'`,
+  // `'moderator'`, or arbitrary strings reach the DB unfiltered. (#29)
+  const role = typeof input.role === 'string' ? input.role.toLowerCase() : '';
+  if (!VALID_MEMBER_ROLES.has(role)) {
+    throw new CapabilityMutationError('validation.failed', 'members.changeRole requires role in member|moderator|admin.', {
+      role: String(input.role ?? ''),
+    });
+  }
+
+  const targetId = requiredId(input, 'members.changeRole');
+  const members = await ctx.db.select('members');
+  const target = members.find((row) => String(row.id) === String(targetId));
+  if (!target) {
+    throw new CapabilityMutationError('notFound.object', 'Member not found.', {
+      object: { type: 'member', id: String(targetId) },
+    });
+  }
+
+  // Last-admin guard: refuse to demote the actor's own admin role if doing
+  // so leaves zero remaining admins. Otherwise the portal locks itself out
+  // of admin features until someone goes around the API. (#29)
+  const actorMemberId = ctx.actor.member?.id ?? null;
+  if (
+    role !== 'admin' &&
+    actorMemberId != null &&
+    String(actorMemberId) === String(targetId) &&
+    String(target.role).toLowerCase() === 'admin'
+  ) {
+    const otherAdmins = members.filter(
+      (row) => String(row.id) !== String(targetId) && String(row.role).toLowerCase() === 'admin' && String(row.status).toLowerCase() === 'active',
+    );
+    if (otherAdmins.length === 0) {
+      throw new CapabilityMutationError('conflict.state', 'Cannot demote the last active admin.', {
+        object: { type: 'member', id: String(targetId) },
+      });
+    }
+  }
+
+  const row = (await ctx.db.update('members', String(targetId), { role })) || { ...target, role };
+  const object = changedObject('member', String(row.id ?? targetId));
+  return actionResult(row, [object], verificationQuery(getOperation('members.get')!.name, { id: row.id ?? targetId }, object));
+}
+
+function isAdminLike(ctx: CapabilityMutationContext): boolean {
+  return ctx.actor.state === 'admin' || ctx.actor.state === 'project_admin';
+}
+
+function isModeratorLike(ctx: CapabilityMutationContext): boolean {
+  return ctx.actor.state === 'moderator' || isAdminLike(ctx);
+}
+
+// Server-side rich-HTML sanitizer mirroring the read-side allowlist in
+// `src/lib/sanitize-html.ts`. We strip the obvious attack vectors with regex
+// as belt-and-braces for the read-side sanitizer so any other consumer
+// (newsletter generator, translation cache, CSV/RSS export) inherits the
+// guarantee. (#29)
+export function sanitizeRichHtmlServer(input: unknown): string {
+  if (input == null) return '';
+  let html = String(input);
+  html = html.replace(/<(script|style|iframe|object|embed)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  html = html.replace(/<(script|style|iframe|object|embed|link|meta)\b[^>]*\/?>/gi, '');
+  html = html.replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  html = html.replace(/(\s\w+\s*=\s*["'])\s*(?:javascript|vbscript)\s*:/gi, '$1about:blank#blocked-');
+  html = html.replace(/(\s\w+\s*=\s*)(?:javascript|vbscript)\s*:/gi, '$1about:blank#blocked-');
+  return html;
+}
+
 async function translateText(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
   const result = (await ctx.ai?.translateText(input)) || { translatedText: input.text || '' };
   return actionResult(result, [changedObject('translation', String(result.id || 'text'))], null);
@@ -402,6 +577,11 @@ function rowForUpdate(operation: string, input: JsonObject, ctx: CapabilityMutat
   if (operation === 'moderation.markReviewed') return { action: 'reviewed', reviewed_by: memberId(ctx) };
   if (operation === 'insights.updateStatus') return { status: input.status || 'reviewed' };
   if (operation === 'insights.dismiss') return { status: 'dismissed' };
+  if (operation === 'announcements.update') {
+    const patch = stripControlFields(input);
+    if (patch.body != null) patch.body = sanitizeRichHtmlServer(patch.body);
+    return patch;
+  }
   return stripControlFields(input);
 }
 

--- a/src/lib/storage-upload.ts
+++ b/src/lib/storage-upload.ts
@@ -1,0 +1,125 @@
+// Browser-side wrapper around Run402's content-addressed storage upload flow.
+//
+// Run402 retired the legacy `POST /storage/v1/upload/{key}` route post-v1.32
+// in favor of a three-step content-addressed flow:
+//   1. `POST /storage/v1/uploads`       — init with sha256 + size + key
+//   2. `PUT  <part.url>`                — upload each part to its presigned URL
+//   3. `POST /storage/v1/uploads/{id}/complete` — finalize and receive cdn url
+//
+// Every call site that previously hit the single-shot endpoint must route
+// through here. (issue #28)
+
+declare global {
+  interface Window {
+    __KYCHON_API: string;
+    __KYCHON_ANON_KEY: string;
+  }
+}
+
+export interface UploadFileOpts {
+  /** Path prefix the file lands under, e.g. `resources`, `avatars/123`, `assets`. */
+  keyPrefix: string;
+  /** Optional filename override; defaults to `safeStorageName(file.name)`. */
+  keyName?: string;
+  /** Storage visibility — public by default to match prior behavior. */
+  visibility?: 'public' | 'private';
+  /** Immutable blobs are CDN-cached aggressively; safe for upload-and-forget assets. */
+  immutable?: boolean;
+  /**
+   * Bearer token. Defaults to the anon key. Pass the signed-in user's
+   * `access_token` for user-scoped uploads (avatars, etc.).
+   */
+  authToken?: string;
+}
+
+export interface UploadFileResult {
+  key: string;
+  url: string;
+}
+
+function getApiBase(): string {
+  return window.__KYCHON_API || 'https://api.run402.com';
+}
+
+function getAnonKey(): string {
+  return window.__KYCHON_ANON_KEY || '';
+}
+
+export function safeStorageName(name: string): string {
+  const base = String(name).split(/[\\/]/).pop() || 'file';
+  return base.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'file';
+}
+
+export async function sha256Hex(file: Blob): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  const hash = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function uploadFileContentAddressed(
+  file: File | Blob,
+  opts: UploadFileOpts,
+): Promise<UploadFileResult> {
+  const api = getApiBase();
+  const anon = getAnonKey();
+  const bearer = opts.authToken || anon;
+  const rawName = file instanceof File ? file.name : 'file';
+  const filename = safeStorageName(opts.keyName || rawName);
+  const prefix = opts.keyPrefix.replace(/^\/+|\/+$/g, '');
+  const key = `${prefix}/${Date.now()}_${filename}`;
+  const contentType = file.type || 'application/octet-stream';
+
+  const initRes = await fetch(`${api}/storage/v1/uploads`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: anon,
+      Authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify({
+      key,
+      size_bytes: file.size,
+      content_type: contentType,
+      visibility: opts.visibility || 'public',
+      immutable: opts.immutable !== false,
+      sha256: await sha256Hex(file),
+    }),
+  });
+  if (!initRes.ok) throw new Error(`Upload init failed: ${await initRes.text()}`);
+  const init = await initRes.json();
+
+  const parts: Array<{ part_number: number; etag: string }> = [];
+  for (const part of init.parts || []) {
+    const putRes = await fetch(part.url, {
+      method: 'PUT',
+      body: file.slice(part.byte_start, part.byte_end + 1),
+    });
+    if (!putRes.ok) throw new Error(`Part ${part.part_number} upload failed`);
+    parts.push({ part_number: part.part_number, etag: putRes.headers.get('etag') || '' });
+  }
+
+  const completeRes = await fetch(
+    `${api}/storage/v1/uploads/${encodeURIComponent(init.upload_id)}/complete`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: anon,
+        Authorization: `Bearer ${bearer}`,
+      },
+      body: JSON.stringify(init.mode === 'multipart' ? { parts } : {}),
+    },
+  );
+  if (!completeRes.ok) throw new Error(`Upload complete failed: ${await completeRes.text()}`);
+
+  const completed = await completeRes.json();
+  const url =
+    completed.cdn_immutable_url ||
+    completed.immutable_url ||
+    completed.cdn_url ||
+    completed.url ||
+    `/storage/${key}`;
+  return { key, url };
+}

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -31,6 +31,7 @@ import Portal from '../layouts/Portal.astro';
   import { getSession, isAuthenticated } from '../lib/auth';
   import { showAuthGate } from '../lib/auth-gate';
   import { ready } from '../lib/config';
+  import { uploadFileContentAddressed } from '../lib/storage-upload';
 
   function esc(s: string): string {
     const d = document.createElement('div');
@@ -136,24 +137,18 @@ import Portal from '../layouts/Portal.astro';
     document.getElementById('profile-avatar-upload')?.addEventListener('change', async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
-      const API = window.__KYCHON_API || 'https://api.run402.com';
-      const ANON_KEY = window.__KYCHON_ANON_KEY || '';
-      const path = `avatars/${member.id}/${file.name}`;
-      const formData = new FormData();
-      formData.append('file', file);
-
-      const res = await fetch(`${API}/storage/v1/upload/${path}`, {
-        method: 'POST',
-        headers: { apikey: ANON_KEY, Authorization: `Bearer ${session.access_token}` },
-        body: formData,
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const avatarUrl = data.url || `/storage/${path}`;
+      try {
+        const { url: avatarUrl } = await uploadFileContentAddressed(file, {
+          keyPrefix: `avatars/${member.id}`,
+          authToken: session.access_token,
+        });
         await patch(`members?id=eq.${member.id}`, { avatar_url: avatarUrl });
         (document.getElementById('profile-avatar-img') as HTMLImageElement).src = avatarUrl;
         member.avatar_url = avatarUrl;
         localStorage.setItem('wl_session', JSON.stringify(session));
+      } catch (err) {
+        console.error('Avatar upload failed:', err);
+        alert(err instanceof Error ? err.message : 'Avatar upload failed');
       }
     });
   }

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -49,6 +49,7 @@ import Portal from '../layouts/Portal.astro';
   import { isAdmin, isAuthenticated } from '../lib/auth';
   import { openAuthModal } from '../lib/auth-modal-events';
   import { refreshMemberRecord, translateItems } from '../lib/config';
+  import { uploadFileContentAddressed } from '../lib/storage-upload';
 
   let allResources: any[] = [];
 
@@ -63,64 +64,9 @@ import Portal from '../layouts/Portal.astro';
     return icons[type] || '\u{1F4C1}';
   }
 
-  function safeStorageName(name: string): string {
-    const base = name.split(/[\\/]/).pop() || 'resource';
-    return base.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'resource';
-  }
-
-  async function sha256Hex(file: File): Promise<string> {
-    const hash = await crypto.subtle.digest('SHA-256', await file.arrayBuffer());
-    return Array.from(new Uint8Array(hash))
-      .map((byte) => byte.toString(16).padStart(2, '0'))
-      .join('');
-  }
-
   async function uploadResourceFile(file: File): Promise<string> {
-    const API = window.__KYCHON_API || 'https://api.run402.com';
-    const ANON_KEY = window.__KYCHON_ANON_KEY || '';
-    const key = `resources/${Date.now()}_${safeStorageName(file.name)}`;
-    const initRes = await fetch(`${API}/storage/v1/uploads`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        apikey: ANON_KEY,
-        Authorization: `Bearer ${ANON_KEY}`,
-      },
-      body: JSON.stringify({
-        key,
-        size_bytes: file.size,
-        content_type: file.type || 'application/octet-stream',
-        visibility: 'public',
-        immutable: true,
-        sha256: await sha256Hex(file),
-      }),
-    });
-    if (!initRes.ok) throw new Error(await initRes.text());
-
-    const init = await initRes.json();
-    const parts: Array<{ part_number: number; etag: string }> = [];
-    for (const part of init.parts || []) {
-      const putRes = await fetch(part.url, {
-        method: 'PUT',
-        body: file.slice(part.byte_start, part.byte_end + 1),
-      });
-      if (!putRes.ok) throw new Error(`Part ${part.part_number} upload failed`);
-      parts.push({ part_number: part.part_number, etag: putRes.headers.get('etag') || '' });
-    }
-
-    const completeRes = await fetch(`${API}/storage/v1/uploads/${encodeURIComponent(init.upload_id)}/complete`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        apikey: ANON_KEY,
-        Authorization: `Bearer ${ANON_KEY}`,
-      },
-      body: JSON.stringify(init.mode === 'multipart' ? { parts } : {}),
-    });
-    if (!completeRes.ok) throw new Error(await completeRes.text());
-
-    const completed = await completeRes.json();
-    return completed.cdn_immutable_url || completed.immutable_url || completed.cdn_url || completed.url || `/storage/${key}`;
+    const { url } = await uploadFileContentAddressed(file, { keyPrefix: 'resources' });
+    return url;
   }
 
   function applyFilter() {

--- a/tests/unit/blocks-hero.test.ts
+++ b/tests/unit/blocks-hero.test.ts
@@ -37,7 +37,7 @@ describe('hero renderer — background mode (existing behavior)', () => {
     );
     expect(html).toContain('class="section section-hero"');
     expect(html).not.toContain('hero-foreground');
-    expect(html).toContain('background-image:url(/img/hero.jpg)');
+    expect(html).toContain("background-image:url('/img/hero.jpg')");
     expect(html).toContain('<h1>Welcome</h1>');
     expect(html).toContain('<p>Subhead</p>');
     expect(html).toContain('href="/join"');

--- a/tests/unit/blocks-page-banner.test.ts
+++ b/tests/unit/blocks-page-banner.test.ts
@@ -26,7 +26,7 @@ describe('page_banner block-type', () => {
 
   it('emits background-image on the section', () => {
     const html = renderBlock(bannerSection({ image_url: '/banner.jpg', image_alt: 'Banner' }), ctx);
-    expect(html).toContain('background-image:url(/banner.jpg)');
+    expect(html).toContain("background-image:url('/banner.jpg')");
     expect(html).toContain('aria-label="Banner"');
   });
 

--- a/tests/unit/security-bug-25-uploads.test.ts
+++ b/tests/unit/security-bug-25-uploads.test.ts
@@ -180,14 +180,14 @@ describe('bug #25 — upload-asset.js path traversal in delete', () => {
     expect(mockState.fetchCalls.filter((c) => c.method === 'DELETE')).toHaveLength(0);
   });
 
-  it('accepts a clean asset path', async () => {
+  it('accepts a clean asset path and hits the content-addressed delete endpoint (#28)', async () => {
     mockState.user = { id: 'admin-user' };
     mockState.members = [{ id: 7, user_id: 'admin-user', email: 'admin@example.com', role: 'admin', status: 'active' }];
     const handler = (await import('../../functions/upload-asset.js')).default;
     const res = await handler(jsonReq('upload-asset', { action: 'delete', path: 'logo.png' }));
     expect(res.status).toBe(200);
     const deleteCall = mockState.fetchCalls.find((c) => c.method === 'DELETE');
-    expect(deleteCall?.url).toBe('https://api.run402.com/storage/v1/delete/assets/logo.png');
+    expect(deleteCall?.url).toBe('https://api.run402.com/storage/v1/blob/assets/logo.png');
   });
 });
 

--- a/tests/unit/security-bug-28-storage-upload.test.ts
+++ b/tests/unit/security-bug-28-storage-upload.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { uploadFileContentAddressed } from '../../src/lib/storage-upload.ts';
+
+// Each test starts with a fresh fetch mock so the call log only sees the
+// requests for that scenario.
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeFile(name: string, contents: string, type = 'text/plain'): File {
+  return new File([contents], name, { type });
+}
+
+function jsonResponse(body: unknown, status = 200, extraHeaders?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...(extraHeaders || {}) },
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  // safeStorageName uses Date.now() in the key — pin it so assertions are stable.
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+  // The library reads window.__KYCHON_API + window.__KYCHON_ANON_KEY.
+  vi.stubGlobal('window', {
+    __KYCHON_API: 'https://api.run402.example',
+    __KYCHON_ANON_KEY: 'anon-key',
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('bug #28 — uploadFileContentAddressed uses the post-v1.32 endpoint shape', () => {
+  it('calls /storage/v1/uploads (init) then PUTs each part then /complete — never the retired /upload/{key}', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        // init
+        jsonResponse({
+          upload_id: 'upload-123',
+          mode: 'multipart',
+          parts: [{ part_number: 1, url: 'https://s3.example/part1', byte_start: 0, byte_end: 4 }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        // PUT part1
+        new Response(null, { status: 200, headers: { etag: '"abc123"' } }),
+      )
+      .mockResolvedValueOnce(
+        // complete
+        jsonResponse({ cdn_immutable_url: 'https://cdn.example/blob/abc' }),
+      );
+
+    const file = makeFile('hello.txt', 'hello');
+    const result = await uploadFileContentAddressed(file, { keyPrefix: 'resources' });
+
+    expect(result.url).toBe('https://cdn.example/blob/abc');
+
+    const urls = fetchMock.mock.calls.map((args) => String(args[0]));
+    expect(urls[0]).toBe('https://api.run402.example/storage/v1/uploads');
+    expect(urls[1]).toBe('https://s3.example/part1');
+    expect(urls[2]).toBe('https://api.run402.example/storage/v1/uploads/upload-123/complete');
+    // Make sure we never hit the retired single-shot endpoint.
+    expect(urls.some((u) => u.includes('/storage/v1/upload/'))).toBe(false);
+  });
+
+  it('includes sha256 + size_bytes + content_type in the init body', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ upload_id: 'u', mode: 'single', parts: [] }))
+      .mockResolvedValueOnce(jsonResponse({ cdn_immutable_url: '/storage/x' }));
+
+    const file = makeFile('avatar.png', 'pngbytes', 'image/png');
+    await uploadFileContentAddressed(file, { keyPrefix: 'avatars/42', authToken: 'user-jwt' });
+
+    const initCall = fetchMock.mock.calls[0];
+    expect(initCall[0]).toBe('https://api.run402.example/storage/v1/uploads');
+    const initBody = JSON.parse(String(initCall[1]?.body || '{}'));
+    expect(initBody.content_type).toBe('image/png');
+    expect(initBody.size_bytes).toBe('pngbytes'.length);
+    expect(typeof initBody.sha256).toBe('string');
+    expect(initBody.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(String(initBody.key)).toMatch(/^avatars\/42\/\d+_avatar\.png$/);
+    // authToken propagates into the Authorization header.
+    expect(initCall[1]?.headers?.Authorization).toBe('Bearer user-jwt');
+  });
+
+  it('surfaces an error when the init step fails', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('sha256 is required (every blob is content-addressed post-v1.32)', {
+        status: 400,
+      }),
+    );
+
+    const file = makeFile('x.txt', 'x');
+    await expect(uploadFileContentAddressed(file, { keyPrefix: 'resources' })).rejects.toThrow(/content-addressed/);
+  });
+});

--- a/tests/unit/security-bug-29-hardening.test.ts
+++ b/tests/unit/security-bug-29-hardening.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import { safeCssUrl } from '../../src/lib/blocks.ts';
+import {
+  type CapabilityActor,
+  type CapabilityMutationDb,
+  CapabilityMutationError,
+  executeCapabilityMutation,
+  type JsonObject,
+  sanitizeRichHtmlServer,
+} from '../../src/lib/capability-api/index.ts';
+
+class MemoryMutationDb implements CapabilityMutationDb {
+  counters: Record<string, number> = {};
+
+  constructor(public tables: Record<string, JsonObject[]>) {}
+
+  async select(table: string) {
+    return this.tables[table] || [];
+  }
+
+  async insert(table: string, row: JsonObject) {
+    const nextId = (this.counters[table] || this.maxId(table)) + 1;
+    this.counters[table] = nextId;
+    const created = { id: nextId, ...row };
+    this.tables[table] = [...(this.tables[table] || []), created];
+    return created;
+  }
+
+  async update(table: string, id: string | number, patch: JsonObject) {
+    const rows = this.tables[table] || [];
+    const index = rows.findIndex((row) => String(row.id) === String(id));
+    if (index < 0) return null;
+    rows[index] = { ...rows[index], ...patch };
+    return rows[index];
+  }
+
+  async delete(table: string, id: string | number) {
+    const rows = this.tables[table] || [];
+    const index = rows.findIndex((row) => String(row.id) === String(id));
+    if (index < 0) return null;
+    const [deleted] = rows.splice(index, 1);
+    return deleted || null;
+  }
+
+  private maxId(table: string) {
+    return Math.max(0, ...(this.tables[table] || []).map((row) => Number(row.id || 0)));
+  }
+}
+
+const adminActor: CapabilityActor = {
+  state: 'admin',
+  authenticated: true,
+  user: { id: 'admin-user', email: 'admin@example.com' },
+  member: {
+    id: '1',
+    ref: { type: 'member', id: '1' },
+    userId: 'admin-user',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    role: 'admin',
+    status: 'active',
+    lookup: 'user_id',
+  },
+  authority: { projectAdmin: false, activeMemberAdmin: true },
+};
+
+const adminMember = adminActor.member;
+if (!adminMember) throw new Error('admin actor must have a member context');
+
+const memberActor: CapabilityActor = {
+  ...adminActor,
+  state: 'active_member',
+  user: { id: 'member-user', email: 'member@example.com' },
+  member: {
+    ...adminMember,
+    id: '2',
+    userId: 'member-user',
+    email: 'member@example.com',
+    role: 'member',
+  },
+  authority: { projectAdmin: false, activeMemberAdmin: false },
+};
+
+describe('bug #29 item 1 — rsvps.setStatus validates eventId before insert', () => {
+  it('throws notFound.object when eventId points at a missing event', async () => {
+    const db = new MemoryMutationDb({
+      events: [{ id: 1, title: 'Real Event' }],
+      event_rsvps: [],
+      activity_log: [],
+    });
+
+    await expect(
+      executeCapabilityMutation('rsvps.setStatus', { eventId: 6104, status: 'going' }, { actor: memberActor, db }),
+    ).rejects.toMatchObject({ code: 'notFound.object' });
+  });
+
+  it('still inserts an rsvp when the eventId is real', async () => {
+    const db = new MemoryMutationDb({
+      events: [{ id: 1, title: 'Real Event' }],
+      event_rsvps: [],
+      activity_log: [],
+    });
+
+    await executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'going' }, { actor: memberActor, db });
+    expect(db.tables.event_rsvps).toHaveLength(1);
+    expect(db.tables.event_rsvps[0]).toMatchObject({ event_id: 1, status: 'going' });
+  });
+
+  it('rsvps.cancel throws notFound when eventId is unknown and id is omitted', async () => {
+    const db = new MemoryMutationDb({
+      events: [{ id: 1, title: 'Real Event' }],
+      event_rsvps: [],
+      activity_log: [],
+    });
+
+    await expect(
+      executeCapabilityMutation('rsvps.cancel', { eventId: 6104 }, { actor: memberActor, db }),
+    ).rejects.toMatchObject({ code: 'notFound.object' });
+  });
+});
+
+describe('bug #29 item 2 — members.changeRole role-enum + last-admin guard', () => {
+  it('rejects arbitrary role strings ("project_admin", "superadmin", typos)', async () => {
+    const db = new MemoryMutationDb({
+      members: [
+        { id: 1, role: 'admin', status: 'active', user_id: 'admin-user' },
+        { id: 2, role: 'member', status: 'active' },
+      ],
+      activity_log: [],
+    });
+
+    for (const role of ['project_admin', 'superadmin', 'adimn', 'ADMIN-EDIT']) {
+      await expect(
+        executeCapabilityMutation('members.changeRole', { id: 2, role }, { actor: adminActor, db }),
+      ).rejects.toMatchObject({ code: 'validation.failed' });
+    }
+
+    // The target row is unchanged.
+    expect(db.tables.members[1]?.role).toBe('member');
+  });
+
+  it('accepts the canonical member|moderator|admin enum', async () => {
+    const db = new MemoryMutationDb({
+      members: [
+        { id: 1, role: 'admin', status: 'active', user_id: 'admin-user' },
+        { id: 2, role: 'member', status: 'active' },
+      ],
+      activity_log: [],
+    });
+
+    await executeCapabilityMutation('members.changeRole', { id: 2, role: 'moderator' }, { actor: adminActor, db });
+    expect(db.tables.members[1]?.role).toBe('moderator');
+  });
+
+  it('refuses to demote the only active admin to member', async () => {
+    const db = new MemoryMutationDb({
+      members: [{ id: 1, role: 'admin', status: 'active', user_id: 'admin-user' }],
+      activity_log: [],
+    });
+
+    await expect(
+      executeCapabilityMutation('members.changeRole', { id: 1, role: 'member' }, { actor: adminActor, db }),
+    ).rejects.toMatchObject({ code: 'conflict.state' });
+
+    expect(db.tables.members[0]?.role).toBe('admin');
+  });
+
+  it('lets the admin demote themselves when another active admin remains', async () => {
+    const db = new MemoryMutationDb({
+      members: [
+        { id: 1, role: 'admin', status: 'active', user_id: 'admin-user' },
+        { id: 9, role: 'admin', status: 'active', user_id: 'backup-admin' },
+      ],
+      activity_log: [],
+    });
+
+    await executeCapabilityMutation('members.changeRole', { id: 1, role: 'member' }, { actor: adminActor, db });
+    expect(db.tables.members[0]?.role).toBe('member');
+  });
+});
+
+describe('bug #29 item 3 — safeCssUrl blocks CSS injection in url() context', () => {
+  it('strips ); break-outs in url() value', () => {
+    const evil = 'x);background:red url(y';
+    expect(safeCssUrl(evil)).toBe('');
+  });
+
+  it('blocks javascript: URLs entirely', () => {
+    expect(safeCssUrl('javascript:alert(1)')).toBe('');
+    expect(safeCssUrl('JAVASCRIPT:alert(1)')).toBe('');
+  });
+
+  it('passes a clean http(s) URL through, percent-encoding only CSS-dangerous chars', () => {
+    expect(safeCssUrl('https://cdn.example.com/img.png')).toBe('https://cdn.example.com/img.png');
+    expect(safeCssUrl("https://cdn.example.com/has'apos.png")).toBe('https://cdn.example.com/has%27apos.png');
+  });
+
+  it('allows site-relative paths', () => {
+    expect(safeCssUrl('/storage/avatars/me.png')).toBe('/storage/avatars/me.png');
+  });
+
+  it('rejects newlines and other control chars', () => {
+    expect(safeCssUrl('https://example.com/\nimg.png')).toBe('');
+  });
+});
+
+describe('bug #29 item 4 — sanitize announcement bodies on write', () => {
+  it('strips <script> on publish', async () => {
+    const db = new MemoryMutationDb({
+      announcements: [],
+      activity_log: [],
+    });
+
+    await executeCapabilityMutation(
+      'announcements.publish',
+      { title: 'News', body: '<p>hi</p><script>alert(1)</script>' },
+      { actor: adminActor, db },
+    );
+
+    const stored = String(db.tables.announcements[0]?.body || '');
+    expect(stored).not.toMatch(/<script/i);
+    expect(stored).toContain('<p>hi</p>');
+  });
+
+  it('strips on*= event handlers on publish', async () => {
+    const db = new MemoryMutationDb({ announcements: [], activity_log: [] });
+
+    await executeCapabilityMutation(
+      'announcements.publish',
+      { title: 'News', body: '<img src="x" onerror="alert(1)">' },
+      { actor: adminActor, db },
+    );
+
+    const stored = String(db.tables.announcements[0]?.body || '');
+    expect(stored.toLowerCase()).not.toMatch(/onerror/);
+  });
+
+  it('neutralizes javascript: hrefs on publish', async () => {
+    const db = new MemoryMutationDb({ announcements: [], activity_log: [] });
+
+    await executeCapabilityMutation(
+      'announcements.publish',
+      { title: 'News', body: '<a href="javascript:alert(1)">click</a>' },
+      { actor: adminActor, db },
+    );
+
+    const stored = String(db.tables.announcements[0]?.body || '').toLowerCase();
+    expect(stored).not.toContain('javascript:');
+  });
+
+  it('sanitizes body on announcements.update', async () => {
+    const db = new MemoryMutationDb({
+      announcements: [{ id: 1, title: 'News', body: '<p>safe</p>' }],
+      activity_log: [],
+    });
+
+    await executeCapabilityMutation(
+      'announcements.update',
+      { id: 1, body: '<p>updated</p><script>alert(1)</script>' },
+      { actor: adminActor, db },
+    );
+
+    const stored = String(db.tables.announcements[0]?.body || '');
+    expect(stored).not.toMatch(/<script/i);
+    expect(stored).toContain('<p>updated</p>');
+  });
+
+  it('sanitizeRichHtmlServer leaves safe Tiptap-style HTML intact', () => {
+    expect(sanitizeRichHtmlServer('<p>Hello <strong>world</strong> <a href="https://example.com">link</a></p>')).toBe(
+      '<p>Hello <strong>world</strong> <a href="https://example.com">link</a></p>',
+    );
+  });
+
+  // Even though we no longer throw, ensure the CapabilityMutationError import
+  // is exercised here to keep the bundle's behavior typed-checked.
+  it('CapabilityMutationError is the error class', () => {
+    expect(CapabilityMutationError.name).toBe('CapabilityMutationError');
+  });
+});


### PR DESCRIPTION
## Summary

- **#28 (High):** Run402 storage went content-addressed post-v1.32 — every avatar, admin image, and legacy `upload-resource`/`upload-asset` call returned 404 on the live demos. Routed every caller through a new shared `src/lib/storage-upload.ts` helper (mirrored from the working `resources.astro` flow), updated the two deployed functions, and switched the asset-delete branch to `DELETE /storage/v1/blob/{key}`.
- **#29 (Low/hardening):** four follow-ups — `rsvps.setStatus`/`rsvps.cancel` pre-validate `eventId`; `members.changeRole` gains a `member|moderator|admin` enum check + a last-active-admin guard against self-demotion; new `safeCssUrl()` blocks `background-image:url(...)` injection (event card + 4 other sinks); announcement bodies are now sanitized on write so newsletter/translation/export consumers can't reflect raw `<script>`.

Issues:
- https://github.com/kychee-com/kychon-private/issues/28
- https://github.com/kychee-com/kychon-private/issues/29

## Test plan

- [x] `npm run test` — 810/810 pass (added 21 new regression tests across `security-bug-28-storage-upload.test.ts` and `security-bug-29-hardening.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (70 pre-existing warnings, none introduced)
- [ ] Live: re-run the live QA path from issue #28 against eagles after deploy: avatar upload from profile, admin image drop in the rich-text editor, both legacy edge functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)