### PR TITLE
SSR-bake DB-backed page bodies on clean-route custom pages

### DIFF
--- a/src/components/kychon/CustomPageApp.tsx
+++ b/src/components/kychon/CustomPageApp.tsx
@@ -28,18 +28,31 @@ function PageSkeleton() {
   );
 }
 
-export default function CustomPageApp() {
-  const [page, setPage] = useState<Page | null>(null);
-  const [loading, setLoading] = useState(true);
+interface CustomPageAppProps {
+  /**
+   * Build-time page row baked by `[customPage].astro` (kychon#126). When
+   * present, the island server-renders the real title + content instead of
+   * the loading skeleton, so the served HTML carries the page body; the
+   * client then refreshes silently from the live DB (auth, translations,
+   * admin edit affordances) without flashing back to a skeleton.
+   */
+  initialPage?: Page | null;
+}
+
+export default function CustomPageApp({ initialPage = null }: CustomPageAppProps) {
+  const [page, setPage] = useState<Page | null>(initialPage);
+  const [loading, setLoading] = useState(!initialPage);
   const [error, setError] = useState('');
   const [notFound, setNotFound] = useState(false);
   const [admin, setAdmin] = useState(false);
 
   const loadPage = useCallback(async () => {
-    setLoading(true);
+    // Silent refresh when SSR already painted the page: keep the baked
+    // content on screen instead of flashing the skeleton.
+    setLoading(!initialPage);
     setError('');
     setNotFound(false);
-    setPage(null);
+    if (!initialPage) setPage(null);
     try {
       await ready;
       const slug = currentSlug();
@@ -68,7 +81,7 @@ export default function CustomPageApp() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [initialPage]);
 
   useEffect(() => {
     void loadPage();

--- a/src/lib/build-pages.ts
+++ b/src/lib/build-pages.ts
@@ -1,0 +1,133 @@
+/**
+ * Build-time pages loader. Fetches the published, public `pages` rows from
+ * the deployed gateway during `astro build` (NOT at runtime) so
+ * `[customPage].astro` can SSR the page body — title + rich-text content —
+ * into the document instead of the skeleton shell that previously only
+ * filled in post-hydration.
+ *
+ * Ported sites are the motivating case (kychon#126): their page bodies live
+ * exclusively in the `pages` table, so without this loader every ported
+ * custom page served a ~900-character raw-HTML shell and failed no-JS
+ * content parity.
+ *
+ * **Build-time only.** Reads the same env vars `scripts/_lib.ts:runDeploy`
+ * sets before invoking `astro build` (see build-events.ts for the full
+ * contract): `KYCHON_ANON_KEY`, `KYCHON_PROJECT_ID`, `KYCHON_PUBLIC_URL`.
+ * The anon key means the gateway's `visiblePage` filter applies — only
+ * `published` pages without `requires_auth` come back, so nothing
+ * member-gated can ever be baked into public HTML.
+ *
+ * When any var is missing (local `astro dev`, CI builds without env
+ * plumbing) the loader resolves to an empty cache and `[customPage].astro`
+ * falls back to the existing skeleton + client-fetch path.
+ */
+
+import { createKychonClient } from '@kychon/sdk';
+
+import type { Page } from '@/schemas/content';
+
+interface CapabilityListResult {
+  rows?: Page[];
+}
+
+let loaderPromise: Promise<Page[]> | null = null;
+let cache: Page[] | null = null;
+
+function readEnv(key: string): string | undefined {
+  const value = process.env[key];
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function fetchAllPages(): Promise<Page[]> {
+  const anonKey = readEnv('KYCHON_ANON_KEY');
+  const projectId = readEnv('KYCHON_PROJECT_ID');
+  const portalUrl = readEnv('KYCHON_PUBLIC_URL');
+  if (!anonKey || !projectId || !portalUrl) {
+    console.log(
+      `[build-pages] skipped — missing ${[
+        !anonKey && 'KYCHON_ANON_KEY',
+        !projectId && 'KYCHON_PROJECT_ID',
+        !portalUrl && 'KYCHON_PUBLIC_URL',
+      ]
+        .filter(Boolean)
+        .join(', ')}`,
+    );
+    return [];
+  }
+
+  const client = createKychonClient({
+    portalUrl,
+    apiKey: anonKey,
+    apiBaseUrl: 'https://api.run402.com',
+  });
+
+  try {
+    // The list mode returns every row passing the gateway's `visiblePage`
+    // filter — under the anon key that is exactly the bake-safe set
+    // (published, not requires_auth). Ports carry 100+ pages; the gateway
+    // does not paginate table queries.
+    const result = await client.request<CapabilityListResult>('pages.list', 'query', {});
+    const rows = Array.isArray(result?.rows) ? result.rows : [];
+    // Defense in depth: never bake a gated or unpublished row even if the
+    // gateway filter regresses — baked HTML is public forever.
+    const bakeSafe = rows.filter((row) => row.published !== false && row.requires_auth !== true);
+    console.log(`[build-pages] fetched ${bakeSafe.length} page(s) for ${projectId}`);
+    return bakeSafe;
+  } catch (error) {
+    // Don't fail the build on a transient gateway error — the runtime
+    // hydrate path still populates pages. Noisy log so a regression in
+    // build-time SSR is visible in deploy output.
+    console.warn(
+      `[build-pages] fetch failed for ${projectId} (${portalUrl}):`,
+      error instanceof Error ? error.message : error,
+    );
+    return [];
+  }
+}
+
+/**
+ * Trigger the build-time pages fetch. Call from `.astro` frontmatter (or
+ * `getStaticPaths`) before reading the cache. Idempotent — subsequent calls
+ * await the same promise.
+ */
+export async function ensureBuildPagesLoaded(): Promise<void> {
+  if (loaderPromise) {
+    await loaderPromise;
+    return;
+  }
+  loaderPromise = fetchAllPages();
+  cache = await loaderPromise;
+}
+
+/**
+ * Synchronous accessor for one baked page by slug. Returns `null` when the
+ * cache is unpopulated (loader skipped/failed) or the slug is unknown —
+ * callers fall back to the runtime hydrate path.
+ */
+export function getBuildPageBySlug(slug: string): Page | null {
+  if (!cache) return null;
+  return cache.find((page) => page.slug === slug) ?? null;
+}
+
+/**
+ * Full bake-safe page list, or `null` when the loader hasn't produced a
+ * cache. `[customPage].astro#getStaticPaths` unions these slugs with the
+ * seed's pages so DB-backed ports get per-slug static HTML.
+ */
+export function getAllBuildPages(): Page[] | null {
+  return cache ? cache.slice() : null;
+}
+
+/** Test-only: clear the cache between test runs. */
+export function _clearBuildPagesCacheForTests(): void {
+  loaderPromise = null;
+  cache = null;
+}
+
+/** Test-only: inject a cache without network. */
+export function _setBuildPagesCacheForTests(pages: Page[]): void {
+  loaderPromise = Promise.resolve(pages);
+  cache = pages;
+}

--- a/src/pages/[customPage].astro
+++ b/src/pages/[customPage].astro
@@ -6,11 +6,22 @@ import { safeCustomPageSlugs } from '../lib/clean-routes';
 import { resolveActiveProjectSeed } from '../seeds';
 import { ensureBuildEventsLoaded, getAllBuildEvents } from '../lib/build-events';
 import { ensureBuildAnnouncementsLoaded, getAllBuildAnnouncements } from '../lib/build-announcements';
+import { ensureBuildPagesLoaded, getAllBuildPages, getBuildPageBySlug } from '../lib/build-pages';
 import { renderMainZone, makeBakeContext } from '../lib/chrome-bake';
 
 export async function getStaticPaths() {
   const { seed } = await resolveActiveProjectSeed();
-  return safeCustomPageSlugs(seed.pages).map((customPage) => ({
+  // Union the typed-seed pages with the deployed project's DB-backed pages
+  // (kychon#126): ported sites carry their pages only in the database, so
+  // without the build-time fetch they would get no per-slug static HTML at
+  // all — let alone SSR'd bodies.
+  await ensureBuildPagesLoaded();
+  const slugs = new Set(safeCustomPageSlugs(seed.pages));
+  const buildPages = getAllBuildPages();
+  if (buildPages) {
+    for (const slug of safeCustomPageSlugs(buildPages)) slugs.add(slug);
+  }
+  return [...slugs].map((customPage) => ({
     params: { customPage },
   }));
 }
@@ -32,17 +43,23 @@ export async function getStaticPaths() {
 // the destructive `innerHTML` swap.
 const { seed } = await resolveActiveProjectSeed();
 const slug = String(Astro.params.customPage ?? '');
-await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded()]);
+await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded(), ensureBuildPagesLoaded()]);
 const bakeCtx = {
   ...makeBakeContext(seed),
   buildEvents: getAllBuildEvents(),
   buildAnnouncements: getAllBuildAnnouncements(),
 };
 const { html: sectionsHtml, signature: bakeSignature } = renderMainZone(seed, slug, bakeCtx);
+// SSR the page body itself (kychon#126): with `initialPage` the island
+// server-renders the real title + sanitized rich-text content instead of
+// the loading skeleton, so the served HTML carries the page body for
+// no-JS readers, crawlers, and the concierge parity gate. The runtime
+// still silently refreshes from the live DB after hydration.
+const buildPage = getBuildPageBySlug(slug);
 ---
-<Portal title="Page">
+<Portal title={buildPage?.title ?? 'Page'}>
   <div class="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
-    <CustomPageApp client:load />
+    <CustomPageApp client:load initialPage={buildPage} />
   </div>
   <div id="sections" class="mt-8" data-sortable-group="page-sections" data-zone="main" data-bake-signature={bakeSignature} set:html={sectionsHtml}></div>
   <AdminZoneAddButton zone="main" />

--- a/tests/unit/build-pages.test.ts
+++ b/tests/unit/build-pages.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  _clearBuildPagesCacheForTests,
+  _setBuildPagesCacheForTests,
+  ensureBuildPagesLoaded,
+  getAllBuildPages,
+  getBuildPageBySlug,
+} from '../../src/lib/build-pages';
+import type { Page } from '../../src/schemas/content';
+
+function page(overrides: Partial<Page>): Page {
+  return {
+    id: 1,
+    slug: 'about',
+    title: 'About',
+    content: '<p>Body</p>',
+    requires_auth: false,
+    show_in_nav: true,
+    nav_position: 1,
+    published: true,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('build-pages loader', () => {
+  afterEach(() => {
+    _clearBuildPagesCacheForTests();
+    delete process.env.KYCHON_ANON_KEY;
+    delete process.env.KYCHON_PROJECT_ID;
+    delete process.env.KYCHON_PUBLIC_URL;
+  });
+
+  it('skips cleanly without deploy env vars and reports no pages', async () => {
+    await ensureBuildPagesLoaded();
+    expect(getAllBuildPages()).toEqual([]);
+    expect(getBuildPageBySlug('about')).toBeNull();
+  });
+
+  it('returns null before the loader has run', () => {
+    expect(getAllBuildPages()).toBeNull();
+    expect(getBuildPageBySlug('about')).toBeNull();
+  });
+
+  it('looks up baked pages by slug from the cache', () => {
+    _setBuildPagesCacheForTests([
+      page({ id: 1, slug: 'about', title: 'About Us' }),
+      page({ id: 2, slug: 'membership', title: 'Membership', content: '<p>Join</p>' }),
+    ]);
+    expect(getBuildPageBySlug('membership')?.title).toBe('Membership');
+    expect(getBuildPageBySlug('missing')).toBeNull();
+    expect(getAllBuildPages()).toHaveLength(2);
+  });
+
+  it('returns a copy so callers cannot mutate the cache', () => {
+    _setBuildPagesCacheForTests([page({ slug: 'about' })]);
+    const first = getAllBuildPages();
+    first?.pop();
+    expect(getAllBuildPages()).toHaveLength(1);
+  });
+});

--- a/tests/unit/custom-page-source.test.ts
+++ b/tests/unit/custom-page-source.test.ts
@@ -10,12 +10,20 @@ const app = readFileSync(join(root, 'src/components/kychon/CustomPageApp.tsx'), 
 describe('custom page source', () => {
   it('uses a shared React island instead of inline DOM scripting', () => {
     for (const source of [pageRoute, customPageRoute]) {
-      expect(source).toContain('<CustomPageApp client:load />');
+      expect(source).toMatch(/<CustomPageApp client:load(?: initialPage=\{buildPage\})? \/>/);
       expect(source).not.toContain('<script>');
       expect(source).not.toContain('ky-container');
       expect(source).not.toContain('id="page-title"');
       expect(source).not.toContain('id="page-content"');
     }
+  });
+
+  it('SSR-bakes the page body on clean-route custom pages (kychon#126)', () => {
+    expect(customPageRoute).toContain('ensureBuildPagesLoaded');
+    expect(customPageRoute).toContain('initialPage={buildPage}');
+    expect(app).toContain('initialPage');
+    // The island must not flash a skeleton over baked content.
+    expect(app).toContain('setLoading(!initialPage)');
   });
 
   it('keeps slug resolution, auth redirect, translations, and editor hooks', () => {


### PR DESCRIPTION
## Why

Closes #126. Ported sites carry their page bodies only in the `pages` table, so `[customPage].astro` served a ~900-char skeleton shell until client hydration fetched `pages.content` — every ported page failed no-JS content parity (measured on wsmta-port2: `/membership` 915 chars vs 4,649 on the source). This also blocked the concierge's computed parity gate (kychon-concierge#24/#26) from ever going green.

## What

- **`src/lib/build-pages.ts`** — build-time pages loader on the `build-events.ts` contract: anon-key `pages.list` fetch during `astro build`, so the gateway's `visiblePage` filter (plus a defensive re-filter) guarantees only published, non-`requires_auth` pages can ever be baked into public HTML. Skips cleanly when deploy env is absent (dev/CI).
- **`[customPage].astro`** — `getStaticPaths` unions seed slugs with DB page slugs (DB-backed ports previously got no per-slug HTML at all), and the page row feeds the island as `initialPage`. `<Portal title>` now carries the real page title.
- **`CustomPageApp`** — accepts `initialPage`: server-renders the real title + sanitized content (ultrahtml sanitizer is shared browser/server), hydrates over identical markup with no skeleton flash, then refreshes silently from the live DB (auth redirect, translations, admin edit affordances all unchanged).

## Verification

`vitest` 1035/1035 (new `build-pages` unit tests + updated `custom-page-source` assertions), `biome check` clean, `astro check` clean, `tsc --project tsconfig.scripts.json` clean. (`ui:architecture-check` fails on pre-existing `auth-hosted.css` violations unrelated to this diff; CI does not run that check.)

## Downstream

The concierge re-port acceptance run (kychon-concierge#27 successor) picks this up automatically — its port prerequisite fast-forwards the engine checkout. Demo sites get baked page bodies too via the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)