### PR TITLE
Resolve copied-site source paths via path_aliases

### DIFF
--- a/src/lib/ssr-api.ts
+++ b/src/lib/ssr-api.ts
@@ -104,3 +104,31 @@ export async function ssrEventsList<T = unknown>(params: SsrEventsListParams): P
     return null;
   }
 }
+
+export interface SsrConfigParams {
+  /** site_config key to read (must be in a publicly visible category). */
+  key: string;
+  /** Request host (`Astro.request.headers.get('host')`). */
+  host: string;
+}
+
+/**
+ * Read one public `site_config` value per request. Returns the raw JSONB
+ * value or `null` when the key is absent, non-public, or the gateway call
+ * fails. Used by `[...alias].astro` to resolve copied-site source-path
+ * aliases (kychon#128).
+ */
+export async function ssrConfigValue<T = unknown>(params: SsrConfigParams): Promise<T | null> {
+  try {
+    const row = await client(params.host).request<{ key: string; value: T } | null>(
+      'config.get',
+      'query',
+      { key: params.key },
+    );
+    if (row && typeof row === 'object' && 'value' in row) return row.value;
+    return null;
+  } catch (error) {
+    console.warn('[ssr-api] config.get failed:', error instanceof Error ? error.message : error);
+    return null;
+  }
+}

--- a/src/pages/[...alias].astro
+++ b/src/pages/[...alias].astro
@@ -1,0 +1,42 @@
+---
+import { ssrConfigValue } from '../lib/ssr-api';
+
+export const prerender = false;
+
+// Source-path alias resolver for copied websites (kychon#128). Ported pages
+// are emitted as single-segment slug routes (`/gr-news-13604666`), but the
+// source site's inbound links and the concierge parity harness expect the
+// original nested paths (`/gr-news/13604666`) to keep working. The porter
+// seeds a `path_aliases` site_config map (publicly visible category) from
+// source path → port path; this rest-param route — lowest Astro precedence,
+// so it only sees otherwise-unmatched requests — 301s matched paths and
+// serves a minimal noindex 404 for everything else.
+const host = Astro.request.headers.get('host') ?? Astro.url.host;
+const path = Astro.url.pathname.replace(/\/+$/, '') || '/';
+const aliases = await ssrConfigValue<Record<string, unknown>>({ key: 'path_aliases', host });
+const target = aliases && typeof aliases === 'object' ? aliases[path] : undefined;
+
+// Same-site relative targets only: a leading single slash, never `//host`,
+// so a mis-seeded map can't become an open redirect.
+if (typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')) {
+  return Astro.redirect(target, 301);
+}
+
+Astro.response.status = 404;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found</title>
+  </head>
+  <body>
+    <main style="font-family: system-ui, sans-serif; padding: 4rem 1rem; text-align: center;">
+      <h1>404</h1>
+      <p>Page not found.</p>
+      <p><a href="/">Go to the homepage</a></p>
+    </main>
+  </body>
+</html>

--- a/tests/unit/path-alias-source.test.ts
+++ b/tests/unit/path-alias-source.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(import.meta.dirname, '../..');
+const aliasRoute = readFileSync(join(root, 'src/pages/[...alias].astro'), 'utf8');
+const ssrApi = readFileSync(join(root, 'src/lib/ssr-api.ts'), 'utf8');
+
+describe('source-path alias route', () => {
+  it('renders per request and resolves aliases from public site_config', () => {
+    expect(aliasRoute).toContain('export const prerender = false');
+    expect(aliasRoute).toContain("key: 'path_aliases'");
+    expect(aliasRoute).toContain('ssrConfigValue');
+  });
+
+  it('redirects with a permanent status and refuses non-relative targets', () => {
+    expect(aliasRoute).toContain('Astro.redirect(target, 301)');
+    expect(aliasRoute).toContain("target.startsWith('/')");
+    expect(aliasRoute).toContain("!target.startsWith('//')");
+  });
+
+  it('serves a noindex 404 for unmatched paths', () => {
+    expect(aliasRoute).toContain('Astro.response.status = 404');
+    expect(aliasRoute).toContain('name="robots" content="noindex"');
+  });
+
+  it('ssr-api exposes the per-request config reader', () => {
+    expect(ssrApi).toContain('export async function ssrConfigValue');
+    expect(ssrApi).toContain("'config.get'");
+  });
+});


### PR DESCRIPTION
Closes #128. The wsmta-port3 refuter and parity harness both flagged source-equivalent URLs 404ing: ported pages live at single-segment slugs (`/gr-news-13604666`) while the source's inbound links use nested paths (`/gr-news/13604666`).

- **`src/pages/[...alias].astro`** (`prerender = false`, rest-param = lowest route precedence): reads the porter-seeded `path_aliases` site_config map per request and 301s matched paths. Targets restricted to same-site relative paths (single leading slash) — a mis-seeded map can't become an open redirect. Unmatched paths get a minimal noindex 404 (previously adapter-default).
- **`ssrConfigValue`** added to `ssr-api.ts` (per-request public site_config reader, `config.get` is anonymous for public categories).

Gates: vitest 1039/1039 (4 new source tests), biome clean, astro check clean.

Concierge side (separate PR): the copy-website skill seeds `path_aliases` for every copied page whose source path differs from its port slug route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)