### PR TITLE
Keep baked content on refresh misses; configurable header position

### DIFF
--- a/src/components/kychon/CustomPageApp.tsx
+++ b/src/components/kychon/CustomPageApp.tsx
@@ -64,7 +64,10 @@ export default function CustomPageApp({ initialPage = null }: CustomPageAppProps
 
       const rows = (await get(`pages?slug=eq.${encodeURIComponent(slug)}&published=eq.true&limit=1`)) as Page[];
       if (!rows.length) {
-        setNotFound(true);
+        // Never downgrade SSR-baked content to a not-found card on a
+        // client-side slug-resolution miss (aliased/nested copied-site
+        // paths especially). Only pages with nothing baked show 404.
+        if (!initialPage) setNotFound(true);
         return;
       }
 
@@ -77,7 +80,12 @@ export default function CustomPageApp({ initialPage = null }: CustomPageAppProps
       document.title = translated.title;
       setPage(translated);
     } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : 'Error loading page.');
+      // Same principle for transient refresh errors: keep baked content.
+      if (initialPage) {
+        console.warn('[custom-page] refresh failed; keeping baked content:', loadError);
+      } else {
+        setError(loadError instanceof Error ? loadError.message : 'Error loading page.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -208,6 +208,9 @@ export interface NavPresentationConfig {
   transition?: string;
   mobile_menu_bg?: string;
   mobile_menu_padding?: string;
+  /** 'static' lets the header scroll with the page (copied-site source
+   *  behavior parity); default is the sticky header. */
+  header_position?: string;
 }
 
 export interface NavBehaviorConfig {
@@ -1176,6 +1179,7 @@ function renderNavPresentationProps(cfg: NavConfig): {
   setNavStyle(style, '--nav-transition', p.transition || hover.duration);
   setNavStyle(style, '--nav-mobile-menu-bg', p.mobile_menu_bg);
   setNavStyle(style, '--nav-mobile-menu-padding', p.mobile_menu_padding);
+  setNavStyle(style, '--nav-header-position', p.header_position);
 
   let mobileBreakpoint: number | null = null;
   if (b.mobile_breakpoint != null) {

--- a/src/styles/public.css
+++ b/src/styles/public.css
@@ -88,7 +88,9 @@ a:hover {
   border-bottom: var(--nav-header-border-bottom, 1px solid var(--border, var(--color-border)));
   box-shadow: var(--nav-header-shadow, none);
   padding: var(--nav-header-padding, 0.5rem 0);
-  position: sticky;
+  /* Copied sites whose source header scrolls with the page set
+     header_position: static in the nav block config (kychon#130). */
+  position: var(--nav-header-position, sticky);
   top: var(--demo-banner-height, 0px);
   z-index: 100;
 }

--- a/tests/unit/custom-page-source.test.ts
+++ b/tests/unit/custom-page-source.test.ts
@@ -26,6 +26,11 @@ describe('custom page source', () => {
     expect(app).toContain('setLoading(!initialPage)');
   });
 
+  it('never downgrades baked content to not-found or error on refresh misses', () => {
+    expect(app).toContain('if (!initialPage) setNotFound(true)');
+    expect(app).toContain('keeping baked content');
+  });
+
   it('keeps slug resolution, auth redirect, translations, and editor hooks', () => {
     expect(app).toContain('resolveCustomPageSlugFromLocation');
     expect(app).toContain('translateItems');

--- a/tests/unit/nav-header-position-source.test.ts
+++ b/tests/unit/nav-header-position-source.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(import.meta.dirname, '../..');
+const css = readFileSync(join(root, 'src/styles/public.css'), 'utf8');
+const blocks = readFileSync(join(root, 'src/lib/blocks.ts'), 'utf8');
+
+describe('nav header position config', () => {
+  it('the shell position is variable-driven with a sticky default', () => {
+    expect(css).toContain('position: var(--nav-header-position, sticky)');
+  });
+
+  it('the nav block pipes header_position into the variable', () => {
+    expect(blocks).toContain('header_position?: string');
+    expect(blocks).toContain("setNavStyle(style, '--nav-header-position', p.header_position)");
+  });
+});


### PR DESCRIPTION
Engine half of the wsmta-port4 refuter findings ([kychon-concierge#37](https://github.com/kychee-com/kychon-concierge/issues/37)):

- **Hub routes hydrating to "Page not found" (high)** — `CustomPageApp` overwrote perfectly good SSR-baked content with a 404 card when the client-side slug lookup missed, and with an error card on transient refresh failures. Baked content now wins; only un-baked pages can show 404/error.
- **Sticky header mismatch (medium)** — `[data-nav-shell]` position is now `var(--nav-header-position, sticky)` with a `header_position` nav-config field. Default unchanged (sticky); copied sites seed `'static'` when the source header scrolls (concierge skill PR follows).

Gates: vitest 1042/1042 (3 new source tests), biome clean, astro check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)