### PR TITLE
fix(demo-reset): one multi-table TRUNCATE + staggered schedules (run402#494)

### DIFF
--- a/demo/barrio-unido/reset-demo.js
+++ b/demo/barrio-unido/reset-demo.js
@@ -1,4 +1,4 @@
-// schedule: "0 * * * *"
+// schedule: "40 * * * *"
 // Reset demo site to seed state — auto-generated, do not edit manually
 // Regenerate with: node scripts/generate-reset-function.js <seed.sql>
 import { adminDb } from '@run402/functions';
@@ -1691,10 +1691,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. TRUNCATE mutable content tables (order matters for FK constraints)
-  for (const table of MUTABLE_TABLES) {
-    await adminDb().sql(`TRUNCATE ${table} CASCADE`);
-  }
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
+  //    statement is one transaction = one PostgREST schema-cache reload, vs
+  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
+  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
+  //    semantics (multi-table TRUNCATE is order-independent anyway).
+  await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);
 
   // 3. Delete non-demo members (keep demo accounts by user_id)
   // First nullify tier_id on kept members to avoid FK constraint on membership_tiers

--- a/demo/eagles/reset-demo.js
+++ b/demo/eagles/reset-demo.js
@@ -2052,10 +2052,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. TRUNCATE mutable content tables (order matters for FK constraints)
-  for (const table of MUTABLE_TABLES) {
-    await adminDb().sql(`TRUNCATE ${table} CASCADE`);
-  }
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
+  //    statement is one transaction = one PostgREST schema-cache reload, vs
+  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
+  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
+  //    semantics (multi-table TRUNCATE is order-independent anyway).
+  await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);
 
   // 3. Delete non-demo members (keep demo accounts by user_id)
   // First nullify tier_id on kept members to avoid FK constraint on membership_tiers

--- a/demo/silver-pines/reset-demo.js
+++ b/demo/silver-pines/reset-demo.js
@@ -1,4 +1,4 @@
-// schedule: "0 * * * *"
+// schedule: "20 * * * *"
 // Reset demo site to seed state — auto-generated, do not edit manually
 // Regenerate with: node scripts/generate-reset-function.js <seed.sql>
 import { adminDb } from '@run402/functions';
@@ -1228,10 +1228,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. TRUNCATE mutable content tables (order matters for FK constraints)
-  for (const table of MUTABLE_TABLES) {
-    await adminDb().sql(`TRUNCATE ${table} CASCADE`);
-  }
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
+  //    statement is one transaction = one PostgREST schema-cache reload, vs
+  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
+  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
+  //    semantics (multi-table TRUNCATE is order-independent anyway).
+  await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);
 
   // 3. Delete non-demo members (keep demo accounts by user_id)
   // First nullify tier_id on kept members to avoid FK constraint on membership_tiers

--- a/scripts/deploy-ci.ts
+++ b/scripts/deploy-ci.ts
@@ -68,7 +68,7 @@ try {
   console.log("Generating seed.sql for reset-demo embed...");
   execSync("npx tsx scripts/generate-seed-sql.ts", { stdio: "inherit", cwd: ROOT });
   console.log(`Regenerating ${config.resetDemoFile}...`);
-  execSync(`node scripts/generate-reset-function.js seed.sql > ${config.resetDemoFile}`, {
+  execSync(`node scripts/generate-reset-function.js seed.sql "${config.resetSchedule}" > ${config.resetDemoFile}`, {
     stdio: "inherit",
     cwd: ROOT,
   });

--- a/scripts/deploy-demo.ts
+++ b/scripts/deploy-demo.ts
@@ -47,6 +47,14 @@ export interface DemoConfig {
   kychonProject: string;
   /** Path to the demo's reset-demo.js (relative to repo root). */
   resetDemoFile: string;
+  /**
+   * Cron schedule for the hourly demo reset. Staggered across demos so the
+   * three resets don't all fire at :00 and stack their PostgREST schema-cache
+   * reloads on the shared Aurora writer (run402-private#494). Passed verbatim
+   * to scripts/generate-reset-function.js and parsed back out of the emitted
+   * `// schedule: "..."` directive by scripts/_lib.ts at deploy time.
+   */
+  resetSchedule: string;
 }
 
 export interface DeployOneDemoOptions {
@@ -66,6 +74,7 @@ export const DEMOS: Record<string, DemoConfig> = {
     assetsDir: "demo/eagles/assets",
     kychonProject: "eagles",
     resetDemoFile: "demo/eagles/reset-demo.js",
+    resetSchedule: "0 * * * *",
   },
   "silver-pines": {
     displayName: "Silver Pines",
@@ -76,6 +85,7 @@ export const DEMOS: Record<string, DemoConfig> = {
     assetsDir: "demo/silver-pines/assets",
     kychonProject: "silver-pines",
     resetDemoFile: "demo/silver-pines/reset-demo.js",
+    resetSchedule: "20 * * * *",
   },
   barrio: {
     displayName: "Barrio Unido",
@@ -86,6 +96,7 @@ export const DEMOS: Record<string, DemoConfig> = {
     assetsDir: "demo/barrio-unido/assets",
     kychonProject: "barrio-unido",
     resetDemoFile: "demo/barrio-unido/reset-demo.js",
+    resetSchedule: "40 * * * *",
   },
 };
 
@@ -259,7 +270,7 @@ export async function deployOneDemo(
     });
     console.log(`Regenerating ${config.resetDemoFile} from full seed.sql...`);
     execSync(
-      `node scripts/generate-reset-function.js seed.sql > ${config.resetDemoFile}`,
+      `node scripts/generate-reset-function.js seed.sql "${config.resetSchedule}" > ${config.resetDemoFile}`,
       { stdio: "inherit", cwd: ROOT },
     );
 

--- a/scripts/generate-reset-function.js
+++ b/scripts/generate-reset-function.js
@@ -6,16 +6,22 @@ import { readFileSync } from 'node:fs';
 
 const seedPath = process.argv[2];
 if (!seedPath) {
-  console.error('Usage: node scripts/generate-reset-function.js <seed.sql>');
+  console.error('Usage: node scripts/generate-reset-function.js <seed.sql> [cron-schedule]');
   process.exit(1);
 }
+
+// Optional per-demo cron schedule. The three demos are staggered across the
+// hour (see scripts/deploy-demo.ts) so their hourly resets don't all fire at
+// :00 and stack on the shared Aurora writer (run402-private#494). Defaults to
+// top-of-hour for standalone / manual regeneration.
+const schedule = process.argv[3] || '0 * * * *';
 
 const seedSQL = readFileSync(seedPath, 'utf-8');
 
 // Escape backticks and ${} for JS template literal
 const escaped = seedSQL.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 
-const output = `// schedule: "0 * * * *"
+const output = `// schedule: "${schedule}"
 // Reset demo site to seed state — auto-generated, do not edit manually
 // Regenerate with: node scripts/generate-reset-function.js <seed.sql>
 import { adminDb } from '@run402/functions';
@@ -38,10 +44,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. TRUNCATE mutable content tables (order matters for FK constraints)
-  for (const table of MUTABLE_TABLES) {
-    await adminDb().sql(\`TRUNCATE \${table} CASCADE\`);
-  }
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
+  //    statement is one transaction = one PostgREST schema-cache reload, vs
+  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
+  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
+  //    semantics (multi-table TRUNCATE is order-independent anyway).
+  await adminDb().sql(\`TRUNCATE \${MUTABLE_TABLES.join(', ')} CASCADE\`);
 
   // 3. Delete non-demo members (keep demo accounts by user_id)
   // First nullify tier_id on kept members to avoid FK constraint on membership_tiers

--- a/tests/unit/reset-function-generator.test.ts
+++ b/tests/unit/reset-function-generator.test.ts
@@ -34,4 +34,47 @@ describe('reset-demo generator', () => {
     expect(source).toContain('Annual Spring Food Drive');
     expect(source).not.toContain('Barrio Unido');
   });
+
+  it('wipes mutable tables in one multi-table TRUNCATE, not a per-table loop', () => {
+    // Each per-table TRUNCATE is its own transaction and forces a full
+    // PostgREST schema-cache reload; 18 of them x 3 demos firing at :00 pegged
+    // the shared Aurora writer to 100% (run402-private#494). One multi-table
+    // statement collapses that to a single reload.
+    const source = execFileSync('node', ['scripts/generate-reset-function.js', 'demo/eagles/seed.sql'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    expect(source).toMatch(/TRUNCATE \$\{MUTABLE_TABLES\.join\(', '\)\} CASCADE/);
+    expect(source).not.toMatch(/for \(const table of MUTABLE_TABLES\)/);
+  });
+
+  it('emits the cron schedule from argv, defaulting to top-of-hour', () => {
+    const staggered = execFileSync(
+      'node',
+      ['scripts/generate-reset-function.js', 'demo/eagles/seed.sql', '20 * * * *'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    expect(staggered.startsWith('// schedule: "20 * * * *"')).toBe(true);
+
+    const defaulted = execFileSync('node', ['scripts/generate-reset-function.js', 'demo/eagles/seed.sql'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(defaulted.startsWith('// schedule: "0 * * * *"')).toBe(true);
+  });
+
+  it('staggers the three committed demo reset schedules across the hour', () => {
+    const schedOf = (p: string) => readFileSync(join(root, p), 'utf8').match(/^\/\/ schedule: "([^"]+)"/)?.[1];
+    const schedules = [
+      schedOf('demo/eagles/reset-demo.js'),
+      schedOf('demo/silver-pines/reset-demo.js'),
+      schedOf('demo/barrio-unido/reset-demo.js'),
+    ];
+
+    expect(schedules).toEqual(['0 * * * *', '20 * * * *', '40 * * * *']);
+    // Distinct minute offsets — the whole point is that they don't stack at :00.
+    const minutes = schedules.map((s) => s?.split(' ')[0]);
+    expect(new Set(minutes).size).toBe(3);
+  });
 });


### PR DESCRIPTION
> ⚠️ **Correction (post-merge):** the "PostgREST reload" rationale below is **wrong**. `TRUNCATE` does not fire `ddl_command_end`, so it triggers **zero** PostgREST schema-cache reloads (verified on PG16). This PR's real value is **staggering** the three demos' resets (`:00`/`:20`/`:40`) so they stop running *concurrently*, plus fewer admin-SQL round-trips — not eliminating a reload storm. There is no `notify_pgrst()` platform bug to fix. Full correction with evidence: kychee-com/run402-private#494.

---

## Why

The hosted Kychon demo portals (`eagles`, `silver-pines`, `barrio-unido`) each run `reset-demo.js` on `0 * * * *`. The reset wipes its mutable content tables with a **per-table loop of `TRUNCATE … CASCADE`** — 18 separate `adminDb().sql()` calls, each its own admin-SQL transaction.

On Run402, **every `TRUNCATE` fires the `pgrst_reload` `ddl_command_end` trigger** → a full PostgREST schema-cache re-introspection of ~3300 relations (`pg_event_trigger_ddl_commands()` returns an empty set for TRUNCATE, so `notify_pgrst()` hits its `total = 0 → NOTIFY` branch). So per hour, at exactly `:00`:

- 3 demos × 18 = **~54 full PostgREST schema reloads** (~86–152 ms writer CPU each)
- plus 54 `TRUNCATE … CASCADE` (ACCESS EXCLUSIVE locks + catalog churn)
- plus 3 full reseeds (`SEED_SQL` + `kychon_reindex_search()`)

all crammed into one minute on the shared **2-ACU Aurora writer**, pegging it to 100%. Investigated in run402-private#494 (1-min CloudWatch CPU shows a clean isolated spike at exactly `:00:00Z`; gateway logs show 96 `admin sql executed` lines / 32 per demo in that minute).

## What

1. **One multi-table TRUNCATE.** Replace the 18-iteration loop with a single `TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`. One statement = one transaction = **one** schema reload instead of 18 (18 → 1 per demo, 54 → 3/hr fleet-wide). CASCADE + the existing FK-safe table ordering keep the prior semantics exactly — a multi-table TRUNCATE is order-independent anyway.
2. **Stagger the schedules** to `:00` / `:20` / `:40` so the three resets no longer stack at the top of the hour. `generate-reset-function.js` now takes an optional cron arg (defaults to top-of-hour); `deploy-demo.ts` / `deploy-ci.ts` pass each demo's `resetSchedule`.
3. **Regenerate** the three committed `demo/*/reset-demo.js` artifacts (SEED_SQL untouched) and **add regression tests** (single-statement TRUNCATE, schedule arg, distinct staggered offsets).

## Effect

The `:00` Aurora reload storm goes from ~54 reloads/hr to ~3, spread across `:00`/`:20`/`:40`. (run402-private also bumped the writer to 4 ACU for headroom.)

## Deploy note

The committed `reset-demo.js` artifacts are regenerated on every deploy, so the fix lands in prod when the three demos are next deployed (`deploy-demo` / the CI deploy). Until then prod keeps running the old per-table-TRUNCATE functions; the 4-ACU bump absorbs it in the meantime.

## Test

```
npx vitest run tests/unit/reset-function-generator.test.ts   # 5 passed
npx tsc --project tsconfig.scripts.json --noEmit             # clean
npx biome check <changed files>                              # clean
```

Refs run402-private#494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

