### PR TITLE
theme.color_scheme pin for single-design (copied) sites

### DIFF
--- a/src/layouts/Portal.astro
+++ b/src/layouts/Portal.astro
@@ -117,19 +117,24 @@ const inlineManifestScript = inlineManifest
   <link rel="stylesheet" href="/css/admin-editing.css">
   {inlineManifestScript && <script is:inline set:html={inlineManifestScript}></script>}
   <ClientRouter />
-  <script is:inline>
-    (function applyTheme() {
+  <script is:inline define:vars={{ pinnedColorScheme: chrome.colorScheme }}>
+    // theme.color_scheme pins single-design sites (copied websites
+    // especially) to their baked scheme: honoring the visitor's OS
+    // dark-mode preference would flip the tokens out from under a design
+    // whose imagery and custom CSS are pinned light, producing unreadable
+    // white-on-white text. 'auto' keeps OS/localStorage behavior.
+    function resolveTheme() {
+      if (pinnedColorScheme === 'light' || pinnedColorScheme === 'dark') return pinnedColorScheme;
       var t = localStorage.getItem('wl_theme');
       if (!t) t = window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
-      if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+      return t;
+    }
+    function applyTheme() {
+      if (resolveTheme() === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
       else document.documentElement.removeAttribute('data-theme');
-    })();
-    document.addEventListener('astro:after-swap', function () {
-      var t = localStorage.getItem('wl_theme');
-      if (!t) t = window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
-      if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
-      else document.documentElement.removeAttribute('data-theme');
-    });
+    }
+    applyTheme();
+    document.addEventListener('astro:after-swap', applyTheme);
   </script>
   <script is:inline src="/js/env.js"></script>
 </head>

--- a/src/lib/chrome-bake.ts
+++ b/src/lib/chrome-bake.ts
@@ -30,6 +30,15 @@ export interface BakedChrome {
    * design font AFTER JS runs, producing a visible serif↔sans jump.
    */
   themeFontVarsCss: string;
+  /**
+   * Color-scheme pin from `site_config.theme.color_scheme`. Copied sites
+   * have one design baked into imagery and custom CSS, so honoring the
+   * visitor's OS dark-mode preference flips the tokens out from under that
+   * design (white-on-white text for dark-mode visitors). `'light'`/`'dark'`
+   * pin the scheme; `'auto'` (default) keeps the OS/localStorage behavior
+   * for token-driven native sites.
+   */
+  colorScheme: 'light' | 'dark' | 'auto';
   bakeCtx: BlockRenderContext;
 }
 
@@ -277,6 +286,12 @@ export function bakeChrome(seed: ProjectSeed, pageTitle: string): BakedChrome {
     title: getBrandedTitle(pageTitle, bakeCtx.siteName || bakeCtx.brandText || ''),
     cdnOrigin: cdnOriginFromManifest(bakeCtx.manifest),
     themeFontVarsCss: themeFontVarLines.join(' '),
+    colorScheme: colorSchemeFromTheme(theme),
     bakeCtx,
   };
+}
+
+function colorSchemeFromTheme(theme: Record<string, unknown>): 'light' | 'dark' | 'auto' {
+  const value = theme.color_scheme;
+  return value === 'light' || value === 'dark' ? value : 'auto';
 }

--- a/tests/unit/color-scheme-pin-source.test.ts
+++ b/tests/unit/color-scheme-pin-source.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { bakeChrome } from '../../src/lib/chrome-bake';
+import type { ProjectSeed } from '../../src/seeds/types';
+
+const root = join(import.meta.dirname, '../..');
+const portal = readFileSync(join(root, 'src/layouts/Portal.astro'), 'utf8');
+
+function seedWithTheme(theme: Record<string, unknown>): ProjectSeed {
+  return {
+    site_config: { theme },
+    sections: [],
+    pages: [],
+  } as unknown as ProjectSeed;
+}
+
+describe('theme color-scheme pin', () => {
+  it('bakes light/dark pins and defaults to auto', () => {
+    expect(bakeChrome(seedWithTheme({ color_scheme: 'light' }), 'T').colorScheme).toBe('light');
+    expect(bakeChrome(seedWithTheme({ color_scheme: 'dark' }), 'T').colorScheme).toBe('dark');
+    expect(bakeChrome(seedWithTheme({}), 'T').colorScheme).toBe('auto');
+    expect(bakeChrome(seedWithTheme({ color_scheme: 'mauve' }), 'T').colorScheme).toBe('auto');
+  });
+
+  it('Portal honors the pin before OS preference and localStorage', () => {
+    expect(portal).toContain('pinnedColorScheme');
+    expect(portal).toContain("pinnedColorScheme === 'light' || pinnedColorScheme === 'dark'");
+    expect(portal).toContain('astro:after-swap');
+  });
+});


### PR DESCRIPTION
Root cause of the operator-reported white-on-white text on wsmta-port5 ("SUBSCRIBE: NEWS AND ACTION FOR LMTS" + footer cluster):

`Portal.astro` auto-applies dark mode from `prefers-color-scheme`. A copied site's design is pinned light (baked imagery, source colors, custom CSS) — for a dark-mode visitor only the tokens flip, so `--foreground` becomes slate-200 on pinned-light backgrounds (contrast ratio 1.15, measured). Light-mode browsers — including the worker's and refuter's headless Chrome — render it perfectly, which is exactly why every automated gate missed it and the operator's dark-mode eyes caught it instantly.

- `site_config.theme.color_scheme: 'light' | 'dark'` pins the scheme ahead of localStorage and OS preference; `'auto'` (default) preserves current behavior for native token-driven sites.
- Plumbed through `bakeChrome` (`chrome.colorScheme`) into Portal's inline script, both initial apply and `astro:after-swap`.

Concierge follow-ups (separate PRs): ports seed `color_scheme: 'light'`, and live verification gains a computed-contrast sweep run in BOTH emulated color schemes.

Gates: vitest 1044/1044, biome clean, astro check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)