### PR TITLE
docs(demo-reset): correct rationale — TRUNCATE causes no PostgREST reload (run402#494)

### DIFF
--- a/demo/barrio-unido/reset-demo.js
+++ b/demo/barrio-unido/reset-demo.js
@@ -1691,10 +1691,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
-  //    statement is one transaction = one PostgREST schema-cache reload, vs
-  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
-  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE — one
+  //    statement / one transaction / one admin-SQL round-trip instead of 18
+  //    separate calls. (TRUNCATE doesn't change the schema and doesn't fire
+  //    ddl_command_end, so it triggers no PostgREST reload either way — the
+  //    win is fewer round-trips + one lock-set acquisition. The real
+  //    run402-private#494 fix is staggering the three demos' reset crons so
+  //    they don't all run at once; see the schedule directive at the top.)
   //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
   //    semantics (multi-table TRUNCATE is order-independent anyway).
   await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);

--- a/demo/eagles/reset-demo.js
+++ b/demo/eagles/reset-demo.js
@@ -2052,10 +2052,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
-  //    statement is one transaction = one PostgREST schema-cache reload, vs
-  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
-  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE — one
+  //    statement / one transaction / one admin-SQL round-trip instead of 18
+  //    separate calls. (TRUNCATE doesn't change the schema and doesn't fire
+  //    ddl_command_end, so it triggers no PostgREST reload either way — the
+  //    win is fewer round-trips + one lock-set acquisition. The real
+  //    run402-private#494 fix is staggering the three demos' reset crons so
+  //    they don't all run at once; see the schedule directive at the top.)
   //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
   //    semantics (multi-table TRUNCATE is order-independent anyway).
   await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);

--- a/demo/silver-pines/reset-demo.js
+++ b/demo/silver-pines/reset-demo.js
@@ -1228,10 +1228,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
-  //    statement is one transaction = one PostgREST schema-cache reload, vs
-  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
-  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE — one
+  //    statement / one transaction / one admin-SQL round-trip instead of 18
+  //    separate calls. (TRUNCATE doesn't change the schema and doesn't fire
+  //    ddl_command_end, so it triggers no PostgREST reload either way — the
+  //    win is fewer round-trips + one lock-set acquisition. The real
+  //    run402-private#494 fix is staggering the three demos' reset crons so
+  //    they don't all run at once; see the schedule directive at the top.)
   //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
   //    semantics (multi-table TRUNCATE is order-independent anyway).
   await adminDb().sql(`TRUNCATE ${MUTABLE_TABLES.join(', ')} CASCADE`);

--- a/scripts/deploy-demo.ts
+++ b/scripts/deploy-demo.ts
@@ -49,10 +49,11 @@ export interface DemoConfig {
   resetDemoFile: string;
   /**
    * Cron schedule for the hourly demo reset. Staggered across demos so the
-   * three resets don't all fire at :00 and stack their PostgREST schema-cache
-   * reloads on the shared Aurora writer (run402-private#494). Passed verbatim
-   * to scripts/generate-reset-function.js and parsed back out of the emitted
-   * `// schedule: "..."` directive by scripts/_lib.ts at deploy time.
+   * three resets don't all run concurrently — each is a full DB wipe + reseed,
+   * and three at once at :00 piled onto the shared Aurora writer
+   * (run402-private#494). Passed verbatim to scripts/generate-reset-function.js
+   * and parsed back out of the emitted `// schedule: "..."` directive by
+   * scripts/_lib.ts at deploy time.
    */
   resetSchedule: string;
 }

--- a/scripts/generate-reset-function.js
+++ b/scripts/generate-reset-function.js
@@ -44,10 +44,13 @@ export default async (_req) => {
   const adminUserId = demoAccounts.admin_user_id;
   const memberUserId = demoAccounts.member_user_id;
 
-  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE. A single
-  //    statement is one transaction = one PostgREST schema-cache reload, vs
-  //    one reload per table: 18 per-table TRUNCATEs x 3 demos all firing at
-  //    :00 pegged the shared Aurora writer to 100% (run402-private#494).
+  // 2. Wipe mutable content tables in ONE multi-table TRUNCATE — one
+  //    statement / one transaction / one admin-SQL round-trip instead of 18
+  //    separate calls. (TRUNCATE doesn't change the schema and doesn't fire
+  //    ddl_command_end, so it triggers no PostgREST reload either way — the
+  //    win is fewer round-trips + one lock-set acquisition. The real
+  //    run402-private#494 fix is staggering the three demos' reset crons so
+  //    they don't all run at once; see the schedule directive at the top.)
   //    CASCADE + the FK-safe ordering of MUTABLE_TABLES preserve the prior
   //    semantics (multi-table TRUNCATE is order-independent anyway).
   await adminDb().sql(\`TRUNCATE \${MUTABLE_TABLES.join(', ')} CASCADE\`);

--- a/tests/unit/reset-function-generator.test.ts
+++ b/tests/unit/reset-function-generator.test.ts
@@ -36,10 +36,11 @@ describe('reset-demo generator', () => {
   });
 
   it('wipes mutable tables in one multi-table TRUNCATE, not a per-table loop', () => {
-    // Each per-table TRUNCATE is its own transaction and forces a full
-    // PostgREST schema-cache reload; 18 of them x 3 demos firing at :00 pegged
-    // the shared Aurora writer to 100% (run402-private#494). One multi-table
-    // statement collapses that to a single reload.
+    // Each per-table TRUNCATE was its own admin-SQL round-trip; 18 x 3 demos
+    // firing at :00 piled concurrent reset work on the shared 2-ACU writer
+    // (run402-private#494). One multi-table statement is a single round-trip.
+    // (TRUNCATE itself triggers no PostgREST reload — it doesn't fire
+    // ddl_command_end.)
     const source = execFileSync('node', ['scripts/generate-reset-function.js', 'demo/eagles/seed.sql'], {
       cwd: root,
       encoding: 'utf8',


### PR DESCRIPTION
Comment-only follow-up to #131. The code is unchanged; this fixes the **rationale** baked into #131's comments, which was wrong.

## The error

#131's comments claimed each per-table `TRUNCATE` forced a full PostgREST schema-cache reload (~54/hr across the three demos) and that collapsing 18→1 "eliminated the reload storm."

That's false. **`TRUNCATE` does not fire `ddl_command_end` in Postgres 16**, so run402's `internal.notify_pgrst()` never runs for it — a `TRUNCATE` triggers **zero** PostgREST reloads. Verified empirically (a diagnostic `ddl_command_end` trigger fires for `CREATE`/`ALTER`/`DROP` but not for `TRUNCATE`/`TRUNCATE … CASCADE`). The reseed is DML-only too (`SEED_SQL` has no DDL; `kychon_reindex_search()` is DELETE + tsvector upserts).

## The correct story (now in the comments)

- The `:00` spike was heavy because the three demos ran a full DB wipe + reseed **concurrently** — not because of reloads.
- **Staggering** `:00`/`:20`/`:40` (the real fix, already in #131) de-synchronizes them.
- The **18→1 multi-table TRUNCATE** is a round-trip / lock-acquisition reduction, not a reload fix.

No behavior change; `tests/unit/reset-function-generator.test.ts` still passes (5/5), biome clean. Full write-up: kychee-com/run402-private#494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
