### PR TITLE
Subtle delight: section reveal, stat count-up, card hover lift

### DIFF
--- a/src/components/kychon/MarketingBlocksView.tsx
+++ b/src/components/kychon/MarketingBlocksView.tsx
@@ -278,9 +278,10 @@ function StatsBlock({ config, options }: { config: Record<string, unknown>; opti
       <div className="grid grid-cols-[repeat(auto-fit,minmax(min(14rem,100%),1fr))] gap-4">
         {items.map((item, index) => {
           const content = (
-            <Card className="h-full transition-colors hover:bg-accent/40">
+            <Card className="h-full transition-[background-color,transform,box-shadow] duration-200 hover:-translate-y-0.5 hover:bg-accent/40 hover:shadow-md motion-reduce:transform-none motion-reduce:transition-none">
               <CardHeader>
-                <CardTitle className="text-4xl tracking-normal text-primary" {...editableAttrs(`items.${index}.value`, options)}>
+                {/* data-stat-value: count-up hook for src/lib/delight.ts */}
+                <CardTitle data-stat-value="" className="text-4xl tracking-normal text-primary" {...editableAttrs(`items.${index}.value`, options)}>
                   {item.value || '0'}
                 </CardTitle>
                 <CardDescription className="text-base" {...editableAttrs(`items.${index}.label`, options)}>
@@ -380,7 +381,7 @@ function PromoCardsBlock({ config, options }: { config: Record<string, unknown>;
               href={href}
               key={`${title || 'promo'}-${index}`}
             >
-              <Card className="h-full overflow-hidden transition-colors group-hover:border-primary/30 group-hover:shadow-md">
+              <Card className="h-full overflow-hidden transition-[border-color,transform,box-shadow] duration-200 group-hover:-translate-y-0.5 group-hover:border-primary/30 group-hover:shadow-md motion-reduce:transform-none motion-reduce:transition-none">
                 <div
                   className="relative aspect-[16/10] overflow-hidden bg-muted"
                   {...editableImageAttrs(index, options)}

--- a/src/layouts/Portal.astro
+++ b/src/layouts/Portal.astro
@@ -117,12 +117,13 @@ const inlineManifestScript = inlineManifest
   <link rel="stylesheet" href="/css/admin-editing.css">
   {inlineManifestScript && <script is:inline set:html={inlineManifestScript}></script>}
   <ClientRouter />
-  <script is:inline define:vars={{ pinnedColorScheme: chrome.colorScheme }}>
+  <script is:inline define:vars={{ pinnedColorScheme: chrome.colorScheme, motionMode: chrome.motion }}>
     // theme.color_scheme pins single-design sites (copied websites
     // especially) to their baked scheme: honoring the visitor's OS
     // dark-mode preference would flip the tokens out from under a design
     // whose imagery and custom CSS are pinned light, producing unreadable
     // white-on-white text. 'auto' keeps OS/localStorage behavior.
+    document.documentElement.setAttribute('data-motion', motionMode);
     function resolveTheme() {
       if (pinnedColorScheme === 'light' || pinnedColorScheme === 'dark') return pinnedColorScheme;
       var t = localStorage.getItem('wl_theme');
@@ -179,7 +180,8 @@ const inlineManifestScript = inlineManifest
 
   <script>
     import { hydratePage, currentPageSlug } from '../lib/page-render';
-    function hydrateChrome() { void hydratePage(currentPageSlug()); }
+    import { initDelight } from '../lib/delight';
+    function hydrateChrome() { void hydratePage(currentPageSlug()).finally(initDelight); }
     hydrateChrome();
     document.addEventListener('astro:after-swap', hydrateChrome);
     document.addEventListener('wl-locale-changed', hydrateChrome);

--- a/src/lib/chrome-bake.ts
+++ b/src/lib/chrome-bake.ts
@@ -39,6 +39,9 @@ export interface BakedChrome {
    * for token-driven native sites.
    */
   colorScheme: 'light' | 'dark' | 'auto';
+  /** theme.motion: 'subtle' (default — scroll-reveal + stat count-up via
+   *  src/lib/delight.ts) or 'none' to keep every page static. */
+  motion: 'subtle' | 'none';
   bakeCtx: BlockRenderContext;
 }
 
@@ -287,6 +290,7 @@ export function bakeChrome(seed: ProjectSeed, pageTitle: string): BakedChrome {
     cdnOrigin: cdnOriginFromManifest(bakeCtx.manifest),
     themeFontVarsCss: themeFontVarLines.join(' '),
     colorScheme: colorSchemeFromTheme(theme),
+    motion: theme.motion === 'none' ? 'none' : 'subtle',
     bakeCtx,
   };
 }

--- a/src/lib/delight.ts
+++ b/src/lib/delight.ts
@@ -1,0 +1,115 @@
+/**
+ * Subtle motion polish — section scroll-reveal and stat count-up.
+ *
+ * Inspired by React Bits (reactbits.dev, MIT: AnimatedContent / CountUp),
+ * reimplemented dependency-free for the Kychon substrate: IntersectionObserver
+ * plus CSS transitions, no gsap/motion payload.
+ *
+ * Design constraints (load-bearing — the concierge parity gates check them):
+ * - Progressive enhancement only: the pre-animation hidden state is applied
+ *   BY JS, never by static CSS, so no-JS readers, crawlers, and the no-JS
+ *   parity harness always see full content.
+ * - `prefers-reduced-motion: reduce` disables everything.
+ * - Sections already inside the initial viewport are never hidden — first
+ *   paint and LCP stay identical.
+ * - `theme.motion: "none"` (html[data-motion="none"]) turns it all off;
+ *   the default is "subtle".
+ */
+
+const REVEAL_ATTR = 'data-reveal';
+const STAT_ATTR = 'data-stat-value';
+const COUNT_DURATION_MS = 900;
+
+function motionEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (document.documentElement.getAttribute('data-motion') === 'none') return false;
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
+  return typeof IntersectionObserver !== 'undefined';
+}
+
+/** Parse "1,234+" / "$50" / "98%" into countable parts. Null when the text
+ *  has no usable number (e.g. "24/7") — those stats stay static. */
+export function parseStatValue(text: string): { prefix: string; value: number; suffix: string; grouped: boolean } | null {
+  const match = text.trim().match(/^([^0-9]*?)(\d{1,3}(?:,\d{3})+|\d+)([^0-9]*)$/);
+  if (!match) return null;
+  const grouped = match[2].includes(',');
+  const value = Number(match[2].replace(/,/g, ''));
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return { prefix: match[1], value, suffix: match[3], grouped };
+}
+
+export function formatStatValue(n: number, grouped: boolean): string {
+  const rounded = Math.round(n);
+  return grouped ? rounded.toLocaleString('en-US') : String(rounded);
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - (1 - t) ** 3;
+}
+
+function countUp(el: HTMLElement): void {
+  const original = el.textContent ?? '';
+  const parsed = parseStatValue(original);
+  if (!parsed) return;
+  const start = performance.now();
+  const tick = (now: number) => {
+    const t = Math.min(1, (now - start) / COUNT_DURATION_MS);
+    const current = parsed.value * easeOutCubic(t);
+    el.textContent = `${parsed.prefix}${formatStatValue(current, parsed.grouped)}${parsed.suffix}`;
+    if (t < 1) requestAnimationFrame(tick);
+    else el.textContent = original;
+  };
+  requestAnimationFrame(tick);
+}
+
+function initSectionReveal(): void {
+  const sections = document.querySelectorAll<HTMLElement>('[data-section-zone="main"]');
+  if (sections.length === 0) return;
+  const fold = window.innerHeight;
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        entry.target.setAttribute(REVEAL_ATTR, 'in');
+        observer.unobserve(entry.target);
+      }
+    },
+    { rootMargin: '0px 0px -8% 0px' },
+  );
+  for (const section of sections) {
+    if (section.hasAttribute(REVEAL_ATTR)) continue;
+    // Never hide what the visitor can already see.
+    if (section.getBoundingClientRect().top < fold) {
+      section.setAttribute(REVEAL_ATTR, 'in');
+      continue;
+    }
+    section.setAttribute(REVEAL_ATTR, '');
+    observer.observe(section);
+  }
+}
+
+function initCountUp(): void {
+  const values = document.querySelectorAll<HTMLElement>(`[${STAT_ATTR}]`);
+  if (values.length === 0) return;
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      const el = entry.target as HTMLElement;
+      observer.unobserve(el);
+      if (el.getAttribute(STAT_ATTR) === 'done') continue;
+      el.setAttribute(STAT_ATTR, 'done');
+      countUp(el);
+    }
+  });
+  for (const el of values) {
+    if (el.getAttribute(STAT_ATTR) === 'done') continue;
+    observer.observe(el);
+  }
+}
+
+/** Idempotent; call on page load and again after swaps/section re-renders. */
+export function initDelight(): void {
+  if (!motionEnabled()) return;
+  initSectionReveal();
+  initCountUp();
+}

--- a/src/styles/public.css
+++ b/src/styles/public.css
@@ -82,6 +82,29 @@ a:hover {
   color: var(--ky-color-primary-hover, var(--color-primary-hover));
 }
 
+/* Subtle motion (src/lib/delight.ts). The hidden pre-state is keyed off a
+   JS-applied attribute so no-JS readers always see full content; reduced
+   motion collapses everything to static. */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(8px);
+}
+[data-reveal='in'] {
+  opacity: 1;
+  transform: none;
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal],
+  [data-reveal='in'] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
 /* Nav */
 [data-nav-shell] {
   background: var(--nav-header-bg, var(--background, var(--color-bg)));

--- a/tests/unit/delight.test.ts
+++ b/tests/unit/delight.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { formatStatValue, parseStatValue } from '../../src/lib/delight';
+
+const root = join(import.meta.dirname, '../..');
+const portal = readFileSync(join(root, 'src/layouts/Portal.astro'), 'utf8');
+const css = readFileSync(join(root, 'src/styles/public.css'), 'utf8');
+const delight = readFileSync(join(root, 'src/lib/delight.ts'), 'utf8');
+const marketing = readFileSync(join(root, 'src/components/kychon/MarketingBlocksView.tsx'), 'utf8');
+
+describe('stat value parsing', () => {
+  it('parses plain, grouped, and affixed numbers', () => {
+    expect(parseStatValue('1200')).toEqual({ prefix: '', value: 1200, suffix: '', grouped: false });
+    expect(parseStatValue('1,200+')).toEqual({ prefix: '', value: 1200, suffix: '+', grouped: true });
+    expect(parseStatValue('$50')).toEqual({ prefix: '$', value: 50, suffix: '', grouped: false });
+    expect(parseStatValue('98%')).toEqual({ prefix: '', value: 98, suffix: '%', grouped: false });
+  });
+
+  it('leaves unparseable or zero stats static', () => {
+    expect(parseStatValue('24/7')).toBeNull();
+    expect(parseStatValue('—')).toBeNull();
+    expect(parseStatValue('0')).toBeNull();
+  });
+
+  it('formats grouped values with separators', () => {
+    expect(formatStatValue(1199.6, true)).toBe('1,200');
+    expect(formatStatValue(42.2, false)).toBe('42');
+  });
+});
+
+describe('delight wiring invariants', () => {
+  it('the hidden pre-state is JS-applied, never static CSS on sections', () => {
+    // Static CSS may only hide [data-reveal] (set by delight.ts at runtime);
+    // a bare [data-section] must never be hidden for no-JS readers.
+    expect(css).toContain("[data-reveal] {");
+    expect(css).not.toMatch(/\[data-section\][^{]*\{[^}]*opacity:\s*0/);
+  });
+
+  it('reduced motion collapses reveal to static', () => {
+    expect(css).toContain('prefers-reduced-motion: reduce');
+    expect(delight).toContain("matchMedia('(prefers-reduced-motion: reduce)')");
+  });
+
+  it('theme.motion none disables and Portal stamps the mode', () => {
+    expect(delight).toContain("getAttribute('data-motion') === 'none'");
+    expect(portal).toContain("setAttribute('data-motion', motionMode)");
+    expect(portal).toContain('initDelight');
+  });
+
+  it('in-viewport sections are never hidden (LCP safety)', () => {
+    expect(delight).toContain('getBoundingClientRect().top < fold');
+  });
+
+  it('stats expose the count-up hook with motion-reduce guards on the lift', () => {
+    expect(marketing).toContain('data-stat-value=""');
+    expect(marketing).toContain('motion-reduce:transform-none');
+  });
+});


### PR DESCRIPTION
A touch of modernization from the React Bits catalog (reactbits.dev, MIT — AnimatedContent/CountUp patterns), reimplemented dependency-free (IntersectionObserver + CSS transitions, no gsap/motion payload):

- **Section scroll-reveal** — main-zone sections fade in with an 8px rise, once, below-the-fold only.
- **Stat count-up** — `stats` block values animate 0→value on first view; parses `1,200+`, `$50`, `98%` shapes, leaves `24/7`-style strings static.
- **Card hover lift** — stats/promo cards rise 2px with a soft shadow on hover.

Deliberately not included: particles, shiny/split text, tilt, click sparks — wrong register for club/association sites.

Invariants (unit-tested in `tests/unit/delight.test.ts`):
- Hidden pre-state is **JS-applied only** — no-JS readers, crawlers, and the concierge no-JS parity harness always see full content (static CSS hiding `[data-section]` is test-banned).
- `prefers-reduced-motion: reduce` collapses everything to static (CSS + JS + Tailwind `motion-reduce:` on the lifts).
- Sections in the initial viewport are never hidden — first paint and LCP unchanged.
- `theme.motion: "none"` opts a site out; default `"subtle"`.

Gates: vitest 1055/1055, biome clean, astro check clean, tsc scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)