### PR TITLE
Fix biome quote style in delight test

### DIFF
--- a/tests/unit/delight.test.ts
+++ b/tests/unit/delight.test.ts
@@ -34,7 +34,7 @@ describe('delight wiring invariants', () => {
   it('the hidden pre-state is JS-applied, never static CSS on sections', () => {
     // Static CSS may only hide [data-reveal] (set by delight.ts at runtime);
     // a bare [data-section] must never be hidden for no-JS readers.
-    expect(css).toContain("[data-reveal] {");
+    expect(css).toContain('[data-reveal] {');
     expect(css).not.toMatch(/\[data-section\][^{]*\{[^}]*opacity:\s*0/);
   });
 


### PR DESCRIPTION
One-line lint fix: #134 merged with a red Lint check (single-quote style in `tests/unit/delight.test.ts`). Restores green CI on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)