### PR TITLE
Mailchimp embed provider + newsletter-signup spec

### DIFF
--- a/openspec/changes/add-newsletter-signup/design.md
+++ b/openspec/changes/add-newsletter-signup/design.md
@@ -1,0 +1,33 @@
+# Design — newsletter signup
+
+## Context
+
+Wild Apricot parity target (gethelp.wildapricot.com article 420): per-form
+subscription source, contact-field reuse, optional confirmation email,
+admin search by source, manual blasts. Kychon equivalents: block registry,
+functions + capability registry, admin surface, run402 `email` helper.
+
+## Decisions
+
+1. **Separate `subscribers` table, not `members`.** WA piggybacks on
+   contacts; Kychon's members table carries membership semantics (tiers,
+   status, auth) that newsletter subscribers must not inherit. A dedicated
+   table keeps RLS simple: anon INSERT via the function only, admin SELECT.
+2. **Block + function, not PostgREST insert.** The function owns honeypot
+   checking, per-IP throttling, normalization (lowercase email), idempotent
+   re-subscribe, and the optional confirmation email — none of which belong
+   client-side.
+3. **Single opt-in v1** (WA parity). `status` starts `subscribed`;
+   `confirmed_at` column reserved for a future double-opt-in option.
+4. **Unsubscribe**: tokened GET route (`/unsubscribe?t=…`) flips status;
+   token stored per subscriber; included in confirmation email footer.
+5. **No-JS path**: the block renders a real form; the function accepts form
+   POSTs and returns a friendly thanks/error page server-side; JS enhances
+   inline.
+
+## Risks / Trade-offs
+
+- Spam without CAPTCHA: honeypot + throttle first; provider CAPTCHA only if
+  observed abuse demands it (WA itself ships none on this gadget).
+- The SSR-baked form must not break parity gates: block markup is engine
+  HTML (not sanitized user content), so form controls survive.

--- a/openspec/changes/add-newsletter-signup/proposal.md
+++ b/openspec/changes/add-newsletter-signup/proposal.md
@@ -1,0 +1,42 @@
+# Add first-class newsletter signup (Wild Apricot subscription-form parity)
+
+## Why
+
+Email capture is table-stakes for the club/association market. Wild Apricot
+ships an "Email subscription form gadget": visitors submit contact fields
+(email mandatory), a contact is created/updated stamped with a per-form
+"Subscription source", an optional confirmation email goes to the subscriber
+and/or administrator, and admins build blast lists by searching on that
+source. Kychon has no subscribers concept at all, so ported sites that use
+the native gadget must drop their form (the rich-text sanitizer rightly
+strips form controls from page content), and native Kychon sites can't
+capture interest from non-members.
+
+Sites that embed a third-party form (Mailchimp — e.g. WSMTA) are already
+served by the `mailchimp` embed provider; this change covers the
+WA-native-gadget case and gives Kychon its own capture surface.
+
+## What Changes
+
+- `subscribers` table: email (unique), optional name fields,
+  `subscription_source`, `status` (`subscribed` | `unsubscribed`), consent
+  provenance (source page, timestamps), unsubscribe token.
+- `newsletter_signup` block: configurable heading/blurb/button and field
+  subset (email always), per-instance `subscription_source`; honeypot field;
+  posts to a `newsletter-subscribe` function (anonymous capability,
+  rate-limited in-function).
+- Optional confirmation email to subscriber and/or admin per block config
+  (single opt-in, matching WA; double opt-in is a later option).
+- Capability ops: `subscribers.create` (anon), `subscribers.list` filtered
+  by source (admin), tokened `subscribers.unsubscribe`; CSV export via the
+  admin surface.
+
+## Impact
+
+- Affected specs: `newsletter-signup` (new)
+- Affected code: `schema.sql`, `src/lib/blocks.ts` (+ block view),
+  `functions/newsletter-subscribe.js`, `functions/kychon-api.js`
+  (capability registry), admin surface, seeds/tests.
+- Out of scope: campaign/bulk sending (admins export and blast from their
+  existing tool, mirroring WA's manual-blast model); run402 needs nothing —
+  the `email` runtime helper covers confirmations.

--- a/openspec/changes/add-newsletter-signup/specs/newsletter-signup/spec.md
+++ b/openspec/changes/add-newsletter-signup/specs/newsletter-signup/spec.md
@@ -1,0 +1,81 @@
+# newsletter-signup Specification
+
+## ADDED Requirements
+
+### Requirement: Visitors can subscribe through a first-class block
+
+The engine SHALL provide a `newsletter_signup` block whose markup is
+engine-rendered HTML (never sanitized user content), collecting email
+(always) plus an admin-configured subset of name fields, tagged with a
+per-instance `subscription_source`, and submitting to the
+`newsletter-subscribe` function. The form SHALL work without JavaScript via
+a server-rendered response page; JavaScript MAY enhance the result inline.
+
+#### Scenario: Subscription creates a tagged subscriber
+
+- **WHEN** a visitor submits a valid email on a block whose
+  `subscription_source` is "Newsletter"
+- **THEN** a `subscribers` row exists with that email, source "Newsletter",
+  and status `subscribed`
+- **AND** resubmitting the same email succeeds idempotently without a
+  duplicate row
+
+#### Scenario: No-JS submission still lands
+
+- **WHEN** the form is posted with JavaScript disabled
+- **THEN** the function returns a human-readable confirmation page
+- **AND** the subscriber row is created
+
+### Requirement: Abuse controls live in the function
+
+The `newsletter-subscribe` function SHALL reject submissions whose honeypot
+field is filled, SHALL throttle repeated submissions per source address,
+and SHALL normalize emails (trim, lowercase) before upsert.
+
+#### Scenario: Honeypot rejects bots silently
+
+- **WHEN** a submission arrives with the honeypot field non-empty
+- **THEN** no subscriber row is created
+- **AND** the response is indistinguishable from success
+
+### Requirement: Optional confirmation email matches Wild Apricot parity
+
+Each block instance SHALL be configurable to send a confirmation email to
+the subscriber, the administrator, both, or neither (single opt-in; a
+`confirmed_at` column is reserved for future double opt-in). Confirmation
+emails SHALL include the tokened unsubscribe link.
+
+#### Scenario: Subscriber confirmation carries unsubscribe
+
+- **WHEN** a block configured with subscriber confirmation receives a valid
+  submission
+- **THEN** the subscriber receives one confirmation email
+- **AND** it contains their tokened unsubscribe link
+
+### Requirement: Admins can build blast lists by source
+
+Admin-only capability operations SHALL list subscribers filtered by
+`subscription_source` and export them as CSV from the admin surface;
+anonymous callers SHALL have no read access to subscriber rows.
+
+#### Scenario: Source-filtered export
+
+- **WHEN** an admin exports subscribers for source "Newsletter"
+- **THEN** the CSV contains exactly the subscribed rows tagged "Newsletter"
+
+#### Scenario: Anonymous read is denied
+
+- **WHEN** an anonymous caller invokes `subscribers.list`
+- **THEN** the request is rejected with a permission error
+
+### Requirement: Unsubscribe is tokened and immediate
+
+A tokened unsubscribe link SHALL flip the subscriber's status to
+`unsubscribed` without authentication and SHALL be idempotent; exports and
+list operations SHALL exclude unsubscribed rows by default.
+
+#### Scenario: Unsubscribe excludes from future exports
+
+- **WHEN** a subscriber follows their unsubscribe link
+- **THEN** their status is `unsubscribed`
+- **AND** a subsequent default export for their source omits them

--- a/openspec/changes/add-newsletter-signup/tasks.md
+++ b/openspec/changes/add-newsletter-signup/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — add-newsletter-signup
+
+## 1. Schema + function
+
+- [ ] 1.1 `subscribers` table in schema.sql (+ RLS) with unsubscribe token
+- [ ] 1.2 `functions/newsletter-subscribe.js`: validate, honeypot, throttle,
+      upsert, optional confirmation email (subscriber and/or admin), no-JS
+      form-POST response page
+- [ ] 1.3 Capability registry: `subscribers.create` (anon),
+      `subscribers.list` (admin, filter by source), `subscribers.unsubscribe`
+
+## 2. Block + admin
+
+- [ ] 2.1 `newsletter_signup` block (registry + view): heading/blurb/button,
+      field subset, `subscription_source`, honeypot; SSR-baked markup
+- [ ] 2.2 Unsubscribe route + token flow
+- [ ] 2.3 Admin surface: subscribers list filtered by source + CSV export
+
+## 3. Acceptance
+
+- [ ] 3.1 Unit tests: function validation/throttle/honeypot; block source
+      tests; capability visibility
+- [ ] 3.2 Demo seed gains a newsletter_signup block; demo smoke passes
+- [ ] 3.3 Concierge: port WA-native subscription gadgets onto
+      `newsletter_signup` (skill update lands with this change's release)

--- a/src/lib/blocks/embed-providers.ts
+++ b/src/lib/blocks/embed-providers.ts
@@ -447,6 +447,53 @@ const typeform: EmbedProvider = {
   trustLevel: 'verified',
 };
 
+const mailchimp: EmbedProvider = {
+  id: 'mailchimp',
+  label: 'Mailchimp signup',
+  icon: '\u{1F4E7}',
+  buildSrc(params) {
+    // Accepts the action/hosted URL from a Mailchimp embed
+    // (https://<audience>.<dc>.list-manage.com/subscribe/post?u=…&id=…)
+    // and normalises it to the hosted, iframe-able subscribe page
+    // (verified: Mailchimp serves it without X-Frame-Options or
+    // frame-ancestors). Copied websites keep feeding the club's existing
+    // Mailchimp audience instead of losing the form.
+    const raw = requireString(params, 'signup_url').trim();
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      throw new Error('Mailchimp signup_url must be a valid URL');
+    }
+    if (!/^[a-z0-9][a-z0-9.-]*\.list-manage\.com$/.test(url.hostname)) {
+      throw new Error('Mailchimp signup_url must be on *.list-manage.com');
+    }
+    const u = url.searchParams.get('u');
+    const id = url.searchParams.get('id');
+    if (!u || !id || !/^[A-Za-z0-9]+$/.test(u) || !/^[A-Za-z0-9]+$/.test(id)) {
+      throw new Error('Mailchimp signup_url must include the u and id audience params');
+    }
+    const embed = new URL(`https://${url.hostname}/subscribe`);
+    embed.searchParams.set('u', u);
+    embed.searchParams.set('id', id);
+    return embed.toString();
+  },
+  paramsSchema: {
+    signup_url: {
+      type: 'text',
+      required: true,
+      label: 'Mailchimp signup URL',
+      help: 'The form action or hosted signup link (…list-manage.com/subscribe…?u=…&id=…)',
+      placeholder: 'https://example.us15.list-manage.com/subscribe/post?u=…&id=…',
+    },
+  },
+  sandbox: ['allow-scripts', 'allow-same-origin', 'allow-forms', 'allow-popups'],
+  frameAncestor: 'https://*.list-manage.com',
+  defaultHeight: '600px',
+  responsive: false,
+  trustLevel: 'verified',
+};
+
 const iframe: EmbedProvider = {
   id: 'iframe',
   label: 'Generic iframe (untrusted source)',
@@ -496,6 +543,7 @@ export const PROVIDERS: Record<string, EmbedProvider> = {
   eventbrite,
   google_forms: googleForms,
   typeform,
+  mailchimp,
   iframe,
 };
 

--- a/tests/unit/embed-providers.test.ts
+++ b/tests/unit/embed-providers.test.ts
@@ -283,16 +283,14 @@ describe('mailchimp buildSrc', () => {
   });
 
   it('rejects non-list-manage hosts', () => {
-    expect(() => buildSrc({ signup_url: 'https://evil.example.com/subscribe?u=a1&id=b2' })).toThrow(
-      /list-manage\.com/,
-    );
+    expect(() => buildSrc({ signup_url: 'https://evil.example.com/subscribe?u=a1&id=b2' })).toThrow(/list-manage\.com/);
     expect(() => buildSrc({ signup_url: 'https://list-manage.com.evil.example/subscribe?u=a1&id=b2' })).toThrow();
   });
 
   it('rejects missing or malformed audience params', () => {
     expect(() => buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe/post' })).toThrow(/u and id/);
-    expect(() =>
-      buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe/post?u=<script>&id=b2' }),
-    ).toThrow(/u and id/);
+    expect(() => buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe/post?u=<script>&id=b2' })).toThrow(
+      /u and id/,
+    );
   });
 });

--- a/tests/unit/embed-providers.test.ts
+++ b/tests/unit/embed-providers.test.ts
@@ -9,13 +9,14 @@ function provider(id: keyof typeof PROVIDERS) {
 }
 
 describe('PROVIDERS registry shape', () => {
-  it('includes the v1 providers + admin-content-management expansion (12 total)', () => {
+  it('includes the v1 providers + expansions (13 total)', () => {
     const ids = Object.keys(PROVIDERS).sort();
     expect(ids).toEqual([
       'calendly',
       'eventbrite',
       'google_forms',
       'iframe',
+      'mailchimp',
       'map',
       'soundcloud',
       'spotify',
@@ -56,6 +57,7 @@ describe('PROVIDERS registry shape', () => {
       'eventbrite',
       'google_forms',
       'typeform',
+      'mailchimp',
     ] as const) {
       expect(provider(id).trustLevel, id).toBe('verified');
     }
@@ -259,5 +261,38 @@ describe('sandbox tokens are exact and minimal', () => {
 
   it('iframe (generic) has the strict default', () => {
     expect(provider('iframe').sandbox).toEqual(['allow-scripts', 'allow-same-origin']);
+  });
+});
+
+describe('mailchimp buildSrc', () => {
+  const { buildSrc } = provider('mailchimp');
+
+  it('normalises a classic embed action URL to the hosted subscribe page', () => {
+    expect(
+      buildSrc({
+        signup_url:
+          'https://mywsmta.us15.list-manage.com/subscribe/post?u=8f3d8f4db0f5983f562cb9f4f&id=82a9fb946b&f_id=00a2a7e1f0',
+      }),
+    ).toBe('https://mywsmta.us15.list-manage.com/subscribe?u=8f3d8f4db0f5983f562cb9f4f&id=82a9fb946b');
+  });
+
+  it('accepts an already-hosted subscribe link', () => {
+    expect(buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe?u=abc123&id=def456' })).toBe(
+      'https://x.us2.list-manage.com/subscribe?u=abc123&id=def456',
+    );
+  });
+
+  it('rejects non-list-manage hosts', () => {
+    expect(() => buildSrc({ signup_url: 'https://evil.example.com/subscribe?u=a1&id=b2' })).toThrow(
+      /list-manage\.com/,
+    );
+    expect(() => buildSrc({ signup_url: 'https://list-manage.com.evil.example/subscribe?u=a1&id=b2' })).toThrow();
+  });
+
+  it('rejects missing or malformed audience params', () => {
+    expect(() => buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe/post' })).toThrow(/u and id/);
+    expect(() =>
+      buildSrc({ signup_url: 'https://x.us2.list-manage.com/subscribe/post?u=<script>&id=b2' }),
+    ).toThrow(/u and id/);
   });
 });


### PR DESCRIPTION
Two halves of the newsletter answer for ported sites ([concierge#39](https://github.com/kychee-com/kychon-concierge/issues/39) refuter finding; WA docs read):

1. **`mailchimp` verified embed provider** — WSMTA's form is a Mailchimp classic embed, and the sanitizer (rightly) strips form controls from page content, so the form needs a first-class carrier. The provider takes the embed action URL, validates host (`*.list-manage.com`) + audience params, and normalises to the hosted subscribe page — verified live to serve without `X-Frame-Options`/`frame-ancestors`. Submissions keep feeding the club's existing Mailchimp audience.
2. **`add-newsletter-signup` openspec change (spec only)** — for WA sites using the *native* subscription gadget: `subscribers` table + `newsletter_signup` block + anon `newsletter-subscribe` function, scoped to WA parity (per-form `subscription_source`, single opt-in with optional subscriber/admin confirmation, admin search/export by source, tokened unsubscribe). `openspec validate --strict` passes. No run402 feature needed (the `email` runtime helper covers confirmations).

Gates: vitest 1059/1059 (4 new provider tests incl. the registry-shape update), biome clean, astro check clean, tsc scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)