### PR TITLE
Consume the nav dropdown_* config vars (dead config behind white-on-white #2)

### DIFF
--- a/src/styles/public.css
+++ b/src/styles/public.css
@@ -271,6 +271,27 @@ a:hover {
   width: 100%;
   margin-left: 0;
 }
+/* Dropdown panel + items honor the nav block's dropdown_* config (these
+   vars were set by blocks.ts but previously consumed nowhere — dead
+   config forced ports into !important custom-CSS hammers that bled bar
+   colors onto the light popover; wsmta white-on-white #2). The doubled
+   attribute selector outranks single-class utility styles so the config
+   wins over the component defaults; !important custom CSS still beats
+   everything, which is why the concierge skill bans it for chrome. */
+[data-nav-shell] [data-nav-menu][data-nav-menu] {
+  background: var(--nav-dropdown-bg, var(--popover, var(--color-surface)));
+  color: var(--nav-dropdown-color, var(--muted-foreground, var(--color-text-muted)));
+}
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem],
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem-parent][data-nav-menuitem-parent] {
+  color: var(--nav-dropdown-color, var(--muted-foreground, var(--color-text-muted)));
+}
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem]:hover,
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem]:focus {
+  background: var(--nav-dropdown-hover-bg, var(--accent, var(--color-surface)));
+  color: var(--nav-dropdown-hover-color, var(--accent-foreground, var(--color-text)));
+}
+
 [data-nav-link],
 [data-nav-parent-trigger] {
   padding: var(--nav-link-padding, 0.5rem 0.75rem);

--- a/tests/unit/nav-dropdown-config-source.test.ts
+++ b/tests/unit/nav-dropdown-config-source.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(import.meta.dirname, '../..');
+const css = readFileSync(join(root, 'src/styles/public.css'), 'utf8');
+const blocks = readFileSync(join(root, 'src/lib/blocks.ts'), 'utf8');
+
+describe('nav dropdown config consumption', () => {
+  it('every dropdown var the nav block sets is consumed by the stylesheet', () => {
+    // Dead config is how the wsmta port ended up styling the bar with
+    // subtree-wide !important rules that bled onto the light popover.
+    for (const v of [
+      '--nav-dropdown-bg',
+      '--nav-dropdown-color',
+      '--nav-dropdown-hover-bg',
+      '--nav-dropdown-hover-color',
+    ]) {
+      expect(blocks, `${v} set`).toContain(`setNavStyle(style, '${v}'`);
+      expect(css, `${v} consumed`).toContain(`var(${v}`);
+    }
+  });
+
+  it('dropdown rules outrank single-class utilities via doubled attributes', () => {
+    expect(css).toContain('[data-nav-menu][data-nav-menu]');
+    expect(css).toContain('[data-nav-menuitem][data-nav-menuitem]');
+  });
+});


### PR DESCRIPTION
Operator QA found white dropdown items on the light popover panel on wsmta-port. Root cause chain:

1. **Dead config**: `blocks.ts` sets `--nav-dropdown-bg/color/hover-*` from nav config, but nothing consumed them (compare `--nav-link-color`, consumed in public.css). The proper lever silently did nothing.
2. With config dead, the port styled its dark bar via `[data-nav-root] a … { color:#ffffff !important }` — which bleeds onto the dropdown's DOM descendants, bulldozing the engine's `text-muted-foreground` items.
3. The concierge contrast gate sweeps only visible text; dropdown items hide until hover (gate extension lands concierge-side).

This PR wires the vars: panel + items + hover honor `dropdown_bg`/`dropdown_color`/`dropdown_hover_*` via doubled-attribute selectors (outrank single-class utilities; `!important` hammers get banned in the skill instead). Regression test asserts every dropdown var the block sets is consumed.

Gates: vitest full suite green, biome clean, astro check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)