### PR TITLE
fix: triage and fix 12 open bugs (polls, RSVP, capability API, config, CI)

### DIFF
--- a/.claude/skills/bugs/SKILL.md
+++ b/.claude/skills/bugs/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: bugs
+description: Automated bug triage and fix pipeline for Kychon. Fetches open GitHub Issues, performs root cause analysis, writes failing tests, fixes bugs in isolated worktrees, and deploys. Use when the user says /bugs, "check for bugs", "triage bugs", "work on the gh issues", or "fix production errors".
+---
+
+# /bugs — Triage, Fix, Deploy
+
+Autonomous bug triage pipeline. Fetches all open GitHub issues, analyzes root causes, fixes what can be fixed, and deploys.
+
+> Adapted from the run402 `bugs` skill. Differences: GitHub Issues only (Kychon has no Bugsnag), targets `kychee-com/kychon`, and uses Kychon's Vitest/Biome/Astro tooling + `deploy` skill. For *finding new* bugs and filing them as issues, use the `qa` skill instead — this skill triages and fixes issues that already exist.
+
+Execute all steps in order. Do NOT ask for confirmation until Step 6.
+
+## Step 1: Fetch all open issues
+
+`gh issue list` defaults to **30 results** — without an explicit `--limit`, anything past the first 30 is silently dropped. Pass `--limit 1000` so the triage sees every open issue:
+
+```
+gh issue list --repo kychee-com/kychon --state open --limit 1000 --json number,title,body,labels,createdAt
+```
+
+After the fetch, sanity-check the count against the totals shown on the GitHub Issues tab. If you see exactly 30 (or 100, or another round number), suspect a hidden cap and re-run with a higher `--limit`.
+
+Assign each bug an ID for reference throughout the pipeline: `GH-<number>` (using the actual issue number).
+
+If zero issues found, report "No open bugs" and stop.
+
+## Step 2: Root cause analysis
+
+For each bug:
+
+1. Read the issue title, body, and any labels
+2. Trace through the source code — Kychon source lives in `src/` (Astro pages/components/lib), `functions/` (Run402 edge functions), and `scripts/` (deploy/seed tooling)
+3. Check git log to see if the relevant code has already been changed
+4. Categorize into exactly one bucket:
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| `already-fixed` | Code already changed, or the issue can no longer be reproduced after a deploy | Close |
+| `not-a-bug` | Expected behavior, transient infra blip, or user error | Close with explanation |
+| `needs-spec-change` | "Bug" is actually missing functionality or a design decision | Flag as feature request — do NOT fix |
+| `fixable` | Real code bug with a clear fix | Spawn fix agent |
+
+Print a summary table as you go so progress is visible.
+
+## Step 3: Close resolved bugs and flag feature requests
+
+This step closes ONLY `already-fixed` and `not-a-bug` reports — bugs whose resolution is already in production. **Bugs in the `fixable` bucket are NEVER closed here** — their close happens in Step 7c, only after the new fix is deployed AND health-verified.
+
+### Already-fixed / not-a-bug
+
+Before closing an `already-fixed` bug, confirm the referenced commit is actually deployed. A push to `main` auto-deploys all demos via patchDeploy, so verify CI is green for that SHA (or a later one): `gh run list --repo kychee-com/kychon --branch main`. A merged-but-not-deployed fix is NOT a close criterion.
+
+```
+gh issue close <NUMBER> --repo kychee-com/kychon --comment "<one-line explanation>"
+```
+
+### Needs-spec-change
+
+Add label and comment, do NOT close:
+
+```
+gh issue edit <NUMBER> --repo kychee-com/kychon --add-label "feature-request"
+gh issue comment <NUMBER> --repo kychee-com/kychon --body "Triaged as feature request: <explanation>"
+```
+
+If no fixable bugs remain, skip to Step 5.
+
+## Step 4: Fix bugs in isolated worktrees
+
+For each fixable bug, launch an Agent tool call with `isolation: "worktree"`. Launch all fixable bugs in parallel (single message, multiple Agent tool calls).
+
+Each agent prompt MUST be self-contained — include the literal issue details, file paths, and root cause analysis. The agent has no access to this conversation's context.
+
+**Agent prompt template:**
+
+> Fix bug {ID}: {issue title}
+>
+> Root cause: {analysis}
+> Files: {file paths with line numbers}
+>
+> Steps:
+> 1. Write a failing test in the appropriate `*.test.ts` file under `tests/unit/` or `tests/integration/` (Vitest — `import { describe, expect, it } from 'vitest'`, matching existing tests; happy-dom + fast-check are available)
+> 2. Run the test to confirm it fails: `npx vitest run <test-file>`
+> 3. Implement the fix in the source file (`src/`, `functions/`, or `scripts/`)
+> 4. Run the test again to confirm it passes: `npx vitest run <test-file>`
+> 5. Run `npx biome check .` from the repo root
+> 6. Run `npx tsc --noEmit --project jsconfig.json` from the repo root
+> 7. If all pass, commit with message: `fix(<scope>): <description>`
+>    Add `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` to the commit.
+>    **Do NOT include `Closes #N` / `Fixes #N` / `Resolves #N` trailers or any other GitHub close-keyword referencing the bug.** GitHub auto-closes those issues the moment the commit lands on `main`, and a push to `main` auto-deploys, so the close races the deploy and closes the bug before production verification — violating the after-deploy-only rule in Step 7c. Reference the issue with a bare `#N` link in the body if useful; close happens in Step 7c.
+> 8. If any step fails, do NOT commit. Report what went wrong.
+>
+> IMPORTANT: Never use `$()` command substitution in shell commands. Run commands separately and use literal values.
+
+If more than 10 fixable bugs are found, warn the user and suggest batching before spawning agents.
+
+## Step 5: Report
+
+After all agents complete (or if there were no fixable bugs), present the full report:
+
+```
+## Bug Triage Report
+
+### Summary
+- Total: N open issues
+- Closed (already-fixed): N
+- Closed (not-a-bug): N
+- Feature requests (flagged): N
+- Fixes ready: N
+- Fix failures: N
+
+### Fixes Ready to Merge
+| ID | Title | Worktree Branch | Test | Lint | TSC |
+|---|---|---|---|---|---|
+
+### Failed Fixes (if any)
+| ID | Title | What went wrong |
+|---|---|---|
+
+### Closed Bugs
+| ID | Title | Reason |
+|---|---|---|
+
+### Feature Requests (not auto-fixed)
+| ID | Title | Recommendation |
+|---|---|---|
+```
+
+If there are no fixes to merge, stop here.
+
+## Step 6: User decision
+
+Use AskUserQuestion with these options:
+- **Merge all** — merge all ready fixes, deploy, and close bugs
+- **Exclude specific bugs** — let the user type which bug IDs to skip
+
+Wait for the user's response before proceeding.
+
+## Step 7: Merge, deploy, close
+
+### 7a. Merge fix branches
+
+For each included fix, the Agent tool with `isolation: "worktree"` returns the worktree path and branch name. Merge each branch:
+
+```
+git merge <branch-name> --no-edit
+```
+
+If a merge conflict occurs, stop and report which branches conflict. Let the user resolve manually.
+
+### 7b. Deploy
+
+Invoke the deploy skill:
+
+```
+Use the Skill tool: Skill(skill: "deploy")
+```
+
+This runs Kychon's full pipeline: quality checks (`npm run check`), commit, push, deploy to Run402, Chrome verification, and GitHub release. The push to `main` auto-deploys all 3 demos via patchDeploy; monitor CI to completion.
+
+### 7c. Close fixed bugs
+
+**Close ONLY after the deploy pipeline is live and verified in production.** Specifically, ALL of these must be true before issuing a single close command:
+
+1. CI workflow status is `completed` with conclusion `success` for the pushed SHA on `kychee-com/kychon` (`gh run list --repo kychee-com/kychon --branch main`). Since the push auto-deploys all 3 demos, this covers the fleet.
+2. The deploy skill's Chrome verification of the affected demo site(s) passed — the changed behavior is confirmed live, not just built.
+
+CI green alone is NOT sufficient — a workflow can finish "success" before the new release is actually serving traffic. The live Chrome verification is what authorizes the close.
+
+If any of those checks fail, the bug stays open. Investigate via the deploy skill's troubleshooting steps, fix forward, re-deploy, and retry the close only after verification passes against the new deploy.
+
+```
+gh issue close <NUMBER> --repo kychee-com/kychon --comment "Fixed and deployed in <commit-hash>"
+```
+
+If a GitHub issue was already auto-closed by a `Closes #N` trailer that slipped through Step 4 (despite the rule there), still validate the post-deploy checks above, then add a confirming comment via `gh issue comment <NUMBER>` — do NOT trust the auto-close as a deploy signal.
+
+### 7d. Clean up
+
+Excluded fix worktrees are kept (user can revisit). Merged worktrees are cleaned up automatically by the Agent tool.
+
+Report final summary: which bugs were fixed, deployed, and closed.

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -66,11 +66,11 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -497,6 +497,10 @@ function handleQuery(correlationId, envelope, operation, actor) {
     return handleMediaList(correlationId, envelope.input, actor);
   }
 
+  if (operation.name === 'pollVotes.list') {
+    return handlePollVotesList(correlationId, envelope.input, actor);
+  }
+
   const tableQuery = TABLE_QUERIES[operation.name];
   if (tableQuery) {
     return handleTableQuery(correlationId, envelope.input, actor, tableQuery, operation.name);
@@ -621,6 +625,35 @@ async function handleSearchQuery(correlationId, input, actor, suggest) {
       retryable: true,
     });
   }
+}
+
+async function handlePollVotesList(correlationId, input, actor) {
+  try {
+    const votes = (await selectRows('poll_votes')).filter((row) => matchesInput(row, input));
+    const rows = await redactAnonymousVotes(votes);
+    return successResponse(correlationId, { rows, count: rows.length });
+  } catch (error) {
+    console.error('kychon-api poll votes list failed:', error);
+    return errorResponse(correlationId, 500, {
+      code: 'internal.error',
+      message: 'Query failed for poll_votes.',
+      retryable: true,
+    });
+  }
+}
+
+// For anonymous polls, voter identity SHALL NOT be exposed in API responses
+// (member_id stays in the DB only to enforce vote uniqueness). The redaction is
+// unconditional — anonymity applies to every caller, admins included. (#117)
+async function redactAnonymousVotes(votes) {
+  if (votes.length === 0) return votes;
+  const anonymousPollIds = new Set(
+    (await selectRows('polls')).filter((poll) => poll.is_anonymous === true).map((poll) => String(poll.id)),
+  );
+  if (anonymousPollIds.size === 0) return votes;
+  return votes.map((vote) =>
+    anonymousPollIds.has(String(vote.poll_id)) ? { ...vote, member_id: null } : vote,
+  );
 }
 
 async function handlePollResultsQuery(correlationId, input, actor) {
@@ -1098,6 +1131,14 @@ async function createPollAction(input, actor) {
 
 async function createPoll(input, actor) {
   // created_by is bound to the actor — never honored from input. (#24)
+  // A poll needs at least two options. Validate before inserting the poll row
+  // so an under-specified request never leaves an orphan poll behind. (#118)
+  const options = Array.isArray(input.options) ? input.options : [];
+  if (options.length < 2) {
+    throw capabilityError('validation.failed', 'A poll requires at least two options.', {
+      object: { type: 'poll', id: 'new' },
+    });
+  }
   const poll = await insertRow('polls', {
     question: input.question || 'Poll',
     description: input.description || null,
@@ -1110,7 +1151,6 @@ async function createPoll(input, actor) {
     attached_id: input.attached_id || input.attachedId || null,
     created_by: memberId(actor),
   });
-  const options = Array.isArray(input.options) ? input.options : [];
   let position = 0;
   for (const option of options) {
     const label = isPlainObject(option) ? option.label : option;
@@ -1120,11 +1160,29 @@ async function createPoll(input, actor) {
   return poll;
 }
 
-async function validatePollVoteInput(input) {
-  const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
-  const optionIds = Array.isArray(input.optionIds)
+// Resolve the submitted option ids to a de-duplicated list. A multiple-choice
+// vote that repeats the same option id would otherwise insert the same
+// (poll, member, option) row twice and trip the UNIQUE constraint, surfacing as
+// a generic 500 instead of a deterministic result. (#119)
+function resolveVoteOptionIds(input) {
+  const raw = Array.isArray(input.optionIds)
     ? input.optionIds
     : [requiredAny(input.optionId ?? input.option_id, 'pollVotes.cast requires optionId.')];
+  const seen = new Set();
+  const deduped = [];
+  for (const value of raw) {
+    const key = String(value);
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(value);
+    }
+  }
+  return deduped;
+}
+
+async function validatePollVoteInput(input) {
+  const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
+  const optionIds = resolveVoteOptionIds(input);
   await findOpenPoll(pollId);
   await validatePollOptionIds(pollId, optionIds);
 }
@@ -1157,9 +1215,7 @@ async function validatePollOptionIds(pollId, optionIds) {
 
 async function castPollVote(input, actor) {
   const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
-  const optionIds = Array.isArray(input.optionIds)
-    ? input.optionIds
-    : [requiredAny(input.optionId ?? input.option_id, 'pollVotes.cast requires optionId.')];
+  const optionIds = resolveVoteOptionIds(input);
   const poll = await findOpenPoll(pollId);
   await validatePollOptionIds(pollId, optionIds);
 

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -272,6 +272,17 @@ const SQL_WRITE_TABLES = new Set(['events', 'resources']);
 // callers. Anything else (future webhook URLs, integration tokens, etc.)
 // requires admin. (#27 item 4)
 const PUBLIC_CONFIG_CATEGORIES = new Set(['branding', 'features', 'theme', 'demo', 'general']);
+// Brand-identity keys are always anonymously readable so hydrated chrome matches
+// the baked chrome even when a porter wrote them under a non-public category (or
+// no category at all). Key-scoped, so it does not widen any other config
+// surface the category gate protects. (#125)
+const PUBLIC_CONFIG_KEYS = new Set([
+  'brand_text',
+  'brand_text_short',
+  'brand_icon_url',
+  'brand_wordmark_url',
+  'favicon_url',
+]);
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -547,12 +558,19 @@ async function handleTableQuery(correlationId, input, actor, spec, operationName
       // Non-admin callers see only the categories that are explicitly safe to
       // publish — branding, features, theme, demo. Any other category (a
       // future webhook URL, integration token, etc.) requires admin. (#27 item 4)
-      const visibleConfig = (row) => isAdminLike(actor) || PUBLIC_CONFIG_CATEGORIES.has(row.category);
+      const visibleConfig = (row) =>
+        isAdminLike(actor) || PUBLIC_CONFIG_CATEGORIES.has(row.category) || PUBLIC_CONFIG_KEYS.has(row.key);
       if (typeof input.key === 'string') {
         const row = rows.find((item) => item.key === input.key && visibleConfig(item));
         return successResponse(correlationId, row ? configRow(row) : null);
       }
-      const mapped = rows.filter(visibleConfig).map(configRow);
+      // Honor an optional category filter — previously ignored, so callers asking
+      // for one category received every visible row. (#112)
+      const category = typeof input.category === 'string' ? input.category : null;
+      const mapped = rows
+        .filter(visibleConfig)
+        .filter((row) => category == null || row.category === category)
+        .map(configRow);
       return successResponse(correlationId, { rows: mapped, count: mapped.length });
     }
 
@@ -1530,8 +1548,11 @@ async function upsertConfig(input) {
     return last;
   }
   const key = String(requiredAny(input.key, 'config.set requires key.'));
-  const patch = { value: input.value ?? null, category: input.category || 'general' };
   const existing = (await selectRows('site_config')).find((row) => row.key === key);
+  // Preserve the stored category when the caller omits it — a value-only edit
+  // must not silently re-file the row under 'general'. (#112)
+  const category = input.category || existing?.category || 'general';
+  const patch = { value: input.value ?? null, category };
   if (existing) return updateConfigRow(key, patch);
   return insertRow('site_config', { key, ...patch });
 }

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -227,7 +227,7 @@ const OPERATIONS = new Map(OPERATION_CATALOG.map((entry) => [entry.name, entry])
 const TABLE_QUERIES = {
   'config.get': { table: 'site_config', mode: 'config' },
   'pages.list': { table: 'pages', mode: 'list', visible: visiblePage },
-  'pages.get': { table: 'pages', mode: 'one', visible: visiblePage },
+  'pages.get': { table: 'pages', mode: 'one', visible: visiblePage, keys: ['id', 'slug'] },
   'sections.list': { table: 'sections', mode: 'list', visible: visibleSection },
   'sections.get': { table: 'sections', mode: 'one', visible: visibleSection },
   'members.list': { table: 'members', mode: 'list', map: memberRow },
@@ -557,6 +557,7 @@ async function handleTableQuery(correlationId, input, actor, spec, operationName
     }
 
     if (spec.mode === 'one') {
+      requireGetIdentifier(spec, queryInput, operationName);
       const row = rows.find((item) => matchesInput(item, queryInput) && visible(item, actor));
       return successResponse(correlationId, row ? map(row, actor) : null);
     }
@@ -572,6 +573,17 @@ async function handleTableQuery(correlationId, input, actor, spec, operationName
       .map((row) => map(row, actor));
     return successResponse(correlationId, { rows: filtered, count: filtered.length });
   } catch (error) {
+    // A handler that intentionally raised a capability error (e.g. a missing
+    // required identifier on a `.get`) must surface its dotted code, not get
+    // flattened into a generic internal.error. (#107)
+    if (error?.capabilityCode) {
+      return errorResponse(correlationId, mutationStatus(error.capabilityCode), {
+        code: mutationErrorCode(error.capabilityCode),
+        message: error.message,
+        detail: error.detail,
+        retryable: false,
+      });
+    }
     console.error('kychon-api table query failed:', error);
     return errorResponse(correlationId, 500, {
       code: 'internal.error',
@@ -2187,6 +2199,19 @@ function mutationErrorCode(code) {
 async function selectRows(table) {
   const rows = await adminDb().from(table).select('*');
   return Array.isArray(rows) ? rows : rows?.data || rows?.rows || [];
+}
+
+// A `*.get` (mode: 'one') must be addressed by a required identifier. Without
+// this guard, an empty input matched every row and `selectOne` returned row 0;
+// a wrong-typed id silently returned null. Both now fail as validation. (#107)
+function requireGetIdentifier(spec, input, operationName) {
+  const keys = spec.keys || ['id'];
+  if (!keys.some((key) => input[key] != null)) {
+    throw capabilityError('validation.failed', `${operationName} requires ${keys.join(' or ')}.`, { keys });
+  }
+  if (input.id != null && !Number.isInteger(Number(input.id))) {
+    throw capabilityError('validation.failed', `${operationName} id must be an integer.`, { id: String(input.id) });
+  }
 }
 
 function matchesInput(row, input) {

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -509,7 +509,7 @@ function handleQuery(correlationId, envelope, operation, actor) {
   }
 
   if (operation.name === 'pollVotes.list') {
-    return handlePollVotesList(correlationId, envelope.input, actor);
+    return handlePollVotesList(correlationId, envelope.input);
   }
 
   const tableQuery = TABLE_QUERIES[operation.name];
@@ -657,7 +657,7 @@ async function handleSearchQuery(correlationId, input, actor, suggest) {
   }
 }
 
-async function handlePollVotesList(correlationId, input, actor) {
+async function handlePollVotesList(correlationId, input) {
   try {
     const votes = (await selectRows('poll_votes')).filter((row) => matchesInput(row, input));
     const rows = await redactAnonymousVotes(votes);
@@ -681,9 +681,7 @@ async function redactAnonymousVotes(votes) {
     (await selectRows('polls')).filter((poll) => poll.is_anonymous === true).map((poll) => String(poll.id)),
   );
   if (anonymousPollIds.size === 0) return votes;
-  return votes.map((vote) =>
-    anonymousPollIds.has(String(vote.poll_id)) ? { ...vote, member_id: null } : vote,
-  );
+  return votes.map((vote) => (anonymousPollIds.has(String(vote.poll_id)) ? { ...vote, member_id: null } : vote));
 }
 
 async function handlePollResultsQuery(correlationId, input, actor) {
@@ -947,7 +945,9 @@ function validateEventDates(input) {
   }
   if (ends != null) {
     if (Number.isNaN(Date.parse(String(ends)))) {
-      throw capabilityError('validation.failed', 'events.create ends_at must be a valid date.', { ends_at: String(ends) });
+      throw capabilityError('validation.failed', 'events.create ends_at must be a valid date.', {
+        ends_at: String(ends),
+      });
     }
     if (starts != null && Date.parse(String(ends)) < Date.parse(String(starts))) {
       throw capabilityError('validation.failed', 'events.create ends_at must be on or after starts_at.', {});
@@ -2253,7 +2253,7 @@ function capabilityError(code, message, detail) {
 // exports, the retryable internal.error the capability_executions insert used to
 // produce. (#110)
 function notImplementedAction(name) {
-  throw capabilityError('notImplemented', `${name} is not implemented on this portal.`, { operation: name });
+  throw capabilityError('api.notImplemented', `${name} is not implemented on this portal.`, { operation: name });
 }
 
 function mutationStatus(code) {
@@ -2262,7 +2262,7 @@ function mutationStatus(code) {
   if (code === 'notFound.object') return 404;
   if (code === 'conflict.idempotencyKey') return 409;
   if (code === 'conflict.state') return 409;
-  if (code === 'notImplemented') return 501;
+  if (code === 'api.notImplemented') return 501;
   return 501;
 }
 
@@ -2274,7 +2274,7 @@ function mutationErrorCode(code) {
       'notFound.object',
       'conflict.idempotencyKey',
       'conflict.state',
-      'notImplemented',
+      'api.notImplemented',
     ].includes(code)
   )
     return code;

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -902,8 +902,63 @@ async function executeMutation(name, input, actor) {
 
 const VALID_MEMBER_ROLES = new Set(['member', 'moderator', 'admin']);
 
+// Required-field validation for create operations, shared by the validate
+// phase and the execute handlers so the two agree. Without it, `validate`
+// reported accepted:true for empty input and execute then coerced the missing
+// fields (title -> 'Untitled', body -> ''). (#108, #111)
+function validateCreateInput(operation, input) {
+  if (operation === 'forum.topics.create') {
+    requireNonEmptyString(input.title, 'forum.topics.create requires a non-empty title.');
+  } else if (operation === 'events.create') {
+    requireNonEmptyString(input.title, 'events.create requires a non-empty title.');
+    validateEventDates(input);
+    validateNonNegativeCapacity(input);
+  } else if (operation === 'tiers.create') {
+    requireNonEmptyString(input.name, 'tiers.create requires a non-empty name.');
+  }
+}
+
+function requireNonEmptyString(value, message) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw capabilityError('validation.failed', message, {});
+  }
+}
+
+// Dates are validated only when supplied — a title-only event stays valid per
+// the documented minimal create contract. An out-of-order or unparseable date
+// is rejected rather than silently stored. (#111)
+function validateEventDates(input) {
+  const starts = input.startsAt ?? input.starts_at;
+  const ends = input.endsAt ?? input.ends_at;
+  if (starts != null && Number.isNaN(Date.parse(String(starts)))) {
+    throw capabilityError('validation.failed', 'events.create starts_at must be a valid date.', {
+      starts_at: String(starts),
+    });
+  }
+  if (ends != null) {
+    if (Number.isNaN(Date.parse(String(ends)))) {
+      throw capabilityError('validation.failed', 'events.create ends_at must be a valid date.', { ends_at: String(ends) });
+    }
+    if (starts != null && Date.parse(String(ends)) < Date.parse(String(starts))) {
+      throw capabilityError('validation.failed', 'events.create ends_at must be on or after starts_at.', {});
+    }
+  }
+}
+
+function validateNonNegativeCapacity(input) {
+  if (input.capacity != null) {
+    const capacity = Number(input.capacity);
+    if (!Number.isInteger(capacity) || capacity < 0) {
+      throw capabilityError('validation.failed', 'events.create capacity must be a non-negative integer.', {
+        capacity: String(input.capacity),
+      });
+    }
+  }
+}
+
 async function validateMutationSemantics(operation, input, actor) {
   try {
+    validateCreateInput(operation, input);
     if (operation === 'members.updateProfile') {
       idForUpdate(operation, input, actor);
     } else if (operation === 'forum.replies.create') {
@@ -1012,6 +1067,7 @@ async function genericMutation(operation, input, actor) {
 
   let row = null;
   if (spec.action === 'create') {
+    validateCreateInput(operation, input);
     row = await insertRow(spec.table, rowForCreate(operation, input, actor));
   } else if (spec.action === 'delete') {
     row = await deleteRow(spec.table, requiredId(input, `${operation} delete`));
@@ -1068,6 +1124,7 @@ async function createForumTopic(input, actor) {
   // author_id / author_name come from the actor only — caller-supplied values
   // would let any active member impersonate another member or admin. Pinning a
   // topic at create time is reserved for moderators via `forum.topics.pin`. (#24)
+  validateCreateInput('forum.topics.create', input);
   const topic = await insertRow('forum_topics', {
     category_id: input.categoryId ?? input.category_id ?? null,
     title: input.title || 'Untitled',

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -1261,16 +1261,52 @@ async function clearMinePollVotes(input, actor) {
   );
 }
 
+const RSVP_STATUSES = ['going', 'maybe', 'cancelled'];
+
+// RSVP status is constrained to the documented enum — an unknown value is a
+// validation error rather than a silently persisted string. A missing status
+// defaults to 'going'; an empty/garbage value is rejected, not coerced. (#116)
+function normalizeRsvpStatus(value) {
+  const status = value == null ? 'going' : value;
+  if (!RSVP_STATUSES.includes(status)) {
+    throw capabilityError('validation.failed', `rsvps.setStatus status must be one of: ${RSVP_STATUSES.join(', ')}.`, {
+      status: String(status),
+    });
+  }
+  return status;
+}
+
+// Capacity caps the number of `going` RSVPs. The member's own row is excluded so
+// re-confirming or switching to going never counts the member twice. Only
+// `going` is capped — `maybe`/`cancelled` are always allowed so a member can
+// step back and free a seat. (#115)
+function assertRsvpCapacity(eventRow, status, member, rsvps) {
+  if (status !== 'going' || eventRow.capacity == null) return;
+  const goingCount = rsvps.filter(
+    (row) =>
+      String(row.event_id) === String(eventRow.id) &&
+      String(row.status) === 'going' &&
+      String(row.member_id) !== String(member),
+  ).length;
+  if (goingCount >= Number(eventRow.capacity)) {
+    throw capabilityError('conflict.state', 'Event is full.', {
+      object: { type: 'event', id: String(eventRow.id) },
+    });
+  }
+}
+
 async function setRsvpStatus(input, actor) {
   // member_id is bound to the actor (admins act-as via dedicated admin paths,
   // not this capability) and an `id` from input must belong to that member —
   // otherwise an active member could update arbitrary RSVP rows. (#24)
   const member = memberId(actor);
+  const status = normalizeRsvpStatus(input.status);
   const id = input.id;
   const eventId = input.eventId ?? input.event_id;
 
   if (id != null) {
-    const target = (await selectRows('event_rsvps')).find((row) => String(row.id) === String(id));
+    const rsvps = await selectRows('event_rsvps');
+    const target = rsvps.find((row) => String(row.id) === String(id));
     if (!target)
       throw capabilityError('notFound.object', 'RSVP not found.', { object: { type: 'event.rsvp', id: String(id) } });
     if (String(target.member_id) !== String(member) && !isAdminLike(actor) && !isModeratorLike(actor)) {
@@ -1278,7 +1314,9 @@ async function setRsvpStatus(input, actor) {
         object: { type: 'event.rsvp', id: String(id) },
       });
     }
-    const row = await updateRow('event_rsvps', id, { status: input.status || 'going', member_id: target.member_id });
+    const eventRow = (await selectRows('events')).find((row) => String(row.id) === String(target.event_id));
+    if (eventRow) assertRsvpCapacity(eventRow, status, target.member_id, rsvps);
+    const row = await updateRow('event_rsvps', id, { status, member_id: target.member_id });
     const object = changedObject('event.rsvp', row.id ?? id);
     return actionResult(
       row,
@@ -1297,12 +1335,14 @@ async function setRsvpStatus(input, actor) {
       object: { type: 'event', id: String(event) },
     });
   }
-  const existing = (await selectRows('event_rsvps')).find(
+  const rsvps = await selectRows('event_rsvps');
+  assertRsvpCapacity(eventRow, status, member, rsvps);
+  const existing = rsvps.find(
     (row) => String(row.event_id) === String(event) && String(row.member_id) === String(member),
   );
   const row = existing
-    ? await updateRow('event_rsvps', existing.id, { status: input.status || 'going', member_id: member })
-    : await insertRow('event_rsvps', { event_id: event, member_id: member, status: input.status || 'going' });
+    ? await updateRow('event_rsvps', existing.id, { status, member_id: member })
+    : await insertRow('event_rsvps', { event_id: event, member_id: member, status });
   const object = changedObject('event.rsvp', row.id);
   return actionResult(row, [object], verification('rsvps.listForEvent', { eventId: event }, object));
 }

--- a/functions/kychon-api.js
+++ b/functions/kychon-api.js
@@ -894,18 +894,10 @@ async function executeMutation(name, input, actor) {
   if (name === 'pollVotes.clearMine') return clearMinePollVotes(input, actor);
   if (name === 'reactions.toggle') return toggleReaction(input, actor);
   if (name === 'resources.upload') return uploadResource(input, actor);
-  if (name === 'assets.upload')
-    return actionResult(
-      { status: 'uploaded', path: input.path || null },
-      [changedObject('asset', input.path || 'asset')],
-      null,
-    );
-  if (name === 'translations.translateText')
-    return actionResult({ translatedText: input.text || '' }, [changedObject('translation', 'text')], null);
+  if (name === 'assets.upload' || name === 'translations.translateText') return notImplementedAction(name);
   if (name === 'translations.translateContent') return translateContent(input);
   if (name === 'newsletters.drafts.generate') return generateNewsletterDraft(input);
-  if (name.startsWith('jobs.'))
-    return actionResult({ status: 'queued', job: name.replace(/^jobs\./, '') }, [changedObject('job', name)], null);
+  if (name.startsWith('jobs.') || name.startsWith('exports.')) return notImplementedAction(name);
   if (name === 'rsvps.setStatus') return setRsvpStatus(input, actor);
   if (name === 'rsvps.cancel') return cancelRsvp(input, actor);
   if (name === 'members.changeRole') return changeMemberRole(input, actor);
@@ -2255,20 +2247,35 @@ function capabilityError(code, message, detail) {
   return error;
 }
 
+// These capability operations have no backing implementation on the portal
+// gateway (translation/storage/jobs run as separate functions; exports were
+// never wired). An honest notImplemented error beats a fake ok:true — or, for
+// exports, the retryable internal.error the capability_executions insert used to
+// produce. (#110)
+function notImplementedAction(name) {
+  throw capabilityError('notImplemented', `${name} is not implemented on this portal.`, { operation: name });
+}
+
 function mutationStatus(code) {
   if (code === 'permission.denied') return 403;
   if (code === 'validation.failed') return 400;
   if (code === 'notFound.object') return 404;
   if (code === 'conflict.idempotencyKey') return 409;
   if (code === 'conflict.state') return 409;
+  if (code === 'notImplemented') return 501;
   return 501;
 }
 
 function mutationErrorCode(code) {
   if (
-    ['permission.denied', 'validation.failed', 'notFound.object', 'conflict.idempotencyKey', 'conflict.state'].includes(
-      code,
-    )
+    [
+      'permission.denied',
+      'validation.failed',
+      'notFound.object',
+      'conflict.idempotencyKey',
+      'conflict.state',
+      'notImplemented',
+    ].includes(code)
   )
     return code;
   return 'internal.error';

--- a/src/lib/capability-api/gateway.ts
+++ b/src/lib/capability-api/gateway.ts
@@ -210,6 +210,7 @@ function mutationStatus(code: string): number {
   if (code === 'notFound.object') return 404;
   if (code === 'conflict.idempotencyKey') return 409;
   if (code === 'conflict.state') return 409;
+  if (code === 'notImplemented') return 501;
   return 501;
 }
 
@@ -219,7 +220,8 @@ function mutationErrorCode(code: string) {
     code === 'validation.failed' ||
     code === 'notFound.object' ||
     code === 'conflict.idempotencyKey' ||
-    code === 'conflict.state'
+    code === 'conflict.state' ||
+    code === 'notImplemented'
   ) {
     return code;
   }

--- a/src/lib/capability-api/gateway.ts
+++ b/src/lib/capability-api/gateway.ts
@@ -210,7 +210,7 @@ function mutationStatus(code: string): number {
   if (code === 'notFound.object') return 404;
   if (code === 'conflict.idempotencyKey') return 409;
   if (code === 'conflict.state') return 409;
-  if (code === 'notImplemented') return 501;
+  if (code === 'api.notImplemented') return 501;
   return 501;
 }
 
@@ -221,7 +221,7 @@ function mutationErrorCode(code: string) {
     code === 'notFound.object' ||
     code === 'conflict.idempotencyKey' ||
     code === 'conflict.state' ||
-    code === 'notImplemented'
+    code === 'api.notImplemented'
   ) {
     return code;
   }

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -456,16 +456,54 @@ async function uploadAsset(input: JsonObject, ctx: CapabilityMutationContext): P
 
 const VALID_MEMBER_ROLES: ReadonlySet<string> = new Set(['member', 'moderator', 'admin']);
 
+const RSVP_STATUSES = ['going', 'maybe', 'cancelled'];
+
+// RSVP status is constrained to the documented enum — an unknown value is a
+// validation error rather than a silently persisted string. A missing status
+// defaults to 'going'; an empty/garbage value is rejected, not coerced. (#116)
+function normalizeRsvpStatus(value: JsonValue | undefined): string {
+  const status = value == null ? 'going' : value;
+  if (typeof status !== 'string' || !RSVP_STATUSES.includes(status)) {
+    throw new CapabilityMutationError(
+      'validation.failed',
+      `rsvps.setStatus status must be one of: ${RSVP_STATUSES.join(', ')}.`,
+      { status: String(status) },
+    );
+  }
+  return status;
+}
+
+// Capacity caps the number of `going` RSVPs. The member's own row is excluded so
+// re-confirming or switching to going never counts the member twice. Only
+// `going` is capped — `maybe`/`cancelled` are always allowed so a member can
+// step back and free a seat. (#115)
+function assertRsvpCapacity(eventRow: JsonObject, status: string, member: JsonValue, rsvps: JsonObject[]): void {
+  if (status !== 'going' || eventRow.capacity == null) return;
+  const goingCount = rsvps.filter(
+    (row) =>
+      String(row.event_id) === String(eventRow.id) &&
+      String(row.status) === 'going' &&
+      String(row.member_id) !== String(member),
+  ).length;
+  if (goingCount >= Number(eventRow.capacity)) {
+    throw new CapabilityMutationError('conflict.state', 'Event is full.', {
+      object: { type: 'event', id: String(eventRow.id) },
+    });
+  }
+}
+
 async function setRsvpStatus(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
   // member_id is bound to the actor (admins act-as via dedicated admin paths,
   // not this capability) and an `id` from input must belong to that member —
   // otherwise an active member could update arbitrary RSVP rows. (#24)
   const member = memberId(ctx);
+  const status = normalizeRsvpStatus(input.status);
   const id = input.id;
   const eventId = input.eventId ?? input.event_id;
 
   if (id != null) {
-    const target = (await ctx.db.select('event_rsvps')).find((row) => String(row.id) === String(id));
+    const rsvps = await ctx.db.select('event_rsvps');
+    const target = rsvps.find((row) => String(row.id) === String(id));
     if (!target) {
       throw new CapabilityMutationError('notFound.object', 'RSVP not found.', {
         object: { type: 'event.rsvp', id: String(id) },
@@ -476,9 +514,11 @@ async function setRsvpStatus(input: JsonObject, ctx: CapabilityMutationContext):
         object: { type: 'event.rsvp', id: String(id) },
       });
     }
+    const eventRow = (await ctx.db.select('events')).find((row) => String(row.id) === String(target.event_id));
+    if (eventRow) assertRsvpCapacity(eventRow, status, target.member_id, rsvps);
     const row =
       (await ctx.db.update('event_rsvps', String(id), {
-        status: input.status || 'going',
+        status,
         member_id: target.member_id,
       })) || target;
     const object = changedObject('event.rsvp', String(row.id ?? id));
@@ -498,18 +538,20 @@ async function setRsvpStatus(input: JsonObject, ctx: CapabilityMutationContext):
       object: { type: 'event', id: String(event) },
     });
   }
-  const existing = (await ctx.db.select('event_rsvps')).find(
+  const rsvps = await ctx.db.select('event_rsvps');
+  assertRsvpCapacity(eventRow, status, member, rsvps);
+  const existing = rsvps.find(
     (row) => String(row.event_id) === String(event) && String(row.member_id) === String(member),
   );
   const row = existing
     ? (await ctx.db.update('event_rsvps', String(existing.id), {
-        status: input.status || 'going',
+        status,
         member_id: member,
       })) || existing
     : await ctx.db.insert('event_rsvps', {
         event_id: event,
         member_id: member,
-        status: input.status || 'going',
+        status,
       });
   const object = changedObject('event.rsvp', String(row.id));
   return actionResult(

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -313,11 +313,28 @@ async function createForumReply(input: JsonObject, ctx: CapabilityMutationContex
   return actionResult(reply, [object, changedObject('forum.topic', String(topicId))], verificationQuery(getOperation('forum.replies.list')!.name, { topicId }, object), auditReference(String(activity.id), 'forum_reply'));
 }
 
-async function validatePollVoteInput(input: JsonObject, ctx: CapabilityMutationContext): Promise<void> {
-  const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
-  const optionIds = Array.isArray(input.optionIds)
+// De-duplicate submitted option ids so a repeated id in a multiple-choice vote
+// cannot insert the same (poll, member, option) row twice and trip the UNIQUE
+// constraint (which would surface as a generic 500). (#119)
+function resolveVoteOptionIds(input: JsonObject): JsonValue[] {
+  const raw = Array.isArray(input.optionIds)
     ? input.optionIds
     : [requiredAny(input.optionId ?? input.option_id, 'pollVotes.cast requires optionId.')];
+  const seen = new Set<string>();
+  const deduped: JsonValue[] = [];
+  for (const value of raw) {
+    const key = String(value);
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(value);
+    }
+  }
+  return deduped;
+}
+
+async function validatePollVoteInput(input: JsonObject, ctx: CapabilityMutationContext): Promise<void> {
+  const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
+  const optionIds = resolveVoteOptionIds(input);
   await findOpenPoll(pollId, ctx);
   await validatePollOptionIds(pollId, optionIds, ctx);
 }
@@ -356,7 +373,7 @@ async function validatePollOptionIds(
 
 async function castPollVote(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
   const pollId = requiredAny(input.pollId ?? input.poll_id, 'pollVotes.cast requires pollId.');
-  const optionIds = Array.isArray(input.optionIds) ? input.optionIds : [requiredAny(input.optionId ?? input.option_id, 'pollVotes.cast requires optionId.')];
+  const optionIds = resolveVoteOptionIds(input);
   const poll = await findOpenPoll(pollId, ctx);
   await validatePollOptionIds(pollId, optionIds, ctx);
 
@@ -614,6 +631,14 @@ async function runJob(operation: string, input: JsonObject, ctx: CapabilityMutat
 }
 
 async function createPoll(input: JsonObject, ctx: CapabilityMutationContext): Promise<JsonObject> {
+  // A poll needs at least two options — validate before inserting the poll row
+  // so an under-specified request never leaves an orphan poll behind. (#118)
+  const options = Array.isArray(input.options) ? input.options : [];
+  if (options.length < 2) {
+    throw new CapabilityMutationError('validation.failed', 'A poll requires at least two options.', {
+      object: { type: 'poll', id: 'new' },
+    });
+  }
   const poll = await ctx.db.insert('polls', {
     question: input.question || 'Poll',
     description: input.description || null,
@@ -626,7 +651,6 @@ async function createPoll(input: JsonObject, ctx: CapabilityMutationContext): Pr
     attached_id: input.attached_id || input.attachedId || null,
     created_by: memberId(ctx),
   });
-  const options = Array.isArray(input.options) ? input.options : [];
   let position = 0;
   for (const option of options) {
     const label = isObject(option) ? option.label : option;

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -511,7 +511,9 @@ async function toggleReaction(input: JsonObject, ctx: CapabilityMutationContext)
 // Operations with no backing service on this portal raise an honest
 // notImplemented error rather than returning a fake success. (#110)
 function notImplemented(operation: string): never {
-  throw new CapabilityMutationError('notImplemented', `${operation} is not implemented on this portal.`, { operation });
+  throw new CapabilityMutationError('api.notImplemented', `${operation} is not implemented on this portal.`, {
+    operation,
+  });
 }
 
 async function uploadAsset(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -213,6 +213,7 @@ export async function executeCapabilityMutation(
   if (name === 'rsvps.setStatus') return setRsvpStatus(input, ctx);
   if (name === 'rsvps.cancel') return cancelRsvp(input, ctx);
   if (name === 'members.changeRole') return changeMemberRole(input, ctx);
+  if (name.startsWith('exports.')) notImplemented(name);
 
   return genericMutation(name, input, ctx);
 }
@@ -507,10 +508,17 @@ async function toggleReaction(input: JsonObject, ctx: CapabilityMutationContext)
   return actionResult({ toggled: 'added', reaction }, [changedObject('reaction', String(reaction.id))], null);
 }
 
+// Operations with no backing service on this portal raise an honest
+// notImplemented error rather than returning a fake success. (#110)
+function notImplemented(operation: string): never {
+  throw new CapabilityMutationError('notImplemented', `${operation} is not implemented on this portal.`, { operation });
+}
+
 async function uploadAsset(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
-  const upload = await ctx.storage?.upload('asset', asObject(input.file), input);
-  const object = changedObject('asset', String(upload?.path || input.path || 'asset'));
-  return actionResult(upload || { status: 'uploaded', path: input.path || null }, [object], null);
+  if (!ctx.storage) notImplemented('assets.upload');
+  const upload = await ctx.storage.upload('asset', asObject(input.file), input);
+  const object = changedObject('asset', String(upload.path || input.path || 'asset'));
+  return actionResult(upload, [object], null);
 }
 
 const VALID_MEMBER_ROLES: ReadonlySet<string> = new Set(['member', 'moderator', 'admin']);
@@ -695,7 +703,8 @@ function isModeratorLike(ctx: CapabilityMutationContext): boolean {
 export { sanitizeRichHtmlServer };
 
 async function translateText(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
-  const result = (await ctx.ai?.translateText(input)) || { translatedText: input.text || '' };
+  if (!ctx.ai) notImplemented('translations.translateText');
+  const result = await ctx.ai.translateText(input);
   return actionResult(result, [changedObject('translation', String(result.id || 'text'))], null);
 }
 
@@ -726,7 +735,8 @@ async function generateNewsletterDraft(input: JsonObject, ctx: CapabilityMutatio
 
 async function runJob(operation: string, input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
   const name = operation.replace(/^jobs\./, '');
-  const result = (await ctx.jobs?.run(name, input)) || { status: 'queued', job: name };
+  if (!ctx.jobs) notImplemented(operation);
+  const result = await ctx.jobs.run(name, input);
   const object = changedObject('job', String(result.id || name));
   return actionResult(result, [object], verificationQuery(getOperation('jobs.status')!.name, { id: result.id || name }, object));
 }

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -771,7 +771,7 @@ async function upsertConfig(input: JsonObject, ctx: CapabilityMutationContext): 
   }
   const key = String(requiredAny(input.key, 'config.set requires key.'));
   const existing = (await ctx.db.select('site_config')).find((row) => row.key === key);
-  if (existing?.id != null) return (await ctx.db.update('site_config', String(existing.id), configPatch(input))) || existing;
+  if (existing?.id != null) return (await ctx.db.update('site_config', String(existing.id), configPatch(input, existing))) || existing;
   return ctx.db.insert('site_config', { key, ...configPatch(input) });
 }
 
@@ -912,10 +912,12 @@ function objectTypeLabel(objectType: ObjectType): string {
   return 'Object';
 }
 
-function configPatch(input: JsonObject): JsonObject {
+function configPatch(input: JsonObject, existing?: JsonObject): JsonObject {
   return {
     value: input.value ?? null,
-    category: input.category ?? 'general',
+    // Preserve the stored category when the caller omits it — a value-only edit
+    // must not silently re-file the row under 'general'. (#112)
+    category: (input.category as string) || (existing?.category as string) || 'general',
   };
 }
 

--- a/src/lib/capability-api/mutation-handlers.ts
+++ b/src/lib/capability-api/mutation-handlers.ts
@@ -95,12 +95,69 @@ export async function validateCapabilityMutation(
   };
 }
 
+// Required-field validation for create operations, shared by the validate
+// phase and the execute handlers so the two agree. Without it, `validate`
+// reported accepted:true for empty input and execute then coerced the missing
+// fields (title -> 'Untitled', body -> ''). (#108, #111)
+function validateCreateInput(operation: string, input: JsonObject): void {
+  if (operation === 'forum.topics.create') {
+    requireNonEmptyString(input.title, 'forum.topics.create requires a non-empty title.');
+  } else if (operation === 'events.create') {
+    requireNonEmptyString(input.title, 'events.create requires a non-empty title.');
+    validateEventDates(input);
+    validateNonNegativeCapacity(input);
+  } else if (operation === 'tiers.create') {
+    requireNonEmptyString(input.name, 'tiers.create requires a non-empty name.');
+  }
+}
+
+function requireNonEmptyString(value: JsonValue | undefined, message: string): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new CapabilityMutationError('validation.failed', message, {});
+  }
+}
+
+// Dates are validated only when supplied — a title-only event stays valid per
+// the documented minimal create contract. An out-of-order or unparseable date
+// is rejected rather than silently stored. (#111)
+function validateEventDates(input: JsonObject): void {
+  const starts = input.startsAt ?? input.starts_at;
+  const ends = input.endsAt ?? input.ends_at;
+  if (starts != null && Number.isNaN(Date.parse(String(starts)))) {
+    throw new CapabilityMutationError('validation.failed', 'events.create starts_at must be a valid date.', {
+      starts_at: String(starts),
+    });
+  }
+  if (ends != null) {
+    if (Number.isNaN(Date.parse(String(ends)))) {
+      throw new CapabilityMutationError('validation.failed', 'events.create ends_at must be a valid date.', {
+        ends_at: String(ends),
+      });
+    }
+    if (starts != null && Date.parse(String(ends)) < Date.parse(String(starts))) {
+      throw new CapabilityMutationError('validation.failed', 'events.create ends_at must be on or after starts_at.', {});
+    }
+  }
+}
+
+function validateNonNegativeCapacity(input: JsonObject): void {
+  if (input.capacity != null) {
+    const capacity = Number(input.capacity);
+    if (!Number.isInteger(capacity) || capacity < 0) {
+      throw new CapabilityMutationError('validation.failed', 'events.create capacity must be a non-negative integer.', {
+        capacity: String(input.capacity),
+      });
+    }
+  }
+}
+
 async function validateMutationSemantics(
   operation: string,
   input: JsonObject,
   ctx: CapabilityMutationContext,
 ): Promise<CapabilityMutationError | null> {
   try {
+    validateCreateInput(operation, input);
     if (operation === 'members.updateProfile') {
       idForUpdate(operation, input, ctx);
     } else if (operation === 'forum.replies.create') {
@@ -176,6 +233,7 @@ async function genericMutation(operation: string, input: JsonObject, ctx: Capabi
 
   let row: JsonObject | null;
   if (spec.action === 'create') {
+    validateCreateInput(operation, input);
     row = await ctx.db.insert(spec.table, rowForCreate(operation, input, ctx));
   } else if (spec.action === 'delete') {
     row = await ctx.db.delete(spec.table, requiredId(input, operation));
@@ -253,6 +311,7 @@ async function publishAnnouncement(input: JsonObject, ctx: CapabilityMutationCon
 }
 
 async function createForumTopic(input: JsonObject, ctx: CapabilityMutationContext): Promise<ActionResult<JsonValue>> {
+  validateCreateInput('forum.topics.create', input);
   const topic = await ctx.db.insert('forum_topics', {
     category_id: input.categoryId ?? input.category_id ?? null,
     title: input.title || 'Untitled',

--- a/src/lib/capability-api/query-handlers.ts
+++ b/src/lib/capability-api/query-handlers.ts
@@ -18,7 +18,7 @@ type QueryHandler = (input: JsonObject, ctx: CapabilityQueryContext) => Promise<
 const tableQueries: Record<string, QueryHandler> = {
   'config.get': (input, ctx) => tableResult(ctx, 'site_config', input, configRow),
   'pages.list': (input, ctx) => listResult(ctx, 'pages', input, (row) => visiblePage(row, ctx.actor)),
-  'pages.get': (input, ctx) => oneResult(ctx, 'pages', input, (row) => visiblePage(row, ctx.actor)),
+  'pages.get': (input, ctx) => oneResult(ctx, 'pages', input, (row) => visiblePage(row, ctx.actor), undefined, ['id', 'slug']),
   'sections.list': (input, ctx) => listResult(ctx, 'sections', input, (row) => visibleSection(row, ctx.actor)),
   'sections.get': (input, ctx) => oneResult(ctx, 'sections', input, (row) => visibleSection(row, ctx.actor)),
   'members.list': async (input, ctx) => {
@@ -48,7 +48,8 @@ const tableQueries: Record<string, QueryHandler> = {
   'forum.replies.list': (input, ctx) => listResult(ctx, 'forum_replies', input, (row) => visibleForumRow(row, ctx.actor)),
   'polls.list': (input, ctx) => listResult(ctx, 'polls', input, (row) => visiblePoll(row, ctx.actor)),
   'polls.get': (input, ctx) => oneResult(ctx, 'polls', input, (row) => visiblePoll(row, ctx.actor)),
-  'polls.getAttached': (input, ctx) => oneResult(ctx, 'polls', input, (row) => matchesAttached(row, input)),
+  'polls.getAttached': (input, ctx) =>
+    oneResult(ctx, 'polls', input, (row) => matchesAttached(row, input), undefined, ['attachedTo', 'attachedId']),
   'pollOptions.list': (input, ctx) => listResult(ctx, 'poll_options', input),
   'pollVotes.list': (input, ctx) => pollVotesList(input, ctx),
   'pollResults.get': pollResults,
@@ -134,9 +135,23 @@ async function oneResult(
   input: JsonObject,
   visible: (row: JsonObject) => boolean = () => true,
   map: (row: JsonObject) => JsonObject = (row) => row,
+  keys: string[] = ['id'],
 ): Promise<JsonValue> {
+  requireGetIdentifier(keys, input, table);
   const rows = (await ctx.db.select(table)).filter((row) => matchesInput(row, input)).filter(visible);
   return rows[0] ? map(rows[0]) : null;
+}
+
+// A `*.get` must be addressed by a required identifier. Without this guard an
+// empty input matched every row and returned row 0; a wrong-typed id returned
+// null. Both now fail as validation.failed. (#107)
+function requireGetIdentifier(keys: string[], input: JsonObject, table: string): void {
+  if (!keys.some((key) => input[key] != null)) {
+    throw new CapabilityQueryError('validation.failed', `${table}.get requires ${keys.join(' or ')}.`, { keys });
+  }
+  if (input.id != null && !Number.isInteger(Number(input.id))) {
+    throw new CapabilityQueryError('validation.failed', `${table}.get id must be an integer.`, { id: String(input.id) });
+  }
 }
 
 async function search(input: JsonObject, ctx: CapabilityQueryContext, suggest: boolean): Promise<JsonValue> {

--- a/src/lib/capability-api/query-handlers.ts
+++ b/src/lib/capability-api/query-handlers.ts
@@ -50,7 +50,7 @@ const tableQueries: Record<string, QueryHandler> = {
   'polls.get': (input, ctx) => oneResult(ctx, 'polls', input, (row) => visiblePoll(row, ctx.actor)),
   'polls.getAttached': (input, ctx) => oneResult(ctx, 'polls', input, (row) => matchesAttached(row, input)),
   'pollOptions.list': (input, ctx) => listResult(ctx, 'poll_options', input),
-  'pollVotes.list': (input, ctx) => listResult(ctx, 'poll_votes', input),
+  'pollVotes.list': (input, ctx) => pollVotesList(input, ctx),
   'pollResults.get': pollResults,
   'committees.list': (input, ctx) => listResult(ctx, 'committees', input),
   'committees.get': (input, ctx) => oneResult(ctx, 'committees', input),
@@ -192,6 +192,20 @@ async function pollResults(input: JsonObject, ctx: CapabilityQueryContext): Prom
       voteCount: votes.filter((vote) => String(vote.option_id) === String(option.id)).length,
     })),
   };
+}
+
+async function pollVotesList(input: JsonObject, ctx: CapabilityQueryContext): Promise<JsonValue> {
+  const votes = (await ctx.db.select('poll_votes')).filter((row) => matchesInput(row, input));
+  const anonymousPollIds = new Set(
+    (await ctx.db.select('polls')).filter((poll) => poll.is_anonymous === true).map((poll) => String(poll.id)),
+  );
+  // Anonymous polls must not expose voter identity in API responses; member_id
+  // stays in the DB only to enforce vote uniqueness. Redaction is unconditional
+  // — anonymity applies to every caller, admins included. (#117)
+  const rows = votes.map((vote) =>
+    anonymousPollIds.has(String(vote.poll_id)) ? { ...vote, member_id: null } : vote,
+  );
+  return { rows, count: rows.length };
 }
 
 function matchesInput(row: JsonObject, input: JsonObject): boolean {

--- a/src/lib/capability-api/query-handlers.ts
+++ b/src/lib/capability-api/query-handlers.ts
@@ -16,7 +16,7 @@ export interface CapabilityQueryContext {
 type QueryHandler = (input: JsonObject, ctx: CapabilityQueryContext) => Promise<JsonValue>;
 
 const tableQueries: Record<string, QueryHandler> = {
-  'config.get': (input, ctx) => tableResult(ctx, 'site_config', input, configRow),
+  'config.get': (input, ctx) => configGet(input, ctx),
   'pages.list': (input, ctx) => listResult(ctx, 'pages', input, (row) => visiblePage(row, ctx.actor)),
   'pages.get': (input, ctx) => oneResult(ctx, 'pages', input, (row) => visiblePage(row, ctx.actor), undefined, ['id', 'slug']),
   'sections.list': (input, ctx) => listResult(ctx, 'sections', input, (row) => visibleSection(row, ctx.actor)),
@@ -99,20 +99,6 @@ export class CapabilityQueryError extends Error {
     this.code = code;
     this.detail = detail;
   }
-}
-
-async function tableResult(
-  ctx: CapabilityQueryContext,
-  table: string,
-  input: JsonObject,
-  map: (row: JsonObject) => JsonObject = (row) => row,
-): Promise<JsonValue> {
-  const rows = await ctx.db.select(table);
-  if (typeof input.key === 'string') {
-    const row = rows.find((item) => item.key === input.key);
-    return row ? map(row) : null;
-  }
-  return { rows: rows.map(map), count: rows.length };
 }
 
 async function listResult(
@@ -243,6 +229,30 @@ function matchesInput(row: JsonObject, input: JsonObject): boolean {
     if (rowKey in row && String(row[rowKey]) !== String(value)) return false;
   }
   return true;
+}
+
+const PUBLIC_CONFIG_CATEGORIES = new Set(['branding', 'features', 'theme', 'demo', 'general']);
+// Brand-identity keys are always anonymously readable so hydrated chrome matches
+// baked chrome even when written under a non-public category. Key-scoped. (#125)
+const PUBLIC_CONFIG_KEYS = new Set(['brand_text', 'brand_text_short', 'brand_icon_url', 'brand_wordmark_url', 'favicon_url']);
+
+async function configGet(input: JsonObject, ctx: CapabilityQueryContext): Promise<JsonValue> {
+  const rows = await ctx.db.select('site_config');
+  const visible = (row: JsonObject) =>
+    isAdminLike(ctx.actor) ||
+    PUBLIC_CONFIG_CATEGORIES.has(row.category as string) ||
+    PUBLIC_CONFIG_KEYS.has(row.key as string);
+  if (typeof input.key === 'string') {
+    const row = rows.find((item) => item.key === input.key && visible(item));
+    return row ? configRow(row) : null;
+  }
+  // Honor an optional category filter — previously ignored. (#112)
+  const category = typeof input.category === 'string' ? input.category : null;
+  const mapped = rows
+    .filter(visible)
+    .filter((row) => category == null || row.category === category)
+    .map(configRow);
+  return { rows: mapped, count: mapped.length };
 }
 
 function configRow(row: JsonObject): JsonObject {

--- a/src/lib/capability-api/types.ts
+++ b/src/lib/capability-api/types.ts
@@ -215,5 +215,6 @@ export const ERROR_CODES = [
   'confirmation.required',
   'rateLimit.exceeded',
   'cost.limitExceeded',
+  'api.notImplemented',
   'internal.error',
 ] as const;

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -424,4 +424,11 @@ describe('Capability API mutation bug fixes', () => {
     );
     expect(ok.accepted).toBe(true);
   });
+
+  it('GH-112: config.set preserves the stored category when omitted', async () => {
+    const db = makeDb();
+    db.tables.site_config = [{ id: 1, key: 'brand_text', value: 'Old', category: 'branding' }];
+    await executeCapabilityMutation('config.set', { key: 'brand_text', value: 'New' }, { actor: adminActor, db });
+    expect(db.tables.site_config[0]).toMatchObject({ value: 'New', category: 'branding' });
+  });
 });

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -259,9 +259,9 @@ describe('Capability API mutation handlers', () => {
     await executeCapabilityMutation('assets.upload', { file: { name: 'logo.png' }, path: 'logo.png' }, ctx);
     // exports.* is not wired — it now returns an honest notImplemented error
     // instead of a fake success / retryable internal.error. (#110)
-    await expect(
-      executeCapabilityMutation('exports.membersCsv', { format: 'csv' }, ctx),
-    ).rejects.toMatchObject({ code: 'notImplemented' });
+    await expect(executeCapabilityMutation('exports.membersCsv', { format: 'csv' }, ctx)).rejects.toMatchObject({
+      code: 'api.notImplemented',
+    });
 
     expect(db.tables.events.some((row) => row.title === 'New Event')).toBe(true);
     expect(db.tables.event_registration_options[0].is_disabled).toBe(true);
@@ -349,9 +349,7 @@ describe('Capability API mutation bug fixes', () => {
   it('GH-119: de-duplicates repeated optionIds in a multiple-choice vote', async () => {
     const db = makeDb();
     await executeCapabilityMutation('pollVotes.cast', { pollId: 2, optionIds: [3, 3] }, { actor: memberActor, db });
-    const votes = db.tables.poll_votes.filter(
-      (row) => String(row.poll_id) === '2' && String(row.member_id) === '1',
-    );
+    const votes = db.tables.poll_votes.filter((row) => String(row.poll_id) === '2' && String(row.member_id) === '1');
     expect(votes).toHaveLength(1);
     expect(votes[0].option_id).toBe(3);
   });
@@ -371,7 +369,11 @@ describe('Capability API mutation bug fixes', () => {
   it('GH-116: rejects an RSVP status outside the allowed enum (exact match)', async () => {
     const db = makeDb();
     await expect(
-      executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'not-a-real-status' }, { actor: memberActor, db }),
+      executeCapabilityMutation(
+        'rsvps.setStatus',
+        { eventId: 1, status: 'not-a-real-status' },
+        { actor: memberActor, db },
+      ),
     ).rejects.toBeInstanceOf(CapabilityMutationError);
     await expect(
       executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'Going' }, { actor: memberActor, db }),
@@ -401,9 +403,9 @@ describe('Capability API mutation bug fixes', () => {
     await expect(
       executeCapabilityMutation('forum.topics.create', { categoryId: 1 }, { actor: memberActor, db }),
     ).rejects.toBeInstanceOf(CapabilityMutationError);
-    await expect(
-      executeCapabilityMutation('events.create', {}, { actor: adminActor, db }),
-    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(executeCapabilityMutation('events.create', {}, { actor: adminActor, db })).rejects.toBeInstanceOf(
+      CapabilityMutationError,
+    );
     await expect(
       executeCapabilityMutation(
         'events.create',
@@ -444,9 +446,9 @@ describe('Capability API mutation bug fixes', () => {
       ['exports.membersCsv', {}],
     ];
     for (const [op, input] of cases) {
-      await expect(
-        executeCapabilityMutation(op, input, { actor: adminActor, db: makeDb() }),
-      ).rejects.toMatchObject({ code: 'notImplemented' });
+      await expect(executeCapabilityMutation(op, input, { actor: adminActor, db: makeDb() })).rejects.toMatchObject({
+        code: 'api.notImplemented',
+      });
     }
   });
 });

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -257,7 +257,11 @@ describe('Capability API mutation handlers', () => {
       ctx,
     );
     await executeCapabilityMutation('assets.upload', { file: { name: 'logo.png' }, path: 'logo.png' }, ctx);
-    await executeCapabilityMutation('exports.membersCsv', { format: 'csv' }, ctx);
+    // exports.* is not wired — it now returns an honest notImplemented error
+    // instead of a fake success / retryable internal.error. (#110)
+    await expect(
+      executeCapabilityMutation('exports.membersCsv', { format: 'csv' }, ctx),
+    ).rejects.toMatchObject({ code: 'notImplemented' });
 
     expect(db.tables.events.some((row) => row.title === 'New Event')).toBe(true);
     expect(db.tables.event_registration_options[0].is_disabled).toBe(true);
@@ -265,7 +269,7 @@ describe('Capability API mutation handlers', () => {
     expect(announcement.changed.map((ref) => ref.type)).toContain('poll');
     expect(db.tables.resources[0].file_url).toBe('/storage/guide.pdf');
     expect(storage.upload).toHaveBeenCalledTimes(2);
-    expect(db.tables.capability_executions).toHaveLength(1);
+    expect(db.tables.capability_executions).toHaveLength(0);
   });
 
   it('executes forum, poll, committee, reaction, and moderation mutations with domain semantics', async () => {
@@ -430,5 +434,19 @@ describe('Capability API mutation bug fixes', () => {
     db.tables.site_config = [{ id: 1, key: 'brand_text', value: 'Old', category: 'branding' }];
     await executeCapabilityMutation('config.set', { key: 'brand_text', value: 'New' }, { actor: adminActor, db });
     expect(db.tables.site_config[0]).toMatchObject({ value: 'New', category: 'branding' });
+  });
+
+  it('GH-110: unwired service/export ops return notImplemented, not fake success', async () => {
+    const cases: Array<[string, JsonObject]> = [
+      ['assets.upload', { file: { name: 'x.png' }, path: 'x.png' }],
+      ['translations.translateText', { text: 'Hi', target_language: 'es' }],
+      ['jobs.checkExpirations', {}],
+      ['exports.membersCsv', {}],
+    ];
+    for (const [op, input] of cases) {
+      await expect(
+        executeCapabilityMutation(op, input, { actor: adminActor, db: makeDb() }),
+      ).rejects.toMatchObject({ code: 'notImplemented' });
+    }
   });
 });

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -110,6 +110,8 @@ function makeDb() {
     poll_options: [
       { id: 1, poll_id: 1, label: 'Yes', position: 0 },
       { id: 2, poll_id: 1, label: 'No', position: 1 },
+      { id: 3, poll_id: 2, label: 'A', position: 0 },
+      { id: 4, poll_id: 2, label: 'B', position: 1 },
     ],
     poll_votes: [{ id: 1, poll_id: 1, option_id: 1, member_id: 1 }],
     committees: [{ id: 1, name: 'Board' }],
@@ -272,7 +274,7 @@ describe('Capability API mutation handlers', () => {
 
     const topic = await executeCapabilityMutation(
       'forum.topics.create',
-      { categoryId: 1, title: 'Topic', body: 'Body', poll: { question: 'Vote?', options: ['A'] } },
+      { categoryId: 1, title: 'Topic', body: 'Body', poll: { question: 'Vote?', options: ['A', 'B'] } },
       { actor: memberActor, db },
     );
     expect(topic.changed.map((ref) => ref.type)).toContain('poll');
@@ -336,5 +338,29 @@ describe('Capability API mutation handlers', () => {
     expect(db.tables.newsletter_drafts[0].subject).toBe('Weekly');
     expect(db.tables.member_insights[0].status).toBe('dismissed');
     expect(jobs.run).toHaveBeenCalledWith('sendEventReminders', {});
+  });
+});
+
+describe('Capability API mutation bug fixes', () => {
+  it('GH-119: de-duplicates repeated optionIds in a multiple-choice vote', async () => {
+    const db = makeDb();
+    await executeCapabilityMutation('pollVotes.cast', { pollId: 2, optionIds: [3, 3] }, { actor: memberActor, db });
+    const votes = db.tables.poll_votes.filter(
+      (row) => String(row.poll_id) === '2' && String(row.member_id) === '1',
+    );
+    expect(votes).toHaveLength(1);
+    expect(votes[0].option_id).toBe(3);
+  });
+
+  it('GH-118: rejects poll creation with fewer than two options and leaves no orphan poll', async () => {
+    const db = makeDb();
+    const before = db.tables.polls.length;
+    await expect(
+      executeCapabilityMutation('polls.create', { question: 'One?', options: ['only'] }, { actor: adminActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(
+      executeCapabilityMutation('polls.create', { question: 'None?', options: [] }, { actor: adminActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    expect(db.tables.polls.length).toBe(before);
   });
 });

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -391,4 +391,37 @@ describe('Capability API mutation bug fixes', () => {
     await executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'going' }, { actor: memberActor, db });
     expect(db.tables.event_rsvps.some((row) => String(row.member_id) === '1' && row.status === 'going')).toBe(true);
   });
+
+  it('GH-111: rejects create mutations with empty/invalid input instead of coercing', async () => {
+    const db = makeDb();
+    await expect(
+      executeCapabilityMutation('forum.topics.create', { categoryId: 1 }, { actor: memberActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(
+      executeCapabilityMutation('events.create', {}, { actor: adminActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(
+      executeCapabilityMutation(
+        'events.create',
+        { title: 'Bad dates', starts_at: '2026-07-02T10:00:00Z', ends_at: '2026-07-01T10:00:00Z' },
+        { actor: adminActor, db },
+      ),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(
+      executeCapabilityMutation('events.create', { title: 'Bad cap', capacity: -3 }, { actor: adminActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    expect(db.tables.forum_topics.some((row) => row.title === 'Untitled')).toBe(false);
+  });
+
+  it('GH-108: validate phase rejects a create op with missing required input', async () => {
+    const db = makeDb();
+    const result = await validateCapabilityMutation('forum.topics.create', {}, { actor: memberActor, db });
+    expect(result.accepted).toBe(false);
+    const ok = await validateCapabilityMutation(
+      'forum.topics.create',
+      { categoryId: 1, title: 'Real' },
+      { actor: memberActor, db },
+    );
+    expect(ok.accepted).toBe(true);
+  });
 });

--- a/tests/unit/capability-api-mutation-handlers.test.ts
+++ b/tests/unit/capability-api-mutation-handlers.test.ts
@@ -363,4 +363,32 @@ describe('Capability API mutation bug fixes', () => {
     ).rejects.toBeInstanceOf(CapabilityMutationError);
     expect(db.tables.polls.length).toBe(before);
   });
+
+  it('GH-116: rejects an RSVP status outside the allowed enum (exact match)', async () => {
+    const db = makeDb();
+    await expect(
+      executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'not-a-real-status' }, { actor: memberActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+    await expect(
+      executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'Going' }, { actor: memberActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+  });
+
+  it('GH-115: blocks a going RSVP at capacity, and a cancellation frees a seat', async () => {
+    const db = makeDb();
+    db.tables.events[0].capacity = 1;
+    db.tables.event_rsvps = [{ id: 1, event_id: 1, member_id: 99, status: 'going' }];
+
+    // A different member cannot go while the single seat is taken.
+    await expect(
+      executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'going' }, { actor: memberActor, db }),
+    ).rejects.toBeInstanceOf(CapabilityMutationError);
+
+    // The seated member cancels (admin acts on the row) — freeing the seat.
+    await executeCapabilityMutation('rsvps.setStatus', { id: 1, status: 'cancelled' }, { actor: adminActor, db });
+
+    // Now the member can go.
+    await executeCapabilityMutation('rsvps.setStatus', { eventId: 1, status: 'going' }, { actor: memberActor, db });
+    expect(db.tables.event_rsvps.some((row) => String(row.member_id) === '1' && row.status === 'going')).toBe(true);
+  });
 });

--- a/tests/unit/capability-api-query-handlers.test.ts
+++ b/tests/unit/capability-api-query-handlers.test.ts
@@ -364,3 +364,37 @@ describe('Capability API query handlers', () => {
     expect(body.data.rows.map((row: JsonObject) => row.title)).toEqual(['Public Resource', 'Member Resource']);
   });
 });
+
+describe('Capability API query bug fixes', () => {
+  const pollVotesDb = () =>
+    new MemoryQueryDb({
+      polls: [
+        { id: 1, question: 'Anon', is_anonymous: true, is_open: true },
+        { id: 2, question: 'Open', is_anonymous: false, is_open: true },
+      ],
+      poll_votes: [
+        { id: 1, poll_id: 1, option_id: 1, member_id: '10' },
+        { id: 2, poll_id: 2, option_id: 3, member_id: '10' },
+      ],
+    });
+
+  it('GH-117: redacts voter member_id for anonymous polls, even for admins', async () => {
+    for (const actor of [memberActor, adminActor]) {
+      const anon = (await runCapabilityQuery('pollVotes.list', { pollId: 1 }, { actor, db: pollVotesDb() })) as {
+        rows: JsonObject[];
+      };
+      expect(anon.rows).toHaveLength(1);
+      expect(anon.rows[0].member_id).toBeNull();
+    }
+  });
+
+  it('GH-117: keeps voter member_id for non-anonymous polls', async () => {
+    const open = (await runCapabilityQuery(
+      'pollVotes.list',
+      { pollId: 2 },
+      { actor: adminActor, db: pollVotesDb() },
+    )) as { rows: JsonObject[] };
+    expect(open.rows).toHaveLength(1);
+    expect(open.rows[0].member_id).toBe('10');
+  });
+});

--- a/tests/unit/capability-api-query-handlers.test.ts
+++ b/tests/unit/capability-api-query-handlers.test.ts
@@ -399,9 +399,9 @@ describe('Capability API query bug fixes', () => {
   });
 
   it('GH-107: .get without an identifier fails validation instead of returning row 0', async () => {
-    await expect(
-      runCapabilityQuery('events.get', {}, { actor: anonymousActor, db: sampleDb() }),
-    ).rejects.toMatchObject({ code: 'validation.failed' });
+    await expect(runCapabilityQuery('events.get', {}, { actor: anonymousActor, db: sampleDb() })).rejects.toMatchObject(
+      { code: 'validation.failed' },
+    );
     await expect(
       runCapabilityQuery('announcements.get', {}, { actor: anonymousActor, db: sampleDb() }),
     ).rejects.toMatchObject({ code: 'validation.failed' });

--- a/tests/unit/capability-api-query-handlers.test.ts
+++ b/tests/unit/capability-api-query-handlers.test.ts
@@ -421,4 +421,30 @@ describe('Capability API query bug fixes', () => {
     )) as JsonObject | null;
     expect(page?.slug).toBe('public');
   });
+
+  it('GH-112: config.get honors a category filter', async () => {
+    const db = new MemoryQueryDb({
+      site_config: [
+        { key: 'site_name', value: 'X', category: 'general' },
+        { key: 'theme_primary', value: '#000', category: 'theme' },
+      ],
+    });
+    const themed = (await runCapabilityQuery('config.get', { category: 'theme' }, { actor: adminActor, db })) as {
+      rows: JsonObject[];
+    };
+    expect(themed.rows.map((row) => row.key)).toEqual(['theme_primary']);
+  });
+
+  it('GH-125: config.get exposes brand keys to anon even under a non-public category', async () => {
+    const db = new MemoryQueryDb({
+      site_config: [
+        { key: 'brand_wordmark_url', value: '/w.png', category: 'wsmta' },
+        { key: 'secret_token', value: 'x', category: 'integrations' },
+      ],
+    });
+    const all = (await runCapabilityQuery('config.get', {}, { actor: anonymousActor, db })) as { rows: JsonObject[] };
+    const keys = all.rows.map((row) => row.key);
+    expect(keys).toContain('brand_wordmark_url');
+    expect(keys).not.toContain('secret_token');
+  });
 });

--- a/tests/unit/capability-api-query-handlers.test.ts
+++ b/tests/unit/capability-api-query-handlers.test.ts
@@ -397,4 +397,28 @@ describe('Capability API query bug fixes', () => {
     expect(open.rows).toHaveLength(1);
     expect(open.rows[0].member_id).toBe('10');
   });
+
+  it('GH-107: .get without an identifier fails validation instead of returning row 0', async () => {
+    await expect(
+      runCapabilityQuery('events.get', {}, { actor: anonymousActor, db: sampleDb() }),
+    ).rejects.toMatchObject({ code: 'validation.failed' });
+    await expect(
+      runCapabilityQuery('announcements.get', {}, { actor: anonymousActor, db: sampleDb() }),
+    ).rejects.toMatchObject({ code: 'validation.failed' });
+  });
+
+  it('GH-107: .get with a wrong-typed id fails validation instead of returning null', async () => {
+    await expect(
+      runCapabilityQuery('events.get', { id: 'not-an-int' }, { actor: anonymousActor, db: sampleDb() }),
+    ).rejects.toMatchObject({ code: 'validation.failed' });
+  });
+
+  it('GH-107: pages.get still resolves by slug', async () => {
+    const page = (await runCapabilityQuery(
+      'pages.get',
+      { slug: 'public' },
+      { actor: anonymousActor, db: sampleDb() },
+    )) as JsonObject | null;
+    expect(page?.slug).toBe('public');
+  });
 });


### PR DESCRIPTION
Triage-and-fix pass over the open GitHub issues (via the adapted `/bugs` skill). 12 fixable bugs fixed; 6 stale/not-a-bug issues closed and 10 feature requests labeled separately.

Every API fix is applied to **both** the deployed `functions/kychon-api.js` and the vitest-tested `src/lib/capability-api/*` reference.

## Fixes
| Issue | Fix |
|---|---|
| #119 | De-dupe repeated `optionIds` in a multiple-choice vote (was a 500 on the UNIQUE constraint) |
| #118 | Reject poll creation with <2 options before the poll row is inserted (no orphan poll) |
| #117 | Redact voter `member_id` from `pollVotes.list` for anonymous polls (unconditional, admins included) |
| #116 | Enforce the RSVP status enum (`going\|maybe\|cancelled`); reject out-of-enum / wrong-case |
| #115 | Block a new `going` RSVP at `events.capacity`; `maybe`/`cancelled` free a seat |
| #107 | Require an identifier on `*.get`; missing/wrong-typed id → `validation.failed` (was returning row 0 / null) |
| #108 | `validate` phase runs the same create-input validator as execute (no more accepted:true then coerce) |
| #111 | Require non-empty title/name on create ops; validate event dates/capacity when supplied |
| #112 | `config.get` honors the `category` filter; `config.set` preserves the stored category when omitted |
| #125 | Brand-identity keys are anonymously readable via `config.get` regardless of category (chrome hydration parity) |
| #110 | Unwired ops (`translations.translateText`, `assets.upload`, `jobs.*`, `exports.*`) return `api.notImplemented` instead of fake `ok:true` / retryable `internal.error` |
| #14  | Bump `deploy-demos.yml` actions to `@v6` (Node 20 deprecation) |

## Verification
- Vitest: **1076 tests pass** (~14 new regression tests added)
- Biome: clean · Astro typecheck: **0 errors**

Note: the contract-tightening changes (#107/#108/#110/#111/#112) alter documented API behavior — the SDK/docs may want a follow-up bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
