### PR TITLE
Unshadow nav menu-item color (fixes mobile 1.84:1; makes dropdown config actually work)

### DIFF
--- a/src/components/kychon/NavBlockView.tsx
+++ b/src/components/kychon/NavBlockView.tsx
@@ -77,7 +77,16 @@ const nestedMenuListClass = cn(
   '[[data-nav-shell][data-nav-source-mobile=true]_[data-nav-links][data-nav-mobile-open=true]_&]:pl-6',
 );
 
-const navMenuItemClass = 'block rounded-md px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none';
+// No base text-color utility here: globals.css imports public.css into
+// `@layer components` and Tailwind utilities into the later `@layer
+// utilities`, so a `text-muted-foreground` utility would win over the
+// config-driven dropdown/mobile color rules in public.css regardless of
+// their specificity (that shadowing is why the nav dropdown_* config was
+// dead on deploy). The resting color is owned by public.css
+// `[data-nav-menu] [data-nav-menuitem]` (desktop = --nav-dropdown-color,
+// mobile/overflow = --nav-link-color); the hover/focus accent utilities
+// stay as a deliberate legible pairing.
+const navMenuItemClass = 'block rounded-md px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none';
 
 function Chevron() {
   return (

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -207,6 +207,11 @@ export interface NavPresentationConfig {
   chevron_color?: string;
   transition?: string;
   mobile_menu_bg?: string;
+  /** Text color for the mobile/overflow menu surface. Defaults to the bar's
+   *  link color (which pairs with mobile_menu_bg), so submenu items stay
+   *  legible on a dark mobile panel instead of inheriting the desktop
+   *  popover color. */
+  mobile_menu_color?: string;
   mobile_menu_padding?: string;
   /** 'static' lets the header scroll with the page (copied-site source
    *  behavior parity); default is the sticky header. */
@@ -1178,6 +1183,7 @@ function renderNavPresentationProps(cfg: NavConfig): {
   setNavStyle(style, '--nav-focus-color', focus.border || focus.text);
   setNavStyle(style, '--nav-transition', p.transition || hover.duration);
   setNavStyle(style, '--nav-mobile-menu-bg', p.mobile_menu_bg);
+  setNavStyle(style, '--nav-mobile-menu-color', p.mobile_menu_color);
   setNavStyle(style, '--nav-mobile-menu-padding', p.mobile_menu_padding);
   setNavStyle(style, '--nav-header-position', p.header_position);
 

--- a/src/styles/public.css
+++ b/src/styles/public.css
@@ -292,6 +292,24 @@ a:hover {
   color: var(--nav-dropdown-hover-color, var(--accent-foreground, var(--color-text)));
 }
 
+/* On mobile-open / overflow the submenu collapses into the bar's vertical
+   panel — transparent over --nav-mobile-menu-bg, sitting right beside the
+   top-level [data-nav-link]s. So its items belong to the BAR's color context
+   (--nav-link-color, which the porter already pairs with the mobile panel
+   bg), NOT the desktop floating popover's --nav-dropdown-color. Without this
+   override a dark mobile panel keeps the light-popover text color and the
+   submenu items go unreadable (wsmta mobile submenu measured 1.84:1; the
+   top-level links beside them were fine because they already use
+   --nav-link-color). Higher specificity than the desktop rule above (extra
+   [data-nav-links]/[data-nav-mobile-open] / [data-nav-overflow-menu]
+   ancestor), so it wins only in the mobile/overflow contexts. */
+[data-nav-links][data-nav-mobile-open="true"] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem],
+[data-nav-links][data-nav-mobile-open="true"] [data-nav-menu] [data-nav-menuitem-parent][data-nav-menuitem-parent],
+[data-nav-overflow-menu] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem],
+[data-nav-overflow-menu] [data-nav-menu] [data-nav-menuitem-parent][data-nav-menuitem-parent] {
+  color: var(--nav-mobile-menu-color, var(--nav-link-color, var(--muted-foreground, var(--color-text-muted))));
+}
+
 [data-nav-link],
 [data-nav-parent-trigger] {
   padding: var(--nav-link-padding, 0.5rem 0.75rem);

--- a/tests/unit/mobile-submenu-contrast-source.test.ts
+++ b/tests/unit/mobile-submenu-contrast-source.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(import.meta.dirname, '../..');
+const css = readFileSync(join(root, 'src/styles/public.css'), 'utf8');
+const blocks = readFileSync(join(root, 'src/lib/blocks.ts'), 'utf8');
+const navView = readFileSync(join(root, 'src/components/kychon/NavBlockView.tsx'), 'utf8');
+const globals = readFileSync(join(root, 'src/styles/globals.css'), 'utf8');
+
+describe('mobile submenu contrast', () => {
+  it('menu items carry no base text-color utility (it would shadow the config rules via @layer)', () => {
+    // public.css is in @layer components; Tailwind utilities are in the later
+    // @layer utilities, which wins regardless of specificity. A
+    // `text-muted-foreground` on the item therefore overrode the dropdown/
+    // mobile color rules — dead config. The resting color must come from
+    // public.css, not a utility.
+    expect(globals).toContain('@import "./public.css" layer(components)');
+    const navMenuItemClass = navView.split('const navMenuItemClass =')[1].split(';')[0];
+    expect(navMenuItemClass).not.toContain('text-muted-foreground');
+    // no resting text-color utility (font-size text-sm is fine; state-scoped
+    // hover:/focus: colors are intentional)
+    expect(navMenuItemClass).not.toMatch(/(?:^|\s)text-(?:foreground|primary|secondary|accent|muted)/);
+  });
+
+  it('mobile/overflow submenu items use the bar link color, not the desktop popover color', () => {
+    for (const ctx of ['[data-nav-links][data-nav-mobile-open="true"]', '[data-nav-overflow-menu]']) {
+      expect(css).toContain(`${ctx} [data-nav-menu] [data-nav-menuitem][data-nav-menuitem]`);
+    }
+    const mobileRule = css
+      .split('[data-nav-links][data-nav-mobile-open="true"] [data-nav-menu] [data-nav-menuitem][data-nav-menuitem]')[1]
+      ?.split('}')[0];
+    expect(mobileRule).toContain('--nav-mobile-menu-color');
+    expect(mobileRule).toContain('--nav-link-color');
+    expect(mobileRule).not.toContain('--nav-dropdown-color');
+  });
+
+  it('the mobile_menu_color lever is wired (not dead config)', () => {
+    expect(blocks).toContain('mobile_menu_color?: string');
+    expect(blocks).toContain("setNavStyle(style, '--nav-mobile-menu-color', p.mobile_menu_color)");
+  });
+});


### PR DESCRIPTION
## Root cause (deeper than the symptom)

The wsmta mobile submenu measured **1.84:1**. Tracing it surfaced that **#137's `dropdown_*` config was never actually live**: `globals.css` imports `public.css` into `@layer components` and Tailwind utilities into the later `@layer utilities` — a later layer wins regardless of specificity, so the `text-muted-foreground` utility on the menu item overrode every config-driven color rule in `public.css`. The desktop white-on-white only *looked* fixed by #137 because banning the `!important` hack let the muted default show, which is legible on the light popover. On the dark mobile panel that same muted default is the 1.84:1 bug.

Verified live: setting `--nav-dropdown-color: red` on the deployed dropdown did nothing — the utility shadowed it.

## Fix

- Remove the resting text-color utility from `navMenuItemClass` so the component-layer rules own menu-item color (hover/focus accent utilities stay — a legible pair).
- Mobile/overflow submenu items resolve to the bar's `--nav-link-color` (pairs with `--nav-mobile-menu-bg`) instead of the desktop popover's `--nav-dropdown-color`.
- Wire the optional `--nav-mobile-menu-color` lever (not dead config).

Native sites unchanged on desktop (muted default via the #137 fallback); the dark mobile panel goes from 1.84:1 to the bar's own contrast. This also makes `dropdown_color`/`dropdown_bg` genuinely functional for the first time.

Gates: vitest 1079/1079, biome clean, astro check clean. Empirical confirmation comes from the next port re-deploy's dual-state contrast gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)