### PR TITLE
Nav active state: keep the resting legible color, not brand --primary

### DIFF
--- a/src/components/kychon/NavBlockView.tsx
+++ b/src/components/kychon/NavBlockView.tsx
@@ -227,7 +227,7 @@ function MenuAnchor({
 }) {
   return (
     <a
-      className={cn(navMenuItemClass, active ? 'bg-primary/10 text-primary' : '', className)}
+      className={cn(navMenuItemClass, className)}
       data-nav-active={active ? 'true' : undefined}
       data-nav-menuitem=""
       href={href}

--- a/src/styles/public.css
+++ b/src/styles/public.css
@@ -329,10 +329,28 @@ a:hover {
   background: var(--nav-link-hover-bg, var(--muted, var(--color-surface)));
   color: var(--nav-link-hover-color, var(--foreground, var(--color-text)));
 }
+/* Active state keeps the RESTING link color (which is already paired with
+   the bar/panel background, so legible by construction in both schemes) and
+   distinguishes itself with a subtle background tint + heavier weight. The
+   previous default swapped the text to --primary (the brand color), which on
+   a dark bar — where --primary is also dark — went invisible in both light
+   and dark schemes (the wsmta active/dropdown contrast finding). A port can
+   still opt into an explicit active color via --nav-link-active-color. */
 [data-nav-link][data-nav-active="true"],
 [data-nav-parent-trigger][data-nav-active="true"] {
-  color: var(--nav-link-active-color, var(--primary, var(--color-primary)));
-  background: var(--nav-link-active-bg, rgba(99, 102, 241, 0.08));
+  color: var(--nav-link-active-color, var(--nav-link-color, var(--muted-foreground, var(--color-text-muted))));
+  background: var(--nav-link-active-bg, color-mix(in srgb, currentColor 12%, transparent));
+  font-weight: var(--nav-link-active-weight, 600);
+}
+/* Active dropdown/mobile menu item: same principle (the component no longer
+   sets bg-primary/10 text-primary utilities, which @layer-shadowed this). It
+   inherits its context color from the resting menu-item rules — desktop
+   --nav-dropdown-color, mobile/overflow --nav-link-color — and only adds the
+   tint + weight here, so it can never go invisible on a dark panel. */
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem][data-nav-active="true"],
+[data-nav-shell] [data-nav-menu] [data-nav-menuitem-parent][data-nav-active="true"] {
+  background: var(--nav-dropdown-active-bg, color-mix(in srgb, currentColor 12%, transparent));
+  font-weight: var(--nav-link-active-weight, 600);
 }
 [data-nav-user] {
   grid-column: 3;

--- a/tests/unit/nav-active-contrast-source.test.ts
+++ b/tests/unit/nav-active-contrast-source.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(import.meta.dirname, '../..');
+const css = readFileSync(join(root, 'src/styles/public.css'), 'utf8');
+const navView = readFileSync(join(root, 'src/components/kychon/NavBlockView.tsx'), 'utf8');
+
+describe('nav active-state contrast', () => {
+  it('the active menu item carries no brand-color utility (it shadowed the config rules and went invisible on dark bars)', () => {
+    expect(navView).not.toContain('text-primary');
+    expect(navView).not.toContain('bg-primary/10');
+  });
+
+  it('active link text defaults to the resting nav link color, never the brand --primary', () => {
+    const rule = css.split('[data-nav-link][data-nav-active="true"]')[1]?.split('}')[0];
+    expect(rule).toContain('--nav-link-active-color');
+    expect(rule).toContain('--nav-link-color');
+    expect(rule).not.toContain('--primary'); // brand color caused the dark-on-dark failure
+  });
+
+  it('active emphasis is a currentColor-derived tint (scheme/bar proof), plus weight', () => {
+    const rule = css.split('[data-nav-link][data-nav-active="true"]')[1]?.split('}')[0];
+    expect(rule).toContain('color-mix(in srgb, currentColor');
+    expect(rule).toContain('--nav-link-active-weight');
+    // the dropdown/mobile active item only adds bg + weight, keeping its
+    // resting (config-driven) color
+    expect(css).toContain('[data-nav-menuitem][data-nav-active="true"]');
+  });
+});


### PR DESCRIPTION
Closes the last mobile-contrast finding — active/dropdown controls failing in both schemes.

**Mechanism (now fully understood):** the active state swapped text to the *brand* color — top-level via public.css `var(--nav-link-active-color, var(--primary))`, dropdown items via `bg-primary/10 text-primary` utilities (which @layer-shadow any public.css rule). On a dark bar, `--primary` is itself dark → active controls render dark-on-dark, invisible in light AND dark schemes. This is why my two prior passes (resting-color fixes) didn't catch it — they fixed the resting color but the *active* state still swapped to brand.

**Fix:** the active state keeps the **resting** link color — already paired with the bar/panel background, so legible by construction — and distinguishes itself with a `currentColor`-derived background tint (scheme/bar proof) + heavier weight. Removed the shadowing utilities; active text defaults to `--nav-link-color`; active dropdown/mobile items add only tint+weight over their resting config color. `--nav-link-active-color` remains an opt-in lever.

Gates: vitest 1104/1104 (3 new source tests), biome clean, astro check clean. Live confirmation comes from the next port's independent refuter (real mobile viewport, both schemes) — the reasoning is now sound (active = resting legible color) rather than speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)