### PR TITLE
docs(api): document gateway-vs-operation error distinction (closes #113)

### DIFF
--- a/docs/kychon-api.md
+++ b/docs/kychon-api.md
@@ -52,7 +52,13 @@ Mutations return an `ActionPlan` during validation and an `ActionResult` during 
 
 ## Errors
 
-Errors return `ok: false`, `correlationId`, and stable dotted codes such as `request.invalidJson`, `api.unsupportedVersion`, `permission.denied`, `validation.failed`, `conflict.idempotencyKey`, `notFound.object`, and `confirmation.required`.
+There are two error layers, distinguishable by a `source` field on the error.
+
+**Operation errors** are raised by a capability handler once the request reaches the function. They return `{ ok: false, correlationId, error: { code, message, ... } }` with stable dotted codes such as `request.invalidJson`, `api.unsupportedVersion`, `permission.denied`, `validation.failed`, `conflict.idempotencyKey`, `notFound.object`, `confirmation.required`, and `api.notImplemented`.
+
+**Gateway-boundary errors** are raised by the Run402 gateway *before* the function runs — a malformed JSON body, or a missing or invalid `apikey`. These carry `source: "gateway"`, a `category`, a coarse `code` (`VALIDATION_FAILED`, `AUTH_REQUIRED`, `INVALID_AUTH`), and a `next_actions` array describing how to recover. They are **not** part of the dotted operation catalog — branch on `source === "gateway"` to handle them.
+
+In short: treat any error carrying `source: "gateway"` as a transport/auth problem to fix in the request itself (well-formed JSON, a valid `apikey`), and reserve dotted-code handling for operation errors.
 
 ## Catalog
 

--- a/openspec/changes/port-fidelity-typed-blocks/tasks.md
+++ b/openspec/changes/port-fidelity-typed-blocks/tasks.md
@@ -55,4 +55,4 @@
 - [ ] 8.1 File a `kychee-com/run402` issue for the platform bot-protection (reCAPTCHA) hook the `member_login` flag depends on (#91)
 - [ ] 8.2 File a `kychee-com/run402` issue for gateway error-envelope normalization so pre-handler errors match the documented dotted-code contract (#113)
 - [ ] 8.3 File a `kychee-com/kychon-concierge` follow-up: emit the coverage report from the new registry and switch menu/panels/utility-header/login ports from custom-HTML workarounds to the typed blocks
-- [ ] 8.4 After ship + demo verification, close #124, #123, #99, #106, and the Kychon-side of #91
+- [x] 8.4 After ship + demo verification, close #124, #123, #99, #106, and the Kychon-side of #91 _(closed #124/#123/#99; #106 and #91 commented with partial progress and kept open pending the deferred @layer override (#106) and the run402 reCAPTCHA hook (#91))_

--- a/openspec/changes/port-fidelity-typed-blocks/tasks.md
+++ b/openspec/changes/port-fidelity-typed-blocks/tasks.md
@@ -48,7 +48,7 @@
 - [x] 7.1 Add a port-fidelity demo page (seed) exercising `feature_panels`, `menu`, the utility-header preset, and `member_login` _(wired into the silver-pines 'Block Showcase' page)_
 - [x] 7.2 Add the new blocks' translatable keys to `public/custom/strings/*` _(N/A — the blocks are fully config-driven with no hardcoded UI strings; their content translates via `translatableFields` → `content_translations`, not the strings files)_
 - [x] 7.3 Run `npm run check` (vitest, biome, astro check, tsc) and the visual-parity suite to green _(vitest 932 + biome + astro check + tsc all green; the `ui:architecture-check` step fails only on the pre-existing `auth-hosted.css`, unrelated to this change)_
-- [ ] 7.4 Verify the new blocks render on the eagles/silver-pines/barrio demos _(requires a deploy — the showcase content hydrates from the DB; render path itself verified in the local preview)_
+- [x] 7.4 Verify the new blocks render on the eagles/silver-pines/barrio demos _(deployed via PR #140; live `sections.list` on silver-pines returns all 6 new block types on the showcase page — confirmed against the same render path verified in the preview)_
 
 ## 8. Cross-repo escalations and close-out (tracked, not Kychon code)
 

--- a/openspec/changes/port-fidelity-typed-blocks/tasks.md
+++ b/openspec/changes/port-fidelity-typed-blocks/tasks.md
@@ -52,7 +52,7 @@
 
 ## 8. Cross-repo escalations and close-out (tracked, not Kychon code)
 
-- [ ] 8.1 File a `kychee-com/run402` issue for the platform bot-protection (reCAPTCHA) hook the `member_login` flag depends on (#91)
-- [ ] 8.2 File a `kychee-com/run402` issue for gateway error-envelope normalization so pre-handler errors match the documented dotted-code contract (#113)
-- [ ] 8.3 File a `kychee-com/kychon-concierge` follow-up: emit the coverage report from the new registry and switch menu/panels/utility-header/login ports from custom-HTML workarounds to the typed blocks
+- [x] 8.1 File a `kychee-com/run402` issue for the platform bot-protection (reCAPTCHA) hook the `member_login` flag depends on (#91) _(filed run402-private#500; linked from #91)_
+- [x] 8.2 File a `kychee-com/run402` issue for gateway error-envelope normalization so pre-handler errors match the documented dotted-code contract (#113) _(filed run402-private#501; linked from #113)_
+- [x] 8.3 File a `kychee-com/kychon-concierge` follow-up: emit the coverage report from the new registry and switch menu/panels/utility-header/login ports from custom-HTML workarounds to the typed blocks _(filed kychon-concierge#49)_
 - [x] 8.4 After ship + demo verification, close #124, #123, #99, #106, and the Kychon-side of #91 _(closed #124/#123/#99; #106 and #91 commented with partial progress and kept open pending the deferred @layer override (#106) and the run402 reCAPTCHA hook (#91))_


### PR DESCRIPTION
Documents the two error layers in `docs/kychon-api.md` now that the Run402 gateway attributes pre-handler errors with `source:"gateway"` (run402-private#501, live + prod-verified):

- **Operation errors** — dotted catalog codes from a capability handler.
- **Gateway-boundary errors** — `source:"gateway"` + coarse code (`VALIDATION_FAILED`/`AUTH_REQUIRED`/`INVALID_AUTH`) + `next_actions`, raised before the function runs. Branch on `source === "gateway"`.

This is the Kychon-side resolution of #113 (the platform half shipped in run402-private#501). Also carries trailing OpenSpec task-record updates for the port-fidelity change.

Verified live: invalid JSON / missing-apikey / invalid-apikey all now return `source:"gateway"` on api.run402.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)