### PR TITLE
chore(deps): upgrade @run402/sdk + CLI to 3.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "@biomejs/biome": "^2.4.10",
-        "@run402/sdk": "2.46.0",
+        "@run402/sdk": "3.3.2",
         "@tailwindcss/vite": "4.2.4",
         "@types/node": "^25.6.0",
         "@types/react": "19.2.14",
@@ -50,7 +50,7 @@
         "astro": "^6.1.3",
         "fast-check": "^4.1.1",
         "happy-dom": "^20.9.0",
-        "run402": "2.46.0",
+        "run402": "3.3.2",
         "tailwindcss": "4.2.4",
         "tsx": "4.21.0",
         "typescript": "^5.7.3",
@@ -3834,9 +3834,9 @@
       }
     },
     "node_modules/@run402/sdk": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@run402/sdk/-/sdk-2.46.0.tgz",
-      "integrity": "sha512-VJAUdQP6qu0Kdavl26RSKzu/BWzyV5sL0FXDpy47Xh74O//3UHOpZxa4DweQme1wKNi328qwwUmm0mViwGefmQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@run402/sdk/-/sdk-3.3.2.tgz",
+      "integrity": "sha512-ZzaH/wsyKMlqqdJ2WzoyRsYWDTG+x4LQn1JxdO7aiQfBxp7IK00v6jCbJw6syfrJImQv9xTGT4gk0QA17IDWTQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -9044,9 +9044,9 @@
       }
     },
     "node_modules/run402": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/run402/-/run402-2.46.0.tgz",
-      "integrity": "sha512-zjqOHUXkneYQ9MmhJ4RFjYhmzvOxiHuITuxZa+g2bGccn+ppdP8dhDH7xT3sCNRgEeDTWj4UFBPsNdWlhCoyWA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/run402/-/run402-3.3.2.tgz",
+      "integrity": "sha512-MZbOhdZ6hGdC0NeU22sdiQ8F1EFayUxNFPefgUHDomvsduPzpYOZsZ6/IlvJdMqilAJD8z7wGpxk5YLbNf6wYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@biomejs/biome": "^2.4.10",
-    "@run402/sdk": "2.46.0",
+    "@run402/sdk": "3.3.2",
     "@tailwindcss/vite": "4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "19.2.14",
@@ -44,7 +44,7 @@
     "astro": "^6.1.3",
     "fast-check": "^4.1.1",
     "happy-dom": "^20.9.0",
-    "run402": "2.46.0",
+    "run402": "3.3.2",
     "tailwindcss": "4.2.4",
     "tsx": "4.21.0",
     "typescript": "^5.7.3",


### PR DESCRIPTION
Upgrades the run402 SDK + CLI from **2.46.0 → 3.3.2** (a 2.x→3.x major jump). Also bumps the demos, since they deploy from this repo.

## Why no code changes
The 3.x breaking changes all target SDK surfaces Kychon doesn't use:
- **v3.0.0** `ContractWallet*`→`Signer*` rename (contracts/signers — unused)
- **v3.3.0** handoff methods collapsed into the unified `transfer` noun (unused)
- **v3.3.1** `organization_id`→`org_id` (billing/tier/admin-finance — unused)
- **v3.3.2** `Principal`/`Authenticator`/`Cache`/`OrgInvite` → snake_case + transfer keyset pagination (unused)

Kychon's `apply`/`deploy`/`projects.keys`/`ci.*` surface was already snake_case from the 2.0 Unified Apply cutover, so nothing here needed migrating.

## Verification (all green)
- `tsc --project tsconfig.scripts.json`
- 1104 tests (157 files)
- `biome check` (176 files)
- `astro check` — 0 errors
- full `astro build`
- seed smoke (4 seeds)

Lockfile change is surgical — only the two 3.3.2 bumps, no collateral version churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)