### PR TITLE
fix(ui-check): allow vendor .r402-* selectors in the hosted-auth theme bridge

### DIFF
--- a/scripts/ui-architecture-check.ts
+++ b/scripts/ui-architecture-check.ts
@@ -20,6 +20,12 @@ const ALLOWED_UI_FACADE_IMPORT_PREFIXES = ['src/components/ui/'];
 const ALLOWED_UI_FACADE_IMPORT_FILES = new Set(['src/components/kychon/ui.ts']);
 const ALLOWED_DOM_MUTATION_HELPER_FILES = new Set(['tests/helpers/dom-fixture.js']);
 const ALLOWED_DOM_FRAGMENT_IMPORT_FILES = new Set<string>();
+// Hosted @run402/astro auth components (<SignIn>, <AccountSecurity>, …) render their own
+// .r402-* DOM and expose CSS-variable hooks. Theming them requires targeting those vendor
+// class names — data attributes / Tailwind utilities can't reach markup we don't own — so
+// the theme-bridge stylesheet may define .r402-* selectors (and only those vendor names).
+const ALLOWED_VENDOR_SELECTOR_CSS_FILES = new Set(['src/styles/auth-hosted.css']);
+const VENDOR_SELECTOR_PREFIX_RE = /^r402-/;
 const PRIMITIVE_IMPORT_RE = /from\s+['"](@radix-ui\/[^'"]+|@base-ui-components\/[^'"]+)['"]/g;
 const UI_FACADE_IMPORT_RE = /from\s+['"](@\/components\/ui\/[^'"]+)['"]/g;
 const RELATIVE_IMPORT_RE = /from\s+['"](\.{1,2}\/[^'"]+)['"]/g;
@@ -130,6 +136,11 @@ function isAllowedDomMutation(file: string, token: string): boolean {
 function isAllowedDomFragmentImport(file: string): boolean {
   const rel = relative(ROOT, file).replaceAll('\\', '/');
   return ALLOWED_DOM_FRAGMENT_IMPORT_FILES.has(rel);
+}
+
+function isAllowedVendorSelector(file: string, className: string): boolean {
+  const rel = relative(ROOT, file).replaceAll('\\', '/');
+  return ALLOWED_VENDOR_SELECTOR_CSS_FILES.has(rel) && VENDOR_SELECTOR_PREFIX_RE.test(className);
 }
 
 function isDomFragmentImportTarget(target: string): boolean {
@@ -332,6 +343,7 @@ export function checkSource(file: string, source: string): Violation[] {
     }
 
     for (const match of cssForSelectorScan.matchAll(CSS_CLASS_SELECTOR_RE)) {
+      if (isAllowedVendorSelector(file, match[2])) continue;
       const line = lineNumber(cssForSelectorScan, match.index ?? 0);
       violations.push({
         file: rel,

--- a/tests/unit/ui-architecture-check.test.ts
+++ b/tests/unit/ui-architecture-check.test.ts
@@ -173,6 +173,24 @@ describe('ui architecture check', () => {
     );
   });
 
+  it('allows vendor .r402-* selectors only in the hosted-auth theme bridge', () => {
+    const vendorCss =
+      '.r402-sign-in, .r402-input:focus-visible { color: var(--color-foreground); } .r402-method { gap: 0.5rem; }';
+
+    // The designated theme-bridge file may target the hosted @run402/astro components' vendor DOM.
+    expect(messages('src/styles/auth-hosted.css', vendorCss)).toEqual([]);
+
+    // Any other CSS file may not — the exception is scoped to the allowlisted file.
+    expect(messages('src/styles/other.css', vendorCss)).toContain(
+      'Owned CSS must not define custom class selector .r402-sign-in; use data attributes, semantic elements, or Tailwind utilities',
+    );
+
+    // Even the allowlisted file may not define non-vendor owned classes.
+    expect(messages('src/styles/auth-hosted.css', '.feature-card { color: red; }')).toContain(
+      'Owned CSS must not define custom class selector .feature-card; use data attributes, semantic elements, or Tailwind utilities',
+    );
+  });
+
   it('keeps seed artifacts free of legacy embedded HTML primitives', () => {
     const violations = messages(
       '_aage-port.seed.sql',


### PR DESCRIPTION
## Root cause
`npm run check`'s `ui:architecture-check` step (local-only — **not in `ci.yml`**) has failed since commit 346f1f9, which added [`src/styles/auth-hosted.css`](src/styles/auth-hosted.css) — the theme bridge for the hosted `@run402/astro` `<SignIn>`/`<AccountSecurity>` components — without updating the checker.

The CSS rule flags **every** `.class` selector in owned CSS (correct, by default). But the hosted components render their own `.r402-*` DOM and expose only CSS-variable hooks; you can't reach that markup with data attributes or Tailwind utilities, so targeting the vendor class names is the only way to theme them. The file even documents this in its header ("no custom primitive CSS"). It's imported by `profile.astro` and `join.astro`, so it's live, not dead code.

## Fix
Mirror the escape-hatch pattern every other rule in `ui-architecture-check.ts` already uses (`ALLOWED_*` sets): permit the `.r402-*` vendor namespace, and **only** in the allowlisted theme-bridge file.

Deliberately narrow:
- The allowlisted file still **cannot** define non-vendor owned classes (e.g. `.feature-card`).
- No other CSS file can define `.r402-*`.

Both guarantees are covered by a new regression test in `tests/unit/ui-architecture-check.test.ts`.

## Verification
- `npx tsx scripts/ui-architecture-check.ts` → `ok ui architecture check (404 files scanned)`
- `npm run check` → **exit 0** end-to-end (was failing at this step)
- `ui-architecture-check.test.ts` → 11 tests pass (10 → 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)