### PR TITLE
feat(deploy): gated publicPathOverrides + extraRoutes for copied-site source aliases

### DIFF
--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -31,6 +31,7 @@ import type {
 import {
   buildExplicitPublicPathSpecs,
   customPageStaticFile,
+  mergePublicPathOverrides,
   safeCustomPageSlugs,
 } from "../src/lib/clean-routes.ts";
 import { applyLiveConfigOverrides, fetchLiveSiteConfig } from "../src/lib/build-config.ts";
@@ -773,13 +774,14 @@ export async function runDeploy(
     .map(d => join(d.parentPath, d.name).slice(clientDir.length + 1).replaceAll("\\", "/"));
   const fileCount = useExplicitPublicPaths ? distFiles.length : -1;
   const publicPaths = useExplicitPublicPaths
-    ? {
-        ...buildExplicitPublicPathSpecs({
+    ? mergePublicPathOverrides({
+        generated: buildExplicitPublicPathSpecs({
           files: distFiles,
           pageSlugs: materializedCustomPages.map((page) => page.slug),
         }),
-        ...(opts.publicPathOverrides ?? {}),
-      }
+        overrides: opts.publicPathOverrides ?? {},
+        buildAssets: distFiles,
+      })
     : {};
   const publicPathEntries = Object.entries(publicPaths);
 
@@ -835,6 +837,15 @@ export async function runDeploy(
   // client migration; both hit the same function with the same per-op checks.
   // If the Astro slice omits `routes`, base-release routes carry forward.
   // Default to [] so we still prepend /api/kychon.
+  // `extraRoutes` is only meaningful when an adapter slice supplies a routes
+  // table to prepend onto; without one, base-release routes carry forward and
+  // the extras would be silently dropped. Fail loud instead of deploying a spec
+  // that ignores the caller's routes.
+  if ((opts.extraRoutes?.length ?? 0) > 0 && !astroSlice) {
+    throw new Error(
+      "runDeploy: extraRoutes requires an adapter (SSR) deploy; no @run402/astro slice is active for this build.",
+    );
+  }
   const baseRoutes = astroSlice ? (astroSlice.routes?.replace ?? []) : undefined;
   const sameOriginApiRoute = { pattern: "/api/kychon", target: { type: "function", name: "kychon-api" } as const };
   const routes = baseRoutes
@@ -906,8 +917,8 @@ export async function runDeploy(
           ),
           publicPathsCount: publicPathEntries.length,
           publicPaths,
-          routesCount: 0,
-          routes: [],
+          routesCount: (routes ?? []).length,
+          routes: routes ?? [],
           materializedCustomPages,
           migrationsBytes: sql.length,
           migrationId,

--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -517,6 +517,16 @@ export interface RunDeployOptions {
   /** When true, prints the assembled spec and returns without calling the API. */
   dryRun?: boolean;
   /**
+   * Extra browser-visible static paths to overlay on the generated public-path
+   * map. Supplying this (any non-undefined value) switches an adapter deploy
+   * from the default implicit `public_paths` to an explicit map so the
+   * overrides survive — needed for copied-site source aliases such as
+   * capitalized Wild Apricot paths. Omit to leave adapter behavior unchanged.
+   */
+  publicPathOverrides?: Record<string, PublicStaticPathSpec>;
+  /** Extra same-origin route entries, prepended before the adapter routes. */
+  extraRoutes?: NonNullable<Exclude<ReleaseSpec["routes"], null>>["replace"];
+  /**
    * When true, fetch the active release before deploying and use
    * `functions.patch` to only upload functions whose source hash changed.
    * Functions that need to be removed (via excludeFunctions) are explicitly
@@ -750,19 +760,27 @@ export async function runDeploy(
   // is active, astroSlice.site already carries the LocalDirRef +
   // public_paths (implicit mode), so we skip the manual walk.
   const siteDir = adapterActive ? null : dir(clientDir);
-  const dirents = adapterActive
-    ? []
-    : await readdir(clientDir, { recursive: true, withFileTypes: true });
+  // Adapter deploys normally use implicit `public_paths` (the slice carries the
+  // LocalDirRef) and skip the manual walk. When the caller supplies
+  // `publicPathOverrides`, switch to an explicit map so those overrides survive
+  // (copied-site source aliases). Non-adapter deploys always walk.
+  const useExplicitPublicPaths = !adapterActive || opts.publicPathOverrides !== undefined;
+  const dirents = useExplicitPublicPaths
+    ? await readdir(clientDir, { recursive: true, withFileTypes: true })
+    : [];
   const distFiles = dirents
     .filter(d => d.isFile())
     .map(d => join(d.parentPath, d.name).slice(clientDir.length + 1).replaceAll("\\", "/"));
-  const fileCount = adapterActive ? -1 : distFiles.length;
-  const publicPaths = adapterActive
-    ? {}
-    : buildExplicitPublicPathSpecs({
-        files: distFiles,
-        pageSlugs: materializedCustomPages.map((page) => page.slug),
-      });
+  const fileCount = useExplicitPublicPaths ? distFiles.length : -1;
+  const publicPaths = useExplicitPublicPaths
+    ? {
+        ...buildExplicitPublicPathSpecs({
+          files: distFiles,
+          pageSlugs: materializedCustomPages.map((page) => page.slug),
+        }),
+        ...(opts.publicPathOverrides ?? {}),
+      }
+    : {};
   const publicPathEntries = Object.entries(publicPaths);
 
   const collectOpts: CollectFunctionsOptions = {};
@@ -819,7 +837,9 @@ export async function runDeploy(
   // Default to [] so we still prepend /api/kychon.
   const baseRoutes = astroSlice ? (astroSlice.routes?.replace ?? []) : undefined;
   const sameOriginApiRoute = { pattern: "/api/kychon", target: { type: "function", name: "kychon-api" } as const };
-  const routes = baseRoutes ? [sameOriginApiRoute, ...baseRoutes] : baseRoutes;
+  const routes = baseRoutes
+    ? [sameOriginApiRoute, ...(opts.extraRoutes ?? []), ...baseRoutes]
+    : baseRoutes;
 
   const spec = buildKychonReleaseSpec({
     database,
@@ -834,9 +854,13 @@ export async function runDeploy(
     i18n: i18nSpec,
   });
   if (astroSlice) {
-    // Swap in the adapter's full site spec (LocalDirRef to
-    // dist/run402/client + `public_paths: { mode: 'implicit' }`).
-    spec.site = astroSlice.site;
+    // Swap in the adapter's full site spec (LocalDirRef to dist/run402/client).
+    // Keep the slice's implicit `public_paths` unless the caller supplied
+    // `publicPathOverrides`, in which case preserve the explicit map assembled
+    // above so copied-site source aliases survive the adapter deploy.
+    spec.site = opts.publicPathOverrides !== undefined
+      ? { ...astroSlice.site, public_paths: { mode: "explicit", replace: publicPaths } }
+      : astroSlice.site;
   }
 
   const fnSummary = fnDiff

--- a/src/lib/clean-routes.ts
+++ b/src/lib/clean-routes.ts
@@ -214,6 +214,40 @@ export function buildExplicitPublicPathSpecs(opts: {
   return Object.fromEntries([...entries].sort(([a], [b]) => a.localeCompare(b)));
 }
 
+/**
+ * Overlay caller-supplied public-path overrides onto a generated public-path
+ * map, applying the same validation that generated entries pass through. Used by
+ * adapter (SSR) deploys of copied-site ports that must publish source aliases
+ * the engine can't otherwise reach (e.g. capitalized Wild Apricot paths like
+ * `/Tournament-Standings`). Overrides win on key collision. Throws when an
+ * override has a malformed path or asset, or points at an asset that is not
+ * present in the build output — so a typo fails the deploy instead of 404ing at
+ * runtime.
+ */
+export function mergePublicPathOverrides(opts: {
+  generated: Record<string, PublicStaticPathSpec>;
+  overrides: Record<string, PublicStaticPathSpec>;
+  buildAssets: Iterable<string>;
+}): Record<string, PublicStaticPathSpec> {
+  const assets = new Set(opts.buildAssets);
+  const merged: Record<string, PublicStaticPathSpec> = { ...opts.generated };
+  for (const [path, spec] of Object.entries(opts.overrides)) {
+    if (!isValidPublicStaticPath(path)) {
+      throw new Error(`Invalid public static path override: ${path}`);
+    }
+    if (!isValidReleaseAssetPath(spec.asset)) {
+      throw new Error(`Invalid asset in public static path override ${path}: ${spec.asset}`);
+    }
+    if (!assets.has(spec.asset)) {
+      throw new Error(
+        `Public static path override ${path} -> ${spec.asset} references an asset not present in the build output`,
+      );
+    }
+    merged[path] = spec;
+  }
+  return merged;
+}
+
 function isPublicSupportAsset(file: string): boolean {
   if (!isValidReleaseAssetPath(file)) return false;
   if (file === '_headers') return false;

--- a/tests/unit/clean-routes.test.ts
+++ b/tests/unit/clean-routes.test.ts
@@ -11,6 +11,7 @@ import {
   isValidPublicStaticPath,
   isValidReleaseAssetPath,
   isValidStaticRouteTargetFile,
+  mergePublicPathOverrides,
   resolveCustomPageSlugFromLocation,
   safeCustomPageSlugs,
 } from '../../src/lib/clean-routes.ts';
@@ -182,5 +183,41 @@ describe('clean routes', () => {
     expect(canonicalRouteKey('/about')).toBe('/about');
     expect(canonicalRouteKey('/search.html?type=all&q=hello')).toBe('/search?q=hello&type=all');
     expect(canonicalRouteKey('/search?q=hello&type=all')).toBe('/search?q=hello&type=all');
+  });
+
+  it('overlays public-path overrides, letting overrides win on key collision', () => {
+    const generated = {
+      '/': { asset: 'index.html' },
+      '/events': { asset: 'events.html' },
+    };
+    const merged = mergePublicPathOverrides({
+      generated,
+      overrides: {
+        '/Tournament-Standings': { asset: 'Tournament-Standings.html' },
+        '/events': { asset: 'Tournament-Standings.html' },
+      },
+      buildAssets: ['index.html', 'events.html', 'Tournament-Standings.html'],
+    });
+    expect(merged['/Tournament-Standings']).toEqual({ asset: 'Tournament-Standings.html' });
+    expect(merged['/events']).toEqual({ asset: 'Tournament-Standings.html' });
+    expect(merged['/']).toEqual({ asset: 'index.html' });
+  });
+
+  it('returns the generated map unchanged when no overrides are supplied', () => {
+    const generated = { '/': { asset: 'index.html' } };
+    expect(mergePublicPathOverrides({ generated, overrides: {}, buildAssets: ['index.html'] })).toEqual(generated);
+  });
+
+  it('rejects malformed override paths, malformed assets, and assets missing from the build', () => {
+    const buildAssets = ['ok.html'];
+    expect(() =>
+      mergePublicPathOverrides({ generated: {}, overrides: { 'no-slash': { asset: 'ok.html' } }, buildAssets }),
+    ).toThrow(/Invalid public static path override/);
+    expect(() =>
+      mergePublicPathOverrides({ generated: {}, overrides: { '/bad': { asset: '../ok.html' } }, buildAssets }),
+    ).toThrow(/Invalid asset in public static path override/);
+    expect(() =>
+      mergePublicPathOverrides({ generated: {}, overrides: { '/missing': { asset: 'gone.html' } }, buildAssets }),
+    ).toThrow(/not present in the build output/);
   });
 });


### PR DESCRIPTION
## Why
`runDeploy` adapter deploys use implicit `public_paths` (the adapter slice carries the `LocalDirRef`) and skip the explicit file walk, so callers can't add browser-visible static paths beyond what the adapter generates. Copied-site ports (`kychon-concierge`) need to serve **source aliases the engine can't otherwise reach** — e.g. capitalized Wild Apricot paths like `/Tournament-Standings`, `/Current-Newsletter`, `/Renew-Membership` — plus a per-port extra-routes hook (e.g. a `/news` paginator function).

These were running as **uncommitted hot-patches on the concierge instance's engine checkout**, which (a) blocked clean engine updates — they had to be stashed to fast-forward to #147 — and (b) would vanish on any reset. This upstreams them as a **gated, opt-in** feature.

## What
Two new optional `RunDeployOptions`:
- **`publicPathOverrides?: Record<string, PublicStaticPathSpec>`** — when provided, an adapter deploy switches to an explicit `public_paths` map (generated file map **+** overrides) so the aliases survive. **Omitting it leaves implicit adapter behavior unchanged** (gated on `opts.publicPathOverrides !== undefined`).
- **`extraRoutes?`** — prepended after `/api/kychon`, before the adapter routes. Additive; a no-op when omitted (`...(opts.extraRoutes ?? [])`).

## Safety / scope
- Non-port deploys (engine demos, any adapter deploy without overrides) keep the **exact prior behavior** — implicit `public_paths`, no extra routes.
- Mirrors the patch already proven on the concierge instance (built + deployed live), refined to be opt-in/gated.

## Deliberately NOT included
The concierge checkout also carried a `src/pages/join.astro` edit, but it is a **port-specific hack**: it `import`s `_paloaltotennis-port.chrome-snapshot.json` (a hardcoded port file) and renders a hidden image-stuffing div (`patc-parity-vault`) to game the asset-parity gate. Committing it would break every other build and bake a parity-gaming hack into the engine, so it is excluded and flagged separately to the concierge side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
