### PR TITLE
feat(assets): KYCHON_ASSETS_DIR override so ports reach the @run402/astro image encoder

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,14 @@ const demoAssetDirs = {
 // for <Image src="literal"> — Kychon's images live in JSONB section configs,
 // so we use the data-driven assetsDir path introduced in v0.2.
 const integrationAssetsDir = (() => {
+  // Explicit override for non-demo projects (e.g. concierge ports): point the
+  // @run402/astro asset encoder at a staged source-image directory so port
+  // images get the same WebP/AVIF ladder + HEIC display_jpeg + blurhash +
+  // intrinsic dims as demos, instead of being pre-converted locally and
+  // uploaded as raw blobs. Path is repo-root-relative or absolute. Only takes
+  // effect alongside RUN402_PROJECT_ID (see useRun402Integration below).
+  const override = process.env.KYCHON_ASSETS_DIR;
+  if (override) return override;
   const project = process.env.KYCHON_PROJECT;
   if (project && demoAssetDirs[project]) return demoAssetDirs[project];
   return null;


### PR DESCRIPTION
## Why
`integrationAssetsDir` (`astro.config.mjs`) only resolves for the hardcoded `demoAssetDirs` map — for any non-demo project it returns `null`, so `useRun402Integration` is false and the `@run402/astro` image encoder never runs. That's the engine-side gap behind kychee-com/kychon-concierge#63: concierge ports can't reach the platform encoder, so they pre-convert images **locally** (Sharp/ImageMagick — which can't decode HEIF, the root of friction-F4) and upload raw blobs, getting plain `<img>` with no WebP/AVIF ladder, no blurhash, no HEIC `display_jpeg`.

## What
Add a `KYCHON_ASSETS_DIR` env override to the resolver. When a port stages its fetched source originals (incl. HEIC) into a directory and sets `KYCHON_ASSETS_DIR` + `RUN402_PROJECT_ID`, the existing integration walks that dir and encodes the images exactly as it does for demos → `_assets-manifest.json` → `<picture>` via `kychon-image.ts`.

## Safety
Purely additive — when `KYCHON_ASSETS_DIR` is unset, demo / local-dev / CI resolution is byte-for-byte unchanged.

## Enables
kychee-com/kychon-concierge#63 (route port images through the Run402 assets encoder; fixes HEIF/HEIC F4, drops local conversion, dissolves the parity-vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
