### PR TITLE
fix(alias): resolve path_aliases case-insensitively (kychon#152)

### DIFF
--- a/src/lib/path-aliases.ts
+++ b/src/lib/path-aliases.ts
@@ -1,0 +1,44 @@
+// Source-path alias resolution for copied websites (kychon#128). The porter
+// seeds a `path_aliases` site_config map (source path -> port route); the
+// `[...alias].astro` catch-all resolves it per request and 301s.
+//
+// Inbound links and the concierge parity harness hit source paths in their
+// ORIGINAL casing (e.g. `/event-6730883/JoinWaitlist`, `/Tournament-Standings`)
+// while the seeded keys are often lowercased slug routes. A case-sensitive exact
+// lookup therefore 404'd those paths even though an alias existed (kychon#152).
+// Resolve case-insensitively after an exact try, and keep the same-site
+// relative-target guard so a mis-seeded map can never become an open redirect.
+
+/** Trailing-slash-normalized request path; empty collapses to root. */
+export function normalizeAliasPath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, '');
+  return trimmed === '' ? '/' : trimmed;
+}
+
+/**
+ * Resolve `pathname` against the seeded `path_aliases` map. Returns a validated
+ * same-site relative redirect target, or null when there is no safe match.
+ */
+export function resolvePathAlias(aliases: unknown, pathname: string): string | null {
+  if (!aliases || typeof aliases !== 'object') return null;
+  const map = aliases as Record<string, unknown>;
+  const path = normalizeAliasPath(pathname);
+
+  let target = map[path];
+  if (target === undefined) {
+    const lower = path.toLowerCase();
+    for (const [key, value] of Object.entries(map)) {
+      if (key.toLowerCase() === lower) {
+        target = value;
+        break;
+      }
+    }
+  }
+
+  // Same-site relative targets only: a leading single slash, never `//host`,
+  // so a mis-seeded map cannot become an open redirect.
+  if (typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')) {
+    return target;
+  }
+  return null;
+}

--- a/src/pages/[...alias].astro
+++ b/src/pages/[...alias].astro
@@ -1,5 +1,6 @@
 ---
 import { ssrConfigValue } from '../lib/ssr-api';
+import { resolvePathAlias } from '../lib/path-aliases';
 
 export const prerender = false;
 
@@ -10,15 +11,14 @@ export const prerender = false;
 // seeds a `path_aliases` site_config map (publicly visible category) from
 // source path → port path; this rest-param route — lowest Astro precedence,
 // so it only sees otherwise-unmatched requests — 301s matched paths and
-// serves a minimal noindex 404 for everything else.
+// serves a minimal noindex 404 for everything else. Matching is
+// case-insensitive (kychon#152): inbound paths keep their source casing while
+// seeded keys are lowercased slug routes.
 const host = Astro.request.headers.get('host') ?? Astro.url.host;
-const path = Astro.url.pathname.replace(/\/+$/, '') || '/';
 const aliases = await ssrConfigValue<Record<string, unknown>>({ key: 'path_aliases', host });
-const target = aliases && typeof aliases === 'object' ? aliases[path] : undefined;
+const target = resolvePathAlias(aliases, Astro.url.pathname);
 
-// Same-site relative targets only: a leading single slash, never `//host`,
-// so a mis-seeded map can't become an open redirect.
-if (typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')) {
+if (target) {
   return Astro.redirect(target, 301);
 }
 

--- a/tests/unit/path-alias-source.test.ts
+++ b/tests/unit/path-alias-source.test.ts
@@ -13,10 +13,9 @@ describe('source-path alias route', () => {
     expect(aliasRoute).toContain('ssrConfigValue');
   });
 
-  it('redirects with a permanent status and refuses non-relative targets', () => {
+  it('redirects with a permanent status and delegates resolution to the validated helper', () => {
     expect(aliasRoute).toContain('Astro.redirect(target, 301)');
-    expect(aliasRoute).toContain("target.startsWith('/')");
-    expect(aliasRoute).toContain("!target.startsWith('//')");
+    expect(aliasRoute).toContain('resolvePathAlias');
   });
 
   it('serves a noindex 404 for unmatched paths', () => {

--- a/tests/unit/path-aliases.test.ts
+++ b/tests/unit/path-aliases.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAliasPath, resolvePathAlias } from '../../src/lib/path-aliases';
+
+describe('resolvePathAlias', () => {
+  const aliases = {
+    '/gr-news/13604666': '/gr-news-13604666',
+    '/event-6730883/joinwaitlist': '/event-6730883',
+    '/Tournament-Standings': '/tournament-standings',
+  };
+
+  it('resolves an exact key', () => {
+    expect(resolvePathAlias(aliases, '/gr-news/13604666')).toBe('/gr-news-13604666');
+  });
+
+  it('resolves case-insensitively when only a lowercase key is seeded (kychon#152)', () => {
+    expect(resolvePathAlias(aliases, '/event-6730883/JoinWaitlist')).toBe('/event-6730883');
+  });
+
+  it('resolves an exact mixed-case key', () => {
+    expect(resolvePathAlias(aliases, '/Tournament-Standings')).toBe('/tournament-standings');
+  });
+
+  it('ignores a trailing slash', () => {
+    expect(resolvePathAlias(aliases, '/event-6730883/JoinWaitlist/')).toBe('/event-6730883');
+  });
+
+  it('returns null for an unmatched path', () => {
+    expect(resolvePathAlias(aliases, '/no-such-path')).toBeNull();
+  });
+
+  it('refuses a non-relative (open-redirect) target', () => {
+    expect(resolvePathAlias({ '/x': '//evil.com' }, '/x')).toBeNull();
+    expect(resolvePathAlias({ '/x': 'https://evil.com' }, '/x')).toBeNull();
+  });
+
+  it('returns null when aliases is missing or not an object', () => {
+    expect(resolvePathAlias(null, '/x')).toBeNull();
+    expect(resolvePathAlias(undefined, '/x')).toBeNull();
+    expect(resolvePathAlias('nope', '/x')).toBeNull();
+  });
+
+  it('returns null for a non-string target', () => {
+    expect(resolvePathAlias({ '/x': 42 }, '/x')).toBeNull();
+  });
+});
+
+describe('normalizeAliasPath', () => {
+  it('collapses trailing slashes, keeping root', () => {
+    expect(normalizeAliasPath('/')).toBe('/');
+    expect(normalizeAliasPath('')).toBe('/');
+    expect(normalizeAliasPath('/a/b/')).toBe('/a/b');
+    expect(normalizeAliasPath('/a///')).toBe('/a');
+  });
+});


### PR DESCRIPTION
Fixes #152.

## Problem
`[...alias].astro` looks up the seeded `path_aliases` map with a **case-sensitive exact match** (`aliases[path]`). Copied-site inbound links and the concierge parity harness request source paths in their original casing (`/event-6730883/JoinWaitlist`, `/Tournament-Standings`), while the seeded keys are lowercased slug routes — so those paths 404'd even though an alias existed. This was the sole parity miss on the PATC re-port (kychon-concierge#76).

## Fix
Extract resolution into `src/lib/path-aliases.ts` (`resolvePathAlias`): exact match first, then **case-insensitive**, preserving the same-site relative-target guard (no open redirects). `[...alias].astro` delegates to it.

Unit-tested in `tests/unit/path-aliases.test.ts` (exact, case-insensitive, trailing slash, unmatched, open-redirect refusal, non-object input). Existing `path-alias-source.test.ts` updated for the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)