### PR TITLE
fix(alias): never self-redirect in resolvePathAlias (kychon#152 follow-up)

### DIFF
--- a/src/lib/path-aliases.ts
+++ b/src/lib/path-aliases.ts
@@ -38,6 +38,15 @@ export function resolvePathAlias(aliases: unknown, pathname: string): string | n
   // Same-site relative targets only: a leading single slash, never `//host`,
   // so a mis-seeded map cannot become an open redirect.
   if (typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')) {
+    // Never self-redirect. A case-insensitive match can resolve a request to a
+    // target equal to the request path — e.g. the lowercase slug
+    // `/tournament-standings` falling through to here matches the seeded cased
+    // alias `/Tournament-Standings` → `/tournament-standings` — which 301-loops
+    // when that slug's own route is missing. Treat self-targets as no-match
+    // (kychon#152 follow-up).
+    if (normalizeAliasPath(target) === path) {
+      return null;
+    }
     return target;
   }
   return null;

--- a/tests/unit/path-aliases.test.ts
+++ b/tests/unit/path-aliases.test.ts
@@ -42,6 +42,14 @@ describe('resolvePathAlias', () => {
   it('returns null for a non-string target', () => {
     expect(resolvePathAlias({ '/x': 42 }, '/x')).toBeNull();
   });
+
+  it('never self-redirects: a lowercase slug matching a cased alias to itself is no-match (kychon#152)', () => {
+    // /Tournament-Standings -> /tournament-standings is seeded; a request for the
+    // lowercase slug must NOT case-insensitively resolve to itself (301 loop).
+    expect(resolvePathAlias({ '/Tournament-Standings': '/tournament-standings' }, '/tournament-standings')).toBeNull();
+    // The cased path itself still redirects to the lowercase route.
+    expect(resolvePathAlias({ '/Tournament-Standings': '/tournament-standings' }, '/Tournament-Standings')).toBe('/tournament-standings');
+  });
 });
 
 describe('normalizeAliasPath', () => {


### PR DESCRIPTION
Case-insensitive path-alias resolution (kychon#152) could 301-loop: a lowercase slug like `/tournament-standings`, when its own route is missing and it falls through to `[...alias].astro`, case-insensitively matches the seeded cased alias `/Tournament-Standings` → `/tournament-standings` and redirects to itself. Guard: a target that normalizes to the request path is no-match. Surfaced on the PATC canonical (kychon-concierge#82) after its per-path routes were pulled. Unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)