### PR TITLE
style: fix biome format error from kychon#155

### DIFF
--- a/tests/unit/path-aliases.test.ts
+++ b/tests/unit/path-aliases.test.ts
@@ -48,7 +48,9 @@ describe('resolvePathAlias', () => {
     // lowercase slug must NOT case-insensitively resolve to itself (301 loop).
     expect(resolvePathAlias({ '/Tournament-Standings': '/tournament-standings' }, '/tournament-standings')).toBeNull();
     // The cased path itself still redirects to the lowercase route.
-    expect(resolvePathAlias({ '/Tournament-Standings': '/tournament-standings' }, '/Tournament-Standings')).toBe('/tournament-standings');
+    expect(resolvePathAlias({ '/Tournament-Standings': '/tournament-standings' }, '/Tournament-Standings')).toBe(
+      '/tournament-standings',
+    );
   });
 });
 


### PR DESCRIPTION
kychon#155 merged with a red biome check (a test line exceeded the formatter width). This wraps it. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)