### PR TITLE
fix(copy-website ports): SSR-bake main-zone sections + resolve single-segment path aliases

### DIFF
--- a/src/lib/build-sections.ts
+++ b/src/lib/build-sections.ts
@@ -1,0 +1,135 @@
+/**
+ * Build-time page-section loader. Fetches a page's page-scoped main-zone
+ * `sections` rows from the deployed gateway during `astro build` (NOT at
+ * runtime) so `chrome-bake.ts:renderMainZone` can SSR-bake the page's
+ * hero/custom/events_list/slideshow blocks into the prerendered HTML.
+ *
+ * Motivating case — copy-website ports (mirrors build-events.ts / build-pages.ts):
+ * `resolveActiveProjectSeed()` returns the chrome SNAPSHOT for a port, which
+ * carries global chrome only (zone='header'/'footer', scope='global'). A
+ * port's page-scoped main-zone sections (zone='main', scope='page') live ONLY
+ * in the deployed database (applied via seed.sql), so `renderMainZone` finds
+ * none in the seed and bakes nothing — the body only appears after the runtime
+ * hydrate. This loader closes that gap so no-JS readers, link previews, and
+ * crawlers see the real sections at first paint.
+ *
+ * **Build-time only.** Reads the same env vars `scripts/_lib.ts:runDeploy` sets
+ * before invoking `astro build` (see build-events.ts for the full contract):
+ * `KYCHON_ANON_KEY`, `KYCHON_PROJECT_ID`, `KYCHON_PUBLIC_URL`. The anon key
+ * means the gateway's `visibleSection` filter applies — only publicly-visible,
+ * non-admin-scoped rows come back, so nothing gated bakes into public HTML.
+ * When any var is missing (local `astro dev`, CI without env plumbing) the
+ * loader resolves to an empty cache and the caller falls back to whatever the
+ * snapshot seed already had — same graceful skip as build-events/build-pages.
+ *
+ * NOTE: the capability gateway's `listResult` does NOT honor `order`/`limit`
+ * (only equality filters via `matchesInput`), exactly like `events.list` —
+ * build-events re-sorts client-side and so do we (by `position`). Do not rely
+ * on a server-side order param.
+ */
+
+import { createKychonClient } from '@kychon/sdk';
+
+import type { Section } from '@/lib/blocks';
+
+interface CapabilityListResult {
+  rows?: Section[];
+}
+
+// Per-slug cache + in-flight promise dedupe; lasts the lifetime of the Astro
+// build process (pages render serially in one Node process).
+const cache = new Map<string, Section[]>();
+const loaders = new Map<string, Promise<Section[]>>();
+
+function readEnv(key: string): string | undefined {
+  const value = process.env[key];
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function fetchPageSections(pageSlug: string): Promise<Section[]> {
+  const anonKey = readEnv('KYCHON_ANON_KEY');
+  const projectId = readEnv('KYCHON_PROJECT_ID');
+  const portalUrl = readEnv('KYCHON_PUBLIC_URL');
+  if (!anonKey || !projectId || !portalUrl) {
+    console.log(
+      `[build-sections] skipped — missing ${[
+        !anonKey && 'KYCHON_ANON_KEY',
+        !projectId && 'KYCHON_PROJECT_ID',
+        !portalUrl && 'KYCHON_PUBLIC_URL',
+      ].filter(Boolean).join(', ')}`,
+    );
+    return [];
+  }
+
+  const client = createKychonClient({
+    portalUrl,
+    apiKey: anonKey,
+    apiBaseUrl: 'https://api.run402.com',
+  });
+
+  try {
+    // Equality filters (page_slug/zone/scope) ARE applied server-side by the
+    // gateway's `matchesInput`; the anon key adds `visibleSection` (drops
+    // visible=false + admin-scoped). We re-filter + re-sort below because the
+    // gateway ignores order/limit and because baked HTML is public forever.
+    const result = await client.request<CapabilityListResult>(
+      'sections.list',
+      'query',
+      { page_slug: pageSlug, zone: 'main', scope: 'page' },
+    );
+    const rows = Array.isArray(result?.rows) ? result.rows : [];
+    const baked = rows
+      .filter(
+        (s) =>
+          s.zone === 'main' &&
+          s.scope === 'page' &&
+          s.page_slug === pageSlug &&
+          s.visible !== false,
+      )
+      .sort((a, b) => a.position - b.position);
+    console.log(
+      `[build-sections] fetched ${baked.length} main-zone section(s) for ${projectId} (slug="${pageSlug}")`,
+    );
+    return baked;
+  } catch (error) {
+    // Never fail the build on a transient gateway error — the runtime hydrate
+    // path still populates sections. Noisy log so a regression is visible.
+    console.warn(
+      `[build-sections] fetch failed for ${projectId} (${portalUrl}, slug="${pageSlug}"):`,
+      error instanceof Error ? error.message : error,
+    );
+    return [];
+  }
+}
+
+/**
+ * Trigger the build-time fetch of a page's main-zone sections. Call from
+ * `.astro` frontmatter BEFORE `renderMainZone`. Idempotent per slug.
+ */
+export async function ensureBuildSectionsLoaded(pageSlug: string): Promise<void> {
+  if (loaders.has(pageSlug)) {
+    await loaders.get(pageSlug);
+    return;
+  }
+  const promise = fetchPageSections(pageSlug);
+  loaders.set(pageSlug, promise);
+  cache.set(pageSlug, await promise);
+}
+
+/**
+ * Synchronous accessor for the build-time page-section cache. Returns the
+ * filtered + sorted main-zone sections for a slug, or `[]` when the loader
+ * skipped/failed/hasn't run. Callers MERGE these into the seed sections passed
+ * to `renderMainZone` — empty means "fall back to whatever the snapshot had".
+ */
+export function getBuildSections(pageSlug: string): Section[] {
+  return cache.get(pageSlug)?.slice() ?? [];
+}
+
+/** Test-only: clear the cache between test runs. */
+export function _clearBuildSectionsCacheForTests(): void {
+  cache.clear();
+  loaders.clear();
+}

--- a/src/lib/merge-sections.ts
+++ b/src/lib/merge-sections.ts
@@ -1,0 +1,51 @@
+import type { ProjectSeed, SeedSection } from '../seeds/types';
+import type { Section } from '@/lib/blocks';
+
+/**
+ * Return a shallow-cloned seed whose `sections` includes the DB-fetched
+ * page-scoped main-zone sections for `pageSlug`, merged on top of the seed's
+ * own sections. Used by index.astro / [customPage].astro so that ported pages
+ * (whose main-zone sections live only in the deployed DB) SSR-bake their real
+ * body instead of an empty hydrate shell.
+ *
+ * De-dup: a section present in BOTH the snapshot seed and the DB is keyed by
+ * `page_slug|zone|scope|section_type|position` — NOT by id (seed sections use
+ * numeric local ids, DB rows use serial/UUID, so id can never cross-match;
+ * same rationale as main-zone-signature.ts). On a key collision the DB row
+ * wins (it's the deployed source of truth). For a pure snapshot port the seed
+ * has zero main-zone rows, so every DB row is purely additive.
+ *
+ * No-op fast path: when `dbSections` is empty the seed is returned unchanged
+ * (reference-equal), preserving today's behavior for typed-seed projects and
+ * local dev where the build-time fetch is skipped.
+ */
+export function mergeSeedSections(
+  seed: ProjectSeed,
+  pageSlug: string,
+  dbSections: Section[],
+): ProjectSeed {
+  if (dbSections.length === 0) return seed;
+
+  const keyOf = (s: {
+    page_slug: string;
+    zone: string;
+    scope: string;
+    section_type: string;
+    position: number;
+  }) => `${s.page_slug}|${s.zone}|${s.scope}|${s.section_type}|${s.position}`;
+
+  const dbKeys = new Set(dbSections.map(keyOf));
+  const seedSections = (seed.sections ?? []) as unknown as SeedSection[];
+  const kept = seedSections.filter((s) => {
+    const isThisPageMain =
+      s.zone === 'main' && s.scope === 'page' && s.page_slug === pageSlug;
+    return !(isThisPageMain && dbKeys.has(keyOf(s)));
+  });
+
+  // `renderMainZone` sorts by `position`, so final order is position-driven
+  // regardless of array order here.
+  return {
+    ...seed,
+    sections: [...kept, ...(dbSections as unknown as SeedSection[])],
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,41 @@
+import { defineMiddleware } from 'astro:middleware';
+import { ssrConfigValue } from './lib/ssr-api';
+import { resolvePathAlias } from './lib/path-aliases';
+
+/**
+ * Copied-site path-alias resolver (kychon#128 / #532 follow-up).
+ *
+ * `[...alias].astro` resolves `path_aliases` (source path → port path) and
+ * 301s, but as a rest-param route it has the LOWEST Astro precedence — so a
+ * single-segment inbound path like `/Classified-Ads` is claimed by the
+ * higher-precedence `[customPage].astro` (a named `[param]` route). That route
+ * is `prerender=true` with a `getStaticPaths` allow-list, so an unknown slug
+ * never runs its body — Astro just serves the built-in 404 and `[...alias]`
+ * never sees the request. Net effect: nested-path aliases worked but
+ * single-segment ones (the common case — capitalized source slugs mapping to
+ * lowercase port slugs) silently 404'd.
+ *
+ * Middleware runs BEFORE route matching, so resolving aliases here sidesteps
+ * route precedence entirely and covers single- and multi-segment alike. Real
+ * pages are prerendered static files served by the gateway without invoking
+ * this function; only SSR requests (unmatched paths, `prerender=false` routes)
+ * reach here, and `resolvePathAlias` returns null for anything that isn't a
+ * seeded alias key (and for self-redirects), so normal routing is untouched.
+ *
+ * `path_aliases` is fetched once per Lambda lifetime and cached: the map only
+ * changes on redeploy, which restarts the function. Fail-open — a config read
+ * miss leaves aliases null and requests fall through to normal routing.
+ */
+let cachedAliases: Record<string, unknown> | null | undefined;
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const host = context.request.headers.get('host') ?? context.url.host;
+  if (cachedAliases === undefined) {
+    cachedAliases = await ssrConfigValue<Record<string, unknown>>({ key: 'path_aliases', host });
+  }
+  const target = resolvePathAlias(cachedAliases ?? null, context.url.pathname);
+  if (target) {
+    return context.redirect(target, 301);
+  }
+  return next();
+});

--- a/src/pages/[customPage].astro
+++ b/src/pages/[customPage].astro
@@ -7,6 +7,8 @@ import { resolveActiveProjectSeed } from '../seeds';
 import { ensureBuildEventsLoaded, getAllBuildEvents } from '../lib/build-events';
 import { ensureBuildAnnouncementsLoaded, getAllBuildAnnouncements } from '../lib/build-announcements';
 import { ensureBuildPagesLoaded, getAllBuildPages, getBuildPageBySlug } from '../lib/build-pages';
+import { ensureBuildSectionsLoaded, getBuildSections } from '../lib/build-sections';
+import { mergeSeedSections } from '../lib/merge-sections';
 import { renderMainZone, makeBakeContext } from '../lib/chrome-bake';
 
 export async function getStaticPaths() {
@@ -43,13 +45,16 @@ export async function getStaticPaths() {
 // the destructive `innerHTML` swap.
 const { seed } = await resolveActiveProjectSeed();
 const slug = String(Astro.params.customPage ?? '');
-await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded(), ensureBuildPagesLoaded()]);
+await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded(), ensureBuildPagesLoaded(), ensureBuildSectionsLoaded(slug)]);
 const bakeCtx = {
   ...makeBakeContext(seed),
   buildEvents: getAllBuildEvents(),
   buildAnnouncements: getAllBuildAnnouncements(),
 };
-const { html: sectionsHtml, signature: bakeSignature } = renderMainZone(seed, slug, bakeCtx);
+// Ported custom pages carry their main-zone sections only in the deployed DB.
+// Merge them in so renderMainZone bakes the real body instead of an empty shell.
+const seedForBake = mergeSeedSections(seed, slug, getBuildSections(slug));
+const { html: sectionsHtml, signature: bakeSignature } = renderMainZone(seedForBake, slug, bakeCtx);
 // SSR the page body itself (kychon#126): with `initialPage` the island
 // server-renders the real title + sanitized rich-text content instead of
 // the loading skeleton, so the served HTML carries the page body for

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,8 @@ import { resolveActiveProjectSeed } from '../seeds';
 import { renderMainZone, renderHeroPreloadLink, makeBakeContext } from '../lib/chrome-bake';
 import { ensureBuildEventsLoaded, getAllBuildEvents } from '../lib/build-events';
 import { ensureBuildAnnouncementsLoaded, getAllBuildAnnouncements } from '../lib/build-announcements';
+import { ensureBuildSectionsLoaded, getBuildSections } from '../lib/build-sections';
+import { mergeSeedSections } from '../lib/merge-sections';
 
 // First-paint bake of the home page's page-scoped main-zone sections from the
 // active project's typed seed. Runtime hydrate (page-render.ts) still re-renders
@@ -20,7 +22,7 @@ const { seed } = await resolveActiveProjectSeed();
 // (or both) can fail silently when env vars are missing (local
 // `astro dev`) — the blocks just fall back to today's skeleton path
 // in that case.
-await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded()]);
+await Promise.all([ensureBuildEventsLoaded(), ensureBuildAnnouncementsLoaded(), ensureBuildSectionsLoaded('index')]);
 const bakeCtx = {
   ...makeBakeContext(seed),
   buildEvents: getAllBuildEvents(),
@@ -33,10 +35,15 @@ const bakeCtx = {
 // replacement when the live data would produce identical HTML. Preserves
 // SSR-baked `<Run402Image>` content (variant ladder + v1.54 pre-decoded
 // blurhash placeholder) when seed = DB.
-const { html: sectionsHtml, signature: bakeSignature } = renderMainZone(seed, 'index', bakeCtx);
+// Ported sites carry their page-scoped main-zone sections only in the deployed
+// DB (applied via seed.sql) — the build seed (chrome snapshot) has global chrome
+// only. Merge the DB-fetched main-zone sections in so renderMainZone bakes them.
+// No-op when the fetch returned [] (typed-seed projects, local dev).
+const seedForBake = mergeSeedSections(seed, 'index', getBuildSections('index'));
+const { html: sectionsHtml, signature: bakeSignature } = renderMainZone(seedForBake, 'index', bakeCtx);
 // Preload the home hero so the WebP download starts before the browser even
 // parses `<source srcset>` in document order — matches Apple-style preload.
-const heroPreloadLink = renderHeroPreloadLink(seed, 'index', bakeCtx.manifest);
+const heroPreloadLink = renderHeroPreloadLink(seedForBake, 'index', bakeCtx.manifest);
 ---
 <Portal title="Home" extraHead={heroPreloadLink}>
   <HomePageApp client:load />


### PR DESCRIPTION
Two engine fixes surfaced + verified during a laptop-local copy-website port run (San Diego Jaguar Club → sdjagclub.run402.com). Both are root-cause fixes, not workarounds.

## 1. SSR-bake home + custom-page main-zone sections — Closes #158
Ported pages carry their `(zone='main', scope='page')` sections (hero / custom / events_list / slideshow) only in the deployed DB, not the chrome snapshot. `index.astro` / `[customPage].astro` fed `renderMainZone` the snapshot seed (global chrome only), so the home page and every custom page SSR'd an **empty main zone** — no welcome copy, events, or carousels — for no-JS readers, link previews, and crawlers; content appeared only after client hydration.

- **`build-sections.ts`** — build-time `sections.list` fetch for `(page_slug, zone='main', scope='page')`, mirroring `build-events.ts`; fail-open (`[]`) on missing env/error.
- **`merge-sections.ts`** — dedup-safe merge of DB sections into the seed, keyed by `page_slug|zone|scope|section_type|position` (never `id`).
- **`index.astro` / `[customPage].astro`** — `ensureBuildSectionsLoaded(slug)` then `mergeSeedSections(...)` before `renderMainZone`.

Runtime reconciles via the existing `data-bake-signature` short-circuit — no flash, no double-render.

## 2. Resolve single-segment path aliases in middleware — Closes #161
`[...alias].astro` (the `path_aliases` resolver) is a rest-param route — lowest Astro precedence. A single-segment inbound path like `/Classified-Ads` is claimed first by the named-param `[customPage].astro` (`prerender=true`, getStaticPaths allow-list), finds no entry for the unknown slug, and gets Astro's **built-in 404** — `[...alias]` never runs. Single-segment aliases (the common case: capitalized source slug → lowercase port slug) silently 404'd; only multi-segment ones worked.

New **`src/middleware.ts`** resolves `path_aliases` **before** route matching, sidestepping precedence for single- and multi-segment alike. Map fetched via `ssrConfigValue`, cached per-Lambda, fail-open. Prerendered pages are served statically without invoking middleware, and `resolvePathAlias` returns null for non-alias paths and self-redirects, so normal routing is untouched.

## Verification (live on sdjagclub.run402.com)
- `/Classified-Ads`, `/Links`, `/Events`, `/Online-Store`, `/Membership`, `/page-18114` → **301** to their lowercase targets.
- No regressions: real pages 200, `/search` 200, `/` 200, unknown single-segment 404, no redirect loops.
- Local CI: `biome check .` clean · `astro check` 0 errors/0 warnings (201 files) · `tsc --noEmit` clean · `vitest` 1138 passed (161 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
